### PR TITLE
fix: sync with optimum-rbln fix

### DIFF
--- a/vllm_rbln/worker/optimum_worker.py
+++ b/vllm_rbln/worker/optimum_worker.py
@@ -79,7 +79,9 @@ class RBLNOptimumWorker(LoRANotSupportedWorkerBase,
         if attn_impl is not None and attn_impl == "flash_attn":
             # We use the last block as dummy block
             num_gpu_blocks = (
-                self.model_runner.model.model.get_kvcache_num_blocks() - 1)
+                self.model_runner.model.model.get_kvcache_num_blocks() - 1) \
+                    if self.model_runner.model.model.rbln_config.batch_size > 1 \
+                        else (self.model_runner.model.model.get_kvcache_num_blocks())
 
             if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
                 num_gpu_blocks = int(npu_num_blocks) - 1

--- a/vllm_rbln/worker/optimum_worker.py
+++ b/vllm_rbln/worker/optimum_worker.py
@@ -80,8 +80,8 @@ class RBLNOptimumWorker(LoRANotSupportedWorkerBase,
             # We use the last block as dummy block
             num_gpu_blocks = (
                 self.model_runner.model.model.get_kvcache_num_blocks() - 1) \
-                    if self.model_runner.model.model.rbln_config.batch_size > 1 \
-                        else (self.model_runner.model.model.get_kvcache_num_blocks())
+                if self.model_runner.model.model.rbln_config.batch_size > 1 \
+                else (self.model_runner.model.model.get_kvcache_num_blocks())
 
             if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
                 num_gpu_blocks = int(npu_num_blocks) - 1


### PR DESCRIPTION
### 🚀 Pull Request Summary

<!-- Describe your changes in detail -->

This PR aligns with a recent fix in `optimum-rbln` that prevents the generation of a dummy block table for single-batch inferences (i.e., when `batch_size = 1`).

---

### 📌 Related Issues / Tickets

* Fixes #
* Related to #

---

### ✅ Changes

* [ ] Feature
* [x] Bug Fix
* [ ] Documentation
* [ ] Refactor
* [ ] Optimization
* [ ] Other (please describe):

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📋 Checklist

* [x] I’ve added unit tests or updated existing ones.
* [x] I’ve updated relevant documentation.
* [x] I’ve checked compatibility (e.g., hardware/backend/platform).

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
