### PR TITLE
fix: get_maximum_num_blocks usage in USE_VLLM_MODEL=1

### DIFF
--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -179,8 +179,8 @@ class RBLNWorker(WorkerBase):
             nbits_per_param=16 if not self.model_config.quantization else 4,
             n_model_params=sum(p.numel()
                                for p in self.model_runner.model.parameters()),
-            # 1 : prefill
-            num_runtimes=1 + self.scheduler_config.max_num_seqs)
+            # 2 : 1 for prefill and decode each
+            num_runtimes=2)
 
         # for partition skip, we need dummy block slot.
         no_dummy_slots = 1

--- a/vllm_rbln/worker/worker.py
+++ b/vllm_rbln/worker/worker.py
@@ -302,8 +302,8 @@ class RBLNWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             nbits_per_param=16 if not self.model_config.quantization else 4,
             n_model_params=sum(p.numel()
                                for p in self.model_runner.model.parameters()),
-            # 1 : prefill
-            num_runtimes=1 + self.scheduler_config.max_num_seqs)
+            # 2 : 1 for prefill and decode each
+            num_runtimes=2)
 
         max_required_num_blocks = (
             self.model_config.max_model_len *


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

As we pad all inputs to the maximum batch size for now, the number of runtime is 2. One for prefill and decode each.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Create LLM instance with max_num_seqs set to 64

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
