### PR TITLE
gha: do not use cuda torch improvements

### DIFF
--- a/.github/workflows/rbln_optimum_ci.yaml
+++ b/.github/workflows/rbln_optimum_ci.yaml
@@ -71,18 +71,21 @@ jobs:
 
       - name: Install local vllm-rbln package and dependencies
         run: |
-          pip install packaging setuptools wheel simphile pynvml huggingface_hub setuptools_scm fire
+          pip install uv
+          uv pip install packaging setuptools wheel simphile pynvml huggingface_hub setuptools_scm fire
 
-          pip install \
+          uv pip install \
             --force-reinstall \
             --no-cache-dir \
+            --no-binary "vllm" \
             --constraint <(echo "optimum-rbln==$VERSION") \
                 dist/vllm_rbln*.whl
           echo "optimum-rbln $VERSION"
         env:
           VERSION: ${{ inputs.optimum_rbln_version }}
           VLLM_TARGET_DEVICE: cpu
-          PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+          UV_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+          UV_INDEX_STRATEGY: unsafe-best-match # match pip's behavior
 
       - name: Run decoder-only test (eager attn) (V1)
         run: >

--- a/.github/workflows/rbln_optimum_ci.yaml
+++ b/.github/workflows/rbln_optimum_ci.yaml
@@ -72,9 +72,17 @@ jobs:
       - name: Install local vllm-rbln package and dependencies
         run: |
           pip install packaging setuptools wheel simphile pynvml huggingface_hub setuptools_scm fire
-          VERSION=${{ inputs.optimum_rbln_version }}
-          pip install --force-reinstall --no-cache-dir dist/vllm_rbln*.whl --constraint <(echo "optimum-rbln==$VERSION")
+
+          pip install \
+            --force-reinstall \
+            --no-cache-dir \
+            --constraint <(echo "optimum-rbln==$VERSION") \
+                dist/vllm_rbln*.whl
           echo "optimum-rbln $VERSION"
+        env:
+          VERSION: ${{ inputs.optimum_rbln_version }}
+          VLLM_TARGET_DEVICE: cpu
+          PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
 
       - name: Run decoder-only test (eager attn) (V1)
         run: >

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyyaml
 datasets
 qwen_vl_utils
 transformers==4.51.3
-vllm==0.9.1
+vllm@git+https://github.com/vllm-project/vllm.git@v0.9.1
 optimum-rbln>=0.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyyaml
 datasets
 qwen_vl_utils
 transformers==4.51.3
-vllm@git+https://github.com/vllm-project/vllm.git@v0.9.1
+vllm==0.9.1
 optimum-rbln>=0.8.3


### PR DESCRIPTION

- using uv instead of pip
- adding `--no-binary=vllm` to force a vllm rebuild
