### PR TITLE
fix: use original vllm entrypoint for vllm cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ Homepage="https://rebellions.ai"
 Documentation="https://docs.rbln.ai"
 Repository="https://github.com/rebellions-sw/vllm-rbln"
 
-[project.scripts]
-vllm = "vllm_rbln.entrypoints.cli.main:main"
-
 [project.entry-points."vllm.platform_plugins"]
 rbln = "vllm_rbln:register"
 


### PR DESCRIPTION
### 🚀 Pull Request Summary
To use the original vLLM entrypoint, removed the redefined entrypoint.
---

### 📌 Related Issues / Tickets

* Fixes #19 

---

### ✅ Changes

* [ ] Feature
* [X] Bug Fix
* [ ] Documentation
* [ ] Refactor
* [ ] Optimization
* [ ] Other (please describe):

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 🧪 How to Test

1. Run `vllm serve meta-llama/Llama-3.2-1B --block-size 1024`
2. Verify output: 'INFO:     Started server process [230740]
INFO:     Waiting for application startup.
INFO:     Application startup complete.`

---

### 📋 Checklist

* [X] I’ve added unit tests or updated existing ones.
* [X] I’ve updated relevant documentation.
* [X] I’ve checked compatibility (e.g., hardware/backend/platform).

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
