### PR TITLE
fix: cross encoder output

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/encoder.py
+++ b/vllm_rbln/model_executor/models/optimum/encoder.py
@@ -138,6 +138,6 @@ class RBLNOptimumForEncoderModel(RBLNOptimumModelBase):
             assert hidden_states.dim() == 2, (
                 f"We expected the shape to be dim 2 ([batch, num_labels]), "
                 f"but the current output is dim {hidden_states.dim()}.")
-            hidden_states = hidden_states[:request_nums]
+            hidden_states = hidden_states[:request_nums].squeeze(-1)
 
         return hidden_states


### PR DESCRIPTION
### 🚀 Pull Request Summary

<!-- Describe your changes in detail -->

This PR modifies the return behavior for cross-encoder models with `num_labels=1`. It assumes that the score has already been computed within the model (ex. `BAAI/bge-reranker-v2-m3`) and will now return scalar values individually. By using `squeeze`, results for models with `num_labels` greater than or equal to 2 (ex. `cardiffnlp/twitter-roberta-base-emotion`) will retain their 1-D tensor shape upon return. This change also enforces the use of `llm.classify` for these models.

---

### 📌 Related Issues / Tickets

* Fixes #
* Related to #

---

### ✅ Changes

* [ ] Feature
* [x] Bug Fix
* [ ] Documentation
* [ ] Refactor
* [ ] Optimization
* [ ] Other (please describe):

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📋 Checklist

* [ ] I’ve added unit tests or updated existing ones.
* [ ] I’ve updated relevant documentation.
* [ ] I’ve checked compatibility (e.g., hardware/backend/platform).

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
