### PR TITLE
fix: add guard_filter to rbln_sampler

### DIFF
--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -265,9 +265,14 @@ class RBLNOptimumModelRunner(LoRAModelRunnerMixin):
                     )
             torch._dynamo.config.recompile_limit = len(
                 self.bucket_sizes) * len(WARM_UP_CONFIGS)
-            self.sampler = torch.compile(self.sampler,
-                                         dynamic=False,
-                                         fullgraph=False)
+            self.sampler = torch.compile(
+                self.sampler,
+                dynamic=False,
+                options={
+                    "guard_filter_fn":
+                    torch.compiler.keep_tensor_guards_unsafe,
+                },
+                fullgraph=False)
 
     def get_model(self) -> nn.Module:
         return self.model


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Currently, an error occurs when top_p=1.0 and the number of requests is more than 1.
```
self = var_ranges = {p0: 4, p1: 50272}
index0 = 50272*p0 + p1
def body(self, ops):
    get_index = self.get_index('index0')
 ...ex)
    get_index_1 = self.get_index('index0')
    store = ops.store('buf27', get_index_1, load, None)
    return store
buffer_name = 'buf7'

    def get_read_expr(self, buffer_name):
        # reversed to match old behavior
        for entry in reversed(self.memory_usage[MemoryUsageType.LOAD]):
            if entry.buffer_name == buffer_name:
                return self.indexing_exprs[entry.index_name]
>       raise KeyError(buffer_name)
E       torch._inductor.exc.InductorError: KeyError: 'buf7'
E       
E       Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/torch/_inductor/loop_body.py:298: InductorError

torch._inductor.exc.InductorError: KeyError: 'buf7'
```
The guard_filter prevents this error, but the root cause has not been identified yet.

## TODO
- #239 must be updated after this PR is merged due to changes in the code location.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
