### PR TITLE
fix(core): block allocation for torch compile path

### DIFF
--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -369,7 +369,7 @@ class RBLNFlashAttentionMetadataBuilder:
                 block_table_tensor,
                 torch.full(
                     (batch_padding_size, block_table_tensor.shape[-1]),
-                    block_table_tensor.numel() - 1,
+                    0,
                 ),
             ])
             decode_attention_mask = torch.zeros(

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1581,10 +1581,6 @@ class RBLNModelRunner:
         self.initialize_attn_backend(kv_cache_config)
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
 
-        # for partition skip, we need dummy block slot.
-        no_dummy_slots = 1
-        kv_cache_config.num_blocks -= no_dummy_slots
-
         if self.speculative_config and self.speculative_config.use_eagle():
             assert isinstance(self.drafter, EagleProposer)
             # validate all draft model layers belong to the same kv cache

--- a/vllm_rbln/worker/worker.py
+++ b/vllm_rbln/worker/worker.py
@@ -305,13 +305,15 @@ class RBLNWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             # 1 : prefill
             num_runtimes=1 + self.scheduler_config.max_num_seqs)
 
-        max_required_num_blocks = (self.model_config.max_model_len *
-                                   self.scheduler_config.max_num_seqs //
-                                   block_size) + self.scheduler_config.max_num_seqs + 1
+        max_required_num_blocks = (
+            self.model_config.max_model_len *
+            self.scheduler_config.max_num_seqs //
+            block_size) + self.scheduler_config.max_num_seqs + 1
 
-        # We always allocate this number of blocks, but the last one is reserved for padding.
-        # As a result, the vLLM system should treat it as if there is one fewer usable block
-        # than the number actually allocated.
+        # We always allocate this number of blocks, but the last one is
+        # reserved for padding. As a result, the vLLM system should treat
+        # it as if there is one fewer usable block than the number
+        # actually allocated.
         num_gpu_blocks = min(max_num_blocks, max_required_num_blocks) - 1
         if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
             num_gpu_blocks = int(npu_num_blocks) - 1

--- a/vllm_rbln/worker/worker.py
+++ b/vllm_rbln/worker/worker.py
@@ -99,8 +99,10 @@ class RBLNCacheEngine:
 
     def _allocate_kv_cache(self, ) -> List[torch.Tensor]:
         """Allocates KV cache on RBLN."""
+
+        # One extra block is reserved for padding.
         kv_cache_shape = self.attn_backend.get_kv_cache_shape(
-            self.num_cpu_blocks, self.block_size, self.num_heads,
+            self.num_cpu_blocks + 1, self.block_size, self.num_heads,
             self.head_size)
         kv_cache: List[torch.Tensor] = []
         logger.info("[RBLN] attention backend get_kv_cache_shape = %s",
@@ -305,10 +307,12 @@ class RBLNWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
         max_required_num_blocks = (self.model_config.max_model_len *
                                    self.scheduler_config.max_num_seqs //
-                                   block_size)
+                                   block_size) + self.scheduler_config.max_num_seqs + 1
 
-        num_gpu_blocks = min(max_num_blocks - 1, max_required_num_blocks)
-
+        # We always allocate this number of blocks, but the last one is reserved for padding.
+        # As a result, the vLLM system should treat it as if there is one fewer usable block
+        # than the number actually allocated.
+        num_gpu_blocks = min(max_num_blocks, max_required_num_blocks) - 1
         if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
             num_gpu_blocks = int(npu_num_blocks) - 1
 


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

* Propely calculate minimum required blocks in V0 wrt block manager heuristics.
* Use reserved null block for padding in V1.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #75 

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `RBLN_KERNEL_MODE="triton" RBLN_PROFILER=0 VLLM_USE_V1=0 python3 examples/experimental/offline_inference_basic.py` or `RBLN_KERNEL_MODE="triton" RBLN_PROFILER=0 VLLM_USE_V1=1 python3 examples/experimental/offline_inference_basic.py` with block_size == max_model_len and max_num_seqs == 1
2. Verify output: for v0 decode is properly done and for v1 code runs without error

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

should be revisited after block allocation with heuristics is addressed
