### PR TITLE
fix: get num_gpu_blocks logic in V1

### DIFF
--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -78,8 +78,8 @@ class RBLNOptimumWorker(WorkerBase):
             # We use the last block as dummy block
             num_gpu_blocks = (
                 self.model_runner.model.model.get_kvcache_num_blocks() + 1) \
-                    if self.model_runner.model.model.rbln_config.batch_size == 1 \
-                    else (self.model_runner.model.model.get_kvcache_num_blocks())
+                if self.model_runner.model.model.rbln_config.batch_size == 1 \
+                else (self.model_runner.model.model.get_kvcache_num_blocks())
 
             if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
                 num_gpu_blocks = int(npu_num_blocks)

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -77,7 +77,9 @@ class RBLNOptimumWorker(WorkerBase):
         if attn_impl is not None and attn_impl == "flash_attn":
             # We use the last block as dummy block
             num_gpu_blocks = (
-                self.model_runner.model.model.get_kvcache_num_blocks())
+                self.model_runner.model.model.get_kvcache_num_blocks() + 1) \
+                    if self.model_runner.model.model.rbln_config.batch_size == 1 \
+                    else (self.model_runner.model.model.get_kvcache_num_blocks())
 
             if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
                 num_gpu_blocks = int(npu_num_blocks)


### PR DESCRIPTION
### 🚀 Pull Request Summary

<!-- Describe your changes in detail -->

Added logic to handle different num_block sizes when compiling the model with `optimum-rbln`, depending on whether the `batch_size==1`.

Update the logic to consistently maintain one additional dummy_block for `vllm-rbln`, as it is required regardless of the batch_size.

---

### 📌 Related Issues / Tickets

* Fixes # 
* Related to #   https://github.com/rebellions-sw/optimum-rbln/blob/49acf44cf6ccf47053e54854026e10891c99ab48/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py#L1221

---

### ✅ Changes

* [ ] Feature
* [x] Bug Fix
* [ ] Documentation
* [ ] Refactor
* [ ] Optimization
* [ ] Other (please describe):

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 🧪 How to Test

1. Run `python examples/optimum/run_qwen2_5_vl.py --batch_size=1 --model_id=qwen2_5-vl-7b-32k-b1-kv16k`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📋 Checklist

* [x] I’ve added unit tests or updated existing ones.
* [x] I’ve updated relevant documentation.
* [x] I’ve checked compatibility (e.g., hardware/backend/platform).

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
