### PR TITLE
Revert "change kv cahce to meta tensor (#306)"

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3391,7 +3391,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             tensor = torch.zeros(kv_cache_tensor.size,
                                  dtype=torch.int8,
-                                 device="meta")
+                                 device="cpu")
             for layer_name in kv_cache_tensor.shared_by:
                 kv_cache_raw_tensors[layer_name] = tensor
 


### PR DESCRIPTION
This reverts commit af04acc4123e6700ee50c611f2af76056f8dfcb1.

Temporarily, disable kv cache meta tensor commit
since it DOES NOT work correctly with vllm model parallel such as data parallel

currently, meta tensor has different id for different dp rank