### PR TITLE
fix(worker): clamp num available blocks by num required blocks

### DIFF
--- a/vllm_rbln/worker/worker.py
+++ b/vllm_rbln/worker/worker.py
@@ -302,7 +302,12 @@ class RBLNWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
                                for p in self.model_runner.model.parameters()),
             # 1 : prefill
             num_runtimes=1 + self.scheduler_config.max_num_seqs)
-        num_gpu_blocks = (max_num_blocks - 1)
+
+        max_required_num_blocks = (self.model_config.max_model_len *
+                                   self.scheduler_config.max_num_seqs //
+                                   block_size)
+
+        num_gpu_blocks = min(max_num_blocks - 1, max_required_num_blocks)
 
         if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
             num_gpu_blocks = int(npu_num_blocks) - 1


### PR DESCRIPTION
 
### 🚀 Summary of Changes
 
* Problem: Worker allocates unnecessarily many blocks even when max_model_len is short.
* Solution: Clamp the number of available blocks by the number of required blocks

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe
 
### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
