### PR TITLE
fix: use config classes when computing max blocks

### DIFF
--- a/vllm_rbln/worker/utils.py
+++ b/vllm_rbln/worker/utils.py
@@ -16,10 +16,12 @@
 import math
 from typing import Optional
 
+from vllm.config import ModelConfig, ParallelConfig
+
 
 def get_maximum_num_blocks(
-    config,
-    tensor_parallel_size: int,
+    model_config: ModelConfig,
+    parallel_config: ParallelConfig,
     kvcache_block_size: int,
     nbits_per_param: Optional[int] = None,
     n_model_params: Optional[int] = None,
@@ -63,11 +65,12 @@ def get_maximum_num_blocks(
     def align_2MB(x: int) -> int:
         return align(x, 2**21)
 
-    num_layers = config.hf_config.num_hidden_layers
-    head_dim = config.hf_config.head_dim
-    vocab_size = config.hf_config.vocab_size
-    hidden_size = config.hf_config.hidden_size
-    num_key_value_heads = config.hf_config.num_key_value_heads
+    num_layers = model_config.get_num_layers(parallel_config)
+    head_dim = model_config.get_head_size()
+    vocab_size = model_config.get_vocab_size()
+    hidden_size = model_config.get_hidden_size()
+    num_key_value_heads = model_config.get_num_kv_heads(parallel_config)
+    tensor_parallel_size = parallel_config.tensor_parallel_size
 
     # TODO(jongho): Update if target npu is REBEL.
     ATOM_DRAM_NBYTES = 16 * 2**30

--- a/vllm_rbln/worker/worker.py
+++ b/vllm_rbln/worker/worker.py
@@ -293,8 +293,8 @@ class RBLNWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         # This function comes from optimum-rbln.
         # We must keep it updated as optimum is upgraded.
         max_num_blocks = get_maximum_num_blocks(
-            config=self.model_config,
-            tensor_parallel_size=self.parallel_config.tensor_parallel_size,
+            model_config=self.model_config,
+            parallel_config=self.parallel_config,
             kvcache_block_size=block_size,
             # quantization : 4 (This is an ad-hoc value. Need to fix it)
             nbits_per_param=16 if not self.model_config.quantization else 4,


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Use vllm config classes instead of using hf config directly during maximum block number computation.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #55 

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): use config classes to retrieve model structural information

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

Using vLLM’s original method (sending the model to the device and profiling memory stats) would be ideal, but it does not seem applicable at the moment.

---

