### PR TITLE
fix(scheduler): adjust max_model_len temporarily for speculative decoding

### DIFF
--- a/examples/experimental/run_specdec_ngram_test.py
+++ b/examples/experimental/run_specdec_ngram_test.py
@@ -17,7 +17,7 @@ os.environ["RBLN_USE_CUSTOM_KERNEL"] = "1"
 os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
 os.environ["VLLM_RBLN_COMPILE_STRICT_MODE"] = "1"
 os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
-os.environ["VLLM_RBLN_ENABLE_WARM_UP"] = "0"
+os.environ["VLLM_RBLN_ENABLE_WARM_UP"] = "1"
 os.environ["VLLM_RBLN_SAMPLER"] = "0"
 # vLLM(v0.10.2) bug: speculative decoding works only in multi-processing.
 # os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"

--- a/examples/experimental/run_specdec_suffix_test.py
+++ b/examples/experimental/run_specdec_suffix_test.py
@@ -18,7 +18,7 @@ os.environ.setdefault("RBLN_USE_CUSTOM_KERNEL", "1")
 os.environ.setdefault("VLLM_RBLN_USE_VLLM_MODEL", "1")
 os.environ.setdefault("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
 os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
-os.environ.setdefault("VLLM_RBLN_ENABLE_WARM_UP", "0")
+os.environ.setdefault("VLLM_RBLN_ENABLE_WARM_UP", "1")
 # vLLM(v0.10.2) bug: speculative decoding works only in multi-processing.
 # os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
 

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -214,13 +214,6 @@ class RblnPlatform(Platform):
                     )
                     envs.VLLM_RBLN_SAMPLER = False
 
-                # FIXME(RBLN): temporarily block warm up with spec-dec
-                if envs.VLLM_RBLN_ENABLE_WARM_UP:
-                    logger.warning(
-                        "Using warm up with speculative decoding is not supported yet."
-                    )
-                    envs.VLLM_RBLN_ENABLE_WARM_UP = False
-
         else:
             # NOTE(eunji.lee):
             # It is for multimodal models

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -13,15 +13,20 @@
 # limitations under the License.
 
 import time
+from copy import deepcopy
 
+from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request, RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln.logger import init_logger
@@ -58,6 +63,34 @@ def undo_uncomputed_block_caching(
 
 
 class RBLNScheduler(Scheduler):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        structured_output_manager: StructuredOutputManager,
+        block_size: int,
+        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+        include_finished_set: bool = False,
+        log_stats: bool = False,
+    ) -> None:
+        # FIXME(RBLN): adjust max_model_len temporarily for speculative decoding
+        if vllm_config.speculative_config is not None and (
+            num_speculative_tokens
+            := vllm_config.speculative_config.num_speculative_tokens
+        ):
+            vllm_config = deepcopy(vllm_config)
+            vllm_config.model_config.max_model_len -= num_speculative_tokens - 1
+
+        super().__init__(
+            vllm_config,
+            kv_cache_config,
+            structured_output_manager,
+            block_size,
+            mm_registry,
+            include_finished_set,
+            log_stats,
+        )
+
     def schedule(self) -> SchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.13.0/vllm/v1/core/sched/scheduler.py#L216-L757
         # The only differences are:

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1796,23 +1796,23 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
 
+        # FIXME(RBLN): At the moment, a single request can’t access multiple
+        # blocks per layer under the current implementation, so we’re forced
+        # to reduce the warmup length to a reasonable value for now.
+        # This is mainly because we still have to run the computation over
+        # the padded tokens in speculative decoing scenario as well.
+        decode_max_seq_len = self.max_model_len // 2
+
         # compile decode graph considering decode batch buckets
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
-            decode_max_seq_len = self.max_model_len // 2
-
             dummy_decode_requests: list[NewRequestData] = []
             dummy_decode_num_scheduled_tokens: dict[str, int] = {}
