### PR TITLE
update: enable profiler for optimum-rbln based vllm

### DIFF
--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -85,7 +85,6 @@ class RBLNOptimumWorker(WorkerBase):
         else:
             self.profiler = None
 
-
     def init_device(self) -> None:
         # Initialize the distributed environment.
         init_worker_distributed_environment(self.vllm_config, self.rank,
@@ -133,7 +132,6 @@ class RBLNOptimumWorker(WorkerBase):
             if self.local_rank == 0:
                 print(self.profiler.key_averages().table(
                     sort_by="self_cuda_time_total"))
-        
 
     def load_model(self):
         self.model_runner.load_model()


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

Add profiling functionality like torch.compile or vllm main.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

```
curl -X POST http://localhost:8001/start_profile
curl -X POST http://localhost:8001/stop_profile
```

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
