### PR TITLE
(WIP) feat(core): allow multiple prefill requests to be scheduled in a chunk

### DIFF
--- a/vllm_rbln/attention/backends/flash_attention.py
+++ b/vllm_rbln/attention/backends/flash_attention.py
@@ -402,7 +402,6 @@ class RBLNAttentionMetadataBuilder(
         if not envs.RBLN_FLASH_CAUSAL_ATTN:
             if input_data.num_prefills:
                 step = steps[0][0]
-                assert input_data.num_prefills == 1
                 prefill_chunk_size = (
                     self.chunked_prefill_size if self.chunked_prefill else 1 <<
                     (math.ceil(math.log2(input_data.seq_lens[0]))))
@@ -414,13 +413,19 @@ class RBLNAttentionMetadataBuilder(
                     max_seq_len,
                     dtype=torch.float16
                     if self.enforce_eager else torch.float32)
-                causal_mask = 1 - torch.triu(torch.ones(
-                    1, 1, prefill_chunk_size, prefill_chunk_size),
-                                             diagonal=1)
-                if step >= prefill_chunk_size:
-                    chunked_attention_mask[:, :, :, :, :step] = 1
+                valid_len = sum(query_lens)
+                causal_masks = [
+                    torch.tril(torch.ones(query_len, query_len))
+                    for query_len in query_lens
+                ]
+                causal_mask = torch.block_diag(*causal_masks)
+                cur_causal_mask = torch.zeros(1, 1, prefill_chunk_size,
+                                              prefill_chunk_size)
+                cur_causal_mask[:, :, :valid_len, :valid_len] = causal_mask
+                if step > 0:
+                    chunked_attention_mask[:, :, :, :query_lens[0], :step] = 1
                 chunked_attention_mask[:, :, :, :, step:step +
-                                       prefill_chunk_size] = causal_mask
+                                       prefill_chunk_size] = cur_causal_mask
                 attn_masks = chunked_attention_mask
             else:
                 decode_attention_mask = torch.zeros(

--- a/vllm_rbln/core/scheduler.py
+++ b/vllm_rbln/core/scheduler.py
@@ -28,6 +28,7 @@ from vllm.core.scheduler import (ARTIFICIAL_PREEMPTION_PROB,
                                  SchedulerSwappedInOutputs, SchedulingBudget)
 from vllm.sequence import SequenceGroup, SequenceStage, SequenceStatus
 
+import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
 
 logger = init_logger(__name__)
@@ -388,9 +389,12 @@ class RBLNScheduler(Scheduler):
             )
             budget.add_num_seqs(seq_group.request_id, num_new_seqs)
 
-            # NOTE(RBLN):
-            # For rbln target, we only consider batch size of 1 for prefill.
-            break
+            if not enable_chunking or envs.RBLN_FLASH_CAUSAL_ATTN:
+                # NOTE(RBLN):
+                # For rbln target, we only consider batch size of 1 for prefill.
+                # In case of chunked prefill, it's available to schedule
+                # multiple requests in a single batch.
+                break
 
         logger.debug("waiting_queue -> len=%s", len(waiting_queue))
         # Queue requests that couldn't be scheduled.


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

- This PR allows multiple prefill requests to be scheduled at a time.
- This scheduling policy can enhance compute utilization by filling all the input tokens with valid tokens instead of padding tokens.
- It's partially implemented; Kernel implementations should be modified accordingly.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Related to https://github.com/rebellions-sw/vllm-rbln/issues/86

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [x] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`bug-fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

With this branch, the overall process of multiple-prefills-in-a-chunk,  including the inputs for the prefill attention kernel, can be analyzed. I guess the values for `slot_mapping` can be modified depending on the kernel implementation.

1. Run `RBLN_KERNEL_MODE=triton USE_VLLM_MODEL=1 VLLM_DISABLE_COMPILE_CACHE=1 USE_VLLM_V1=0 FLASH_CAUSAL_ATTN=0 python examples/experimental/offline_inference_basic.py`
2. Verify output: With the latest compiler/kernels, an error occurs rather than generating wrong outputs.  Please refer to the Notes below.
```
CS_GEN 
 --> L__self___model_model_layers__modules__0___input_layernorm__forward_method___self___weight_0_0


CS_GEN 
 --> L__self___model_model_layers__modules__0___self_attn_qkv_proj_weight_0_0_0

terminate called after throwing an instance of 'rbln::RuntimeError'
  what():  RBLNRuntimeError: CS_GEN 
Aborted (core dumped)
```

*Running with `FLASH_CAUSAL_ATTN`, which is the default, will use the original scheduling policy where only 1 prefill request is scheduled at a time.*

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

In the previous meeting, I've shared some outputs generated by this feature implementation, which indicates that it ran without errors even though the functionality was incorrect. Those results can be reproduced with earlier versions of the compiler/kernels. With the recent versions, it seems that the prefill attention kernel simply raises an error. Please refer to this [note](https://github.com/rebellions-sw/vllm-rbln/blob/static-cache/REPRODUCE_STATIC_CACHE.md) for the results obtained with earlier versions of the compiler/kernels.

---