-            num_speculative_tokens = (
-                self.speculative_config.num_speculative_tokens
-                if self.speculative_config is not None
-                else 0
-            )
             for _ in range(batch_bucket_size):
                 self._add_dummy_requests(
                     requests=dummy_decode_requests,
                     num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
-                    total_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
-                    num_computed_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
+                    total_tokens=decode_max_seq_len,
+                    num_computed_tokens=decode_max_seq_len,
                     num_kv_cache_groups=num_kv_cache_groups,
                     sampling_params=None
                     if self.is_pooling_model
@@ -1822,7 +1822,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                     if self.is_pooling_model
                     else None,
-                    num_speculative_tokens=num_speculative_tokens,
                 )
             so, cso = self._make_dummy_scheduler_outputs(
                 dummy_decode_requests,
@@ -1847,20 +1846,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # compile sampler for all possible decode batches
         max_decode_batch = self.bucketing_manager.decode_batch_buckets[-1]
         for decode_batch in range(1, max_decode_batch + 1):
-            decode_max_seq_len = self.max_model_len // 2
             dummy_decode_requests = []
             dummy_decode_num_scheduled_tokens = {}
-            num_speculative_tokens = (
-                self.speculative_config.num_speculative_tokens
-                if self.speculative_config is not None
-                else 0
-            )
             for _ in range(decode_batch):
                 self._add_dummy_requests(
                     requests=dummy_decode_requests,
                     num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
-                    total_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
-                    num_computed_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
+                    total_tokens=decode_max_seq_len,
+                    num_computed_tokens=decode_max_seq_len,
                     num_kv_cache_groups=num_kv_cache_groups,
                     sampling_params=None
                     if self.is_pooling_model
@@ -1870,7 +1863,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                     if self.is_pooling_model
                     else None,
-                    num_speculative_tokens=num_speculative_tokens,
                 )
             so, cso = self._make_dummy_scheduler_outputs(
                 dummy_decode_requests,
@@ -1892,7 +1884,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_kv_cache_groups: int,
         sampling_params: SamplingParams | None = None,
         pooling_params: PoolingParams | None = None,
-        num_speculative_tokens: int = 0,
     ) -> None:
         num_blocks = (
             round_up(total_tokens, self.cache_config.block_size)
@@ -1914,7 +1905,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         requests.append(req)
         num_scheduled_tokens[req.req_id] = (
-            (1 + num_speculative_tokens)
+            (1 + self.num_spec_tokens)
             if total_tokens - num_computed_tokens == 0
             else total_tokens - num_computed_tokens
         )

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1798,7 +1798,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # compile decode graph considering decode batch buckets
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
-            decode_max_seq_len = self.max_model_len
+            decode_max_seq_len = self.max_model_len // 2
 
             dummy_decode_requests: list[NewRequestData] = []
             dummy_decode_num_scheduled_tokens: dict[str, int] = {}
@@ -1847,7 +1847,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # compile sampler for all possible decode batches
         max_decode_batch = self.bucketing_manager.decode_batch_buckets[-1]
         for decode_batch in range(1, max_decode_batch + 1):
-            decode_max_seq_len = self.max_model_len
+            decode_max_seq_len = self.max_model_len // 2
             dummy_decode_requests = []
             dummy_decode_num_scheduled_tokens = {}
             num_speculative_tokens = (


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

- Add `RBLNScheduler.__init__` to patch vllm_config when speculative decoding is enabled. Reduce max_model_len by num_speculative_tokens to avoid over-accessing KV cache.
- Use deepcopy to avoid mutating the original vllm_config.
- Reduce max_model_len when warming up the model.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #398  

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `examples/experimental/run_specdec_ngram_test.py` after setting `max_tokens` to `max_model_len` and `ignore_eos` in sampling parameter.
2. Verify output: generates text sequences without error
3. Edge case tested: None

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

To resolve runtime error at `max_model_len` boundary due to accessing multi-block of KV caches and benchmark initially, I simply reduced `max_model_len` in the scheduler. After initial benchmarks, we will revisit this issue.

---
