### PR TITLE
fix(attn): remove invalid attention param

### DIFF
--- a/vllm_rbln/attention/backends/flash_attention.py
+++ b/vllm_rbln/attention/backends/flash_attention.py
@@ -14,7 +14,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Dict, List, Optional, Tuple, Type
 
 import torch
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
@@ -492,7 +492,6 @@ class RBLNAttentionImpl(AttentionImpl[RBLNAttentionMetadata]):
         alibi_slopes: Optional[List[float]],
         sliding_window: Optional[int],
         kv_cache_dtype: str,
-        blocksparse_params: Optional[Dict[str, Any]] = None,
         logits_soft_cap: Optional[float] = None,
         attn_type: str = AttentionType.DECODER,
         kv_sharing_target_layer_name: Optional[str] = None,

--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -15,7 +15,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
@@ -787,7 +787,6 @@ class RBLNFlashAttentionImpl(AttentionImpl[RBLNFlashAttentionMetadata]):
         alibi_slopes: Optional[list[float]],
         sliding_window: Optional[int],
         kv_cache_dtype: str,
-        blocksparse_params: Optional[dict[str, Any]] = None,
         logits_soft_cap: Optional[float] = None,
         attn_type: str = AttentionType.DECODER,
         kv_sharing_target_layer_name: Optional[str] = None,
@@ -799,9 +798,6 @@ class RBLNFlashAttentionImpl(AttentionImpl[RBLNFlashAttentionMetadata]):
 
         if kv_sharing_target_layer_name is not None:
             raise NotImplementedError("KV sharing is not supported in RBLN.")
-        if blocksparse_params is not None:
-            raise ValueError("RBLN Attention Backend does not "
-                             "support block-sparse attention.")
         if logits_soft_cap is not None:
             logger.warning_once(
                 "RBLN Attention Backend does not support logits soft cap. "


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rebellions-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Fix attention backend because blocksparse_param was removed from the attention parameters starting in v0.10

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`bug-fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
`google/gemma-2-2b-it`
---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
