### PR TITLE
fix(specdec): remove block size limitation 

### DIFF
--- a/examples/experimental/run_specdec_ngram_test.py
+++ b/examples/experimental/run_specdec_ngram_test.py
@@ -17,7 +17,7 @@ os.environ["RBLN_USE_CUSTOM_KERNEL"] = "1"
 os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
 os.environ["VLLM_RBLN_COMPILE_STRICT_MODE"] = "1"
 os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
-os.environ["VLLM_RBLN_ENABLE_WARM_UP"] = "0"
+os.environ["VLLM_RBLN_ENABLE_WARM_UP"] = "1"
 os.environ["VLLM_RBLN_SAMPLER"] = "0"
 # vLLM(v0.10.2) bug: speculative decoding works only in multi-processing.
 # os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"

--- a/examples/experimental/run_specdec_ngram_test.py
+++ b/examples/experimental/run_specdec_ngram_test.py
@@ -36,7 +36,7 @@ def main():
     llm = LLM(
         model=MODEL_ID,
         max_model_len=2048,
-        block_size=2048,
+        block_size=1024,
         enable_chunked_prefill=True,
         max_num_batched_tokens=256,
         max_num_seqs=4,

--- a/examples/experimental/run_specdec_suffix_test.py
+++ b/examples/experimental/run_specdec_suffix_test.py
@@ -18,7 +18,7 @@ os.environ.setdefault("RBLN_USE_CUSTOM_KERNEL", "1")
 os.environ.setdefault("VLLM_RBLN_USE_VLLM_MODEL", "1")
 os.environ.setdefault("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
 os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
-os.environ.setdefault("VLLM_RBLN_ENABLE_WARM_UP", "0")
+os.environ.setdefault("VLLM_RBLN_ENABLE_WARM_UP", "1")
 # vLLM(v0.10.2) bug: speculative decoding works only in multi-processing.
 # os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
 

--- a/tests/torch_compile/v1/core/test_scheduler.py
+++ b/tests/torch_compile/v1/core/test_scheduler.py
@@ -133,3 +133,279 @@ def test_preempt_during_execution():
     # sampled token id.
     assert len(requests[1].output_token_ids) == 1
     assert requests[1].output_token_ids[0] == 42
+
+
+# ---------------------------------------------------------------------------
+# Helpers for spec_decode_cap tests
+# ---------------------------------------------------------------------------
+
+_SD_BLOCK_SIZE = 1024
+_SD_NUM_BLOCKS = 100
+_SD_MAX_NUM_SEQS = 10
+
+
+def _sd_scheduler(**kwargs):
+    return create_scheduler(
+        block_size=_SD_BLOCK_SIZE,
+        num_blocks=_SD_NUM_BLOCKS,
+        max_num_seqs=_SD_MAX_NUM_SEQS,
+        **kwargs,
+    )
+
+
+def _sd_request(num_tokens, req_id):
+    return create_requests(
+        num_requests=1,
+        num_tokens=num_tokens,
+        block_size=_SD_BLOCK_SIZE,
+        max_tokens=2048,
+        req_ids=[req_id],
+    )[0]
+
+
+def _advance_to_decode(scheduler, request):
+    """Run one prefill step + update so the request enters decode state."""
+    scheduler.add_request(request)
+    sched_out = scheduler.schedule()
+    scheduler.update_from_output(sched_out, create_runner_output(sched_out, 1))
+
+
+def _check_invariant(sched_out, req_id):
+    """num_scheduled_tokens == 1 (decode token) + len(spec_tokens)."""
+    n = sched_out.num_scheduled_tokens[req_id]
+    spec = sched_out.scheduled_spec_decode_tokens.get(req_id, [])
+    assert n == 1 + len(spec), (
+        f"req {req_id}: num_scheduled_tokens={n} but 1+spec={1 + len(spec)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [1/10]:
+# block boundary → cap == block_size → no retroactive trim
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_at_block_boundary():
+    """prompt=1024 → remaining_in_block=1024 == block_size; cap unchanged."""
+    scheduler = _sd_scheduler()
+    req = _sd_request(1024, "A")
+    _advance_to_decode(scheduler, req)
+
+    req.spec_token_ids = [1] * 4
+    sched_out = scheduler.schedule()
+
+    rid = req.request_id
+    assert sched_out.num_scheduled_tokens[rid] == 5
+    assert len(sched_out.scheduled_spec_decode_tokens[rid]) == 4
+    _check_invariant(sched_out, rid)
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [2/10]:
+# near block boundary → all spec tokens trimmed
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_near_block_boundary_all_trimmed():
+    """prompt=1023 → remaining_in_block=1 → cap=1 → all spec removed."""
+    scheduler = _sd_scheduler()
+    req = _sd_request(1023, "A")
+    _advance_to_decode(scheduler, req)
+
+    req.spec_token_ids = [1] * 4
+    sched_out = scheduler.schedule()
+
+    rid = req.request_id
+    assert sched_out.num_scheduled_tokens[rid] == 1
+    assert rid not in sched_out.scheduled_spec_decode_tokens
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [3/10]:
+# partial spec tokens fit (remaining=4, spec=6 → 3 spec survive)
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_partial_spec_tokens_fit():
+    """prompt=1020 → remaining_in_block=4 → cap=4 → 3 spec tokens survive."""
+    scheduler = _sd_scheduler()
+    req = _sd_request(1020, "A")
+    _advance_to_decode(scheduler, req)
+
+    req.spec_token_ids = [1] * 6
+    sched_out = scheduler.schedule()
+
+    rid = req.request_id
+    assert sched_out.num_scheduled_tokens[rid] == 4
+    assert len(sched_out.scheduled_spec_decode_tokens[rid]) == 3
+    _check_invariant(sched_out, rid)
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [4/10]:
+# no spec tokens → retroactive trim skipped even when cap < block_size
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_no_spec_tokens_no_retroactive_trim():
+    """cap=1 but scheduled_spec_decode_tokens is empty → trim skipped."""
+    scheduler = _sd_scheduler()
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(1023, "B")
+    _advance_to_decode(scheduler, req_a)
+    _advance_to_decode(scheduler, req_b)
+
+    sched_out = scheduler.schedule()
+
+    assert sched_out.num_scheduled_tokens[req_a.request_id] == 1
+    assert sched_out.num_scheduled_tokens[req_b.request_id] == 1
+    assert sched_out.scheduled_spec_decode_tokens == {}
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [5/10]:
+# B tightens cap=1 → both A and B lose all spec tokens
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_retroactive_trim_all_spec_removed():
+    """A(1024)+B(1023) with spec=4 each; B sets cap=1 → both trimmed to 1."""
+    scheduler = _sd_scheduler()
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(1023, "B")
+    _advance_to_decode(scheduler, req_a)
+    _advance_to_decode(scheduler, req_b)
+
+    req_a.spec_token_ids = [1] * 4
+    req_b.spec_token_ids = [1] * 4
+    sched_out = scheduler.schedule()
+
+    assert sched_out.num_scheduled_tokens[req_a.request_id] == 1
+    assert sched_out.num_scheduled_tokens[req_b.request_id] == 1
+    assert req_a.request_id not in sched_out.scheduled_spec_decode_tokens
+    assert req_b.request_id not in sched_out.scheduled_spec_decode_tokens
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [6/10]:
+# B tightens cap=4 → both A and B trimmed to 4 (1+3 spec)
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_retroactive_trim_partial_spec_preserved():
+    """A(1024)+B(1020) with spec=6 each; B sets cap=4 → 3 spec each."""
+    scheduler = _sd_scheduler()
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(1020, "B")
+    _advance_to_decode(scheduler, req_a)
+    _advance_to_decode(scheduler, req_b)
+
+    req_a.spec_token_ids = [1] * 6
+    req_b.spec_token_ids = [1] * 6
+    sched_out = scheduler.schedule()
+
+    assert sched_out.num_scheduled_tokens[req_a.request_id] == 4
+    assert sched_out.num_scheduled_tokens[req_b.request_id] == 4
+    assert len(sched_out.scheduled_spec_decode_tokens[req_a.request_id]) == 3
+    assert len(sched_out.scheduled_spec_decode_tokens[req_b.request_id]) == 3
+    _check_invariant(sched_out, req_a.request_id)
+    _check_invariant(sched_out, req_b.request_id)
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [7/10]:
+# three requests; C sets cap=2 → all trimmed to 2 (1+1 spec)
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_retroactive_trim_three_requests():
+    """A(1024)+B(512)+C(1022) with spec=6 each; C sets cap=2 → 1 spec each."""
+    scheduler = _sd_scheduler()
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(512, "B")
+    req_c = _sd_request(1022, "C")
+    _advance_to_decode(scheduler, req_a)
+    _advance_to_decode(scheduler, req_b)
+    _advance_to_decode(scheduler, req_c)
+
+    req_a.spec_token_ids = [1] * 6
+    req_b.spec_token_ids = [1] * 6
+    req_c.spec_token_ids = [1] * 6
+    sched_out = scheduler.schedule()
+
+    for req in (req_a, req_b, req_c):
+        rid = req.request_id
+        assert sched_out.num_scheduled_tokens[rid] == 2
+        assert len(sched_out.scheduled_spec_decode_tokens[rid]) == 1
+        _check_invariant(sched_out, rid)
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [8/10]:
+# decode-only B tightens cap → A retroactively trimmed
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_decode_only_tightens_cap():
+    """A(1024,spec=4)+B(1020,no spec); B sets cap=4 → A trimmed to 4 (1+3)."""
+    scheduler = _sd_scheduler()
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(1020, "B")
+    _advance_to_decode(scheduler, req_a)
+    _advance_to_decode(scheduler, req_b)
+
+    req_a.spec_token_ids = [1] * 4
+    # req_b has no spec tokens
+    sched_out = scheduler.schedule()
+
+    assert sched_out.num_scheduled_tokens[req_a.request_id] == 4
+    assert sched_out.num_scheduled_tokens[req_b.request_id] == 1
+    assert len(sched_out.scheduled_spec_decode_tokens[req_a.request_id]) == 3
+    assert req_b.request_id not in sched_out.scheduled_spec_decode_tokens
+    _check_invariant(sched_out, req_a.request_id)
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [9/10]:
+# max_model_len constraint tightens cap via remaining_in_maxlen
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_maxlen_constraint():
+    """A(1024,spec=6)+B(2046,no spec); B's remaining_in_maxlen=2 → cap=2."""
+    scheduler = _sd_scheduler(max_model_len=2048, max_num_batched_tokens=2048)
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(2046, "B")
+    _advance_to_decode(scheduler, req_a)
+    _advance_to_decode(scheduler, req_b)
+
+    req_a.spec_token_ids = [1] * 6
+    sched_out = scheduler.schedule()
+
+    assert sched_out.num_scheduled_tokens[req_a.request_id] == 2
+    assert sched_out.num_scheduled_tokens[req_b.request_id] == 1
+    assert len(sched_out.scheduled_spec_decode_tokens[req_a.request_id]) == 1
+    assert req_b.request_id not in sched_out.scheduled_spec_decode_tokens
+    _check_invariant(sched_out, req_a.request_id)
+
+
+# ---------------------------------------------------------------------------
+# spec_decode_cap [10/10]:
+# new prefill in waiting triggers no-mixed-batching → decode excluded
+# ---------------------------------------------------------------------------
+
+
+def test_spec_decode_cap_prefill_triggers_no_mixed_batching():
+    """A(1024,decode,spec=4) running + B(512) waiting → only B scheduled."""
+    scheduler = _sd_scheduler()
+    req_a = _sd_request(1024, "A")
+    req_b = _sd_request(512, "B")
+    _advance_to_decode(scheduler, req_a)
+
+    req_a.spec_token_ids = [1] * 4
+    scheduler.add_request(req_b)
+    sched_out = scheduler.schedule()
+
+    assert len(sched_out.scheduled_new_reqs) == 1
+    assert req_a.request_id not in sched_out.num_scheduled_tokens
+    assert req_b.request_id in sched_out.num_scheduled_tokens

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -218,13 +218,6 @@ class RblnPlatform(Platform):
                 )
                 envs.VLLM_RBLN_SAMPLER = False
 
-                # FIXME(RBLN): temporarily block warm up with spec-dec
-                if envs.VLLM_RBLN_ENABLE_WARM_UP:
-                    logger.warning(
-                        "Using warm up with speculative decoding is not supported yet."
-                    )
-                    envs.VLLM_RBLN_ENABLE_WARM_UP = False
-
         else:
             # NOTE(eunji.lee):
             # It is for multimodal models

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -226,13 +226,6 @@ class RblnPlatform(Platform):
                     )
                     envs.VLLM_RBLN_SAMPLER = False
 
-                # FIXME(RBLN): temporarily block warm up with spec-dec
-                if envs.VLLM_RBLN_ENABLE_WARM_UP:
-                    logger.warning(
-                        "Using warm up with speculative decoding is not supported yet."
-                    )
-                    envs.VLLM_RBLN_ENABLE_WARM_UP = False
-
         else:
             # NOTE(eunji.lee):
             # It is for multimodal models

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -218,6 +218,13 @@ class RblnPlatform(Platform):
                 )
                 envs.VLLM_RBLN_SAMPLER = False
 
+                # FIXME(RBLN): temporarily block warm up with spec-dec
+                if envs.VLLM_RBLN_ENABLE_WARM_UP:
+                    logger.warning(
+                        "Using warm up with speculative decoding is not supported yet."
+                    )
+                    envs.VLLM_RBLN_ENABLE_WARM_UP = False
+
         else:
             # NOTE(eunji.lee):
             # It is for multimodal models

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -155,7 +155,6 @@ class RblnPlatform(Platform):
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
-        cache_config = vllm_config.cache_config
 
         if envs.VLLM_RBLN_USE_VLLM_MODEL:
             cls.validate_and_setup_prerequisite(vllm_config)
@@ -212,19 +211,12 @@ class RblnPlatform(Platform):
                 if (lora_config := vllm_config.lora_config) is not None:
                     lora_config.lora_dtype = torch.float16
 
-            if vllm_config.speculative_config is not None:
-                # FIXME(RBLN): remove block size constraint from spec-dec
-                assert model_config.max_model_len == cache_config.block_size, (
-                    "block_size must be set to max_model_len with speculative decoding."
-                )
-
+            if vllm_config.speculative_config is not None and envs.VLLM_RBLN_SAMPLER:
                 # FIXME(RBLN): make RBLNSampler compatible with speculative decoding
-                if envs.VLLM_RBLN_SAMPLER:
-                    logger.warning(
-                        "Using RBLNSampler with speculative decoding "
-                        "is not supported yet."
-                    )
-                    envs.VLLM_RBLN_SAMPLER = False
+                logger.warning(
+                    "Using RBLNSampler with speculative decoding is not supported yet."
+                )
+                envs.VLLM_RBLN_SAMPLER = False
 
         else:
             # NOTE(eunji.lee):

--- a/vllm_rbln/triton_kernels/flash_causal_attention.py
+++ b/vllm_rbln/triton_kernels/flash_causal_attention.py
@@ -283,7 +283,6 @@ def flash_causal_attention_naive_decode(
     NUM_BLOCK: tl.constexpr,
     DIM_BLOCK_TABLE: tl.constexpr,
 ):
-    # tl.static_assert(QUERY_LEN == 1)
     tl.static_assert(MAX_SEQ_LEN % PARTITION_SIZE == 0)
     NUM_PARTITION: tl.constexpr = MAX_SEQ_LEN // PARTITION_SIZE
     DYNAMIC_AXIS: tl.constexpr = 4

--- a/vllm_rbln/triton_kernels/flash_causal_attention.py
+++ b/vllm_rbln/triton_kernels/flash_causal_attention.py
@@ -283,7 +283,7 @@ def flash_causal_attention_naive_decode(
     NUM_BLOCK: tl.constexpr,
     DIM_BLOCK_TABLE: tl.constexpr,
 ):
-    tl.static_assert(QUERY_LEN == 1)
+    # tl.static_assert(QUERY_LEN == 1)
     tl.static_assert(MAX_SEQ_LEN % PARTITION_SIZE == 0)
     NUM_PARTITION: tl.constexpr = MAX_SEQ_LEN // PARTITION_SIZE
     DYNAMIC_AXIS: tl.constexpr = 4

--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -1095,7 +1095,7 @@ class RBLNFlashAttentionMetadataBuilder(
         suffix_kv_lens = None
         prefix_scheduler_metadata = None
 
-        seq_idx = positions[:num_reqs].view(-1, 1)
+        seq_idx = positions[query_start_loc[:num_reqs]].view(-1, 1)
 
         # The length of the partition equals the block size.
         partition_len = self.block_size

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -336,25 +336,15 @@ class RBLNScheduler(Scheduler):
                     continue
                 new_n = spec_decode_cap
 
-                # Check whether the reduced count requires freeing blocks.
-                # Extra blocks exist only when ceil reduces (edge case).
-                old_num_blocks = (
-                    req.num_computed_tokens + old_n + self.block_size - 1
-                ) // self.block_size
-                new_num_blocks = (
-                    req.num_computed_tokens + new_n + self.block_size - 1
-                ) // self.block_size
-
-                if old_num_blocks > new_num_blocks:
-                    # Extra blocks were allocated for the original token count but
-                    # are no longer needed. Invalidate their prefix cache hash so
-                    # they are not reused incorrectly; the blocks remain allocated
-                    # and will be reused when this request needs them in a future step.
-                    undo_uncomputed_block_caching(
-                        req,
-                        self.kv_cache_manager,
-                        req.num_computed_tokens + new_n,
-                    )
+                # Extra blocks were allocated for the original token count but
+                # are no longer needed. Invalidate their prefix cache hash so
+                # they are not reused incorrectly; the blocks remain allocated
+                # and will be reused when this request needs them in a future step.
+                undo_uncomputed_block_caching(
+                    req,
+                    self.kv_cache_manager,
+                    req.num_computed_tokens + new_n,
+                )
 
                 token_budget += old_n - new_n
                 num_scheduled_tokens[req_id] = new_n

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -13,20 +13,15 @@
 # limitations under the License.
 
 import time
-from copy import deepcopy
 
-from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
-from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType
-from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln.logger import init_logger
@@ -63,34 +58,6 @@ def undo_uncomputed_block_caching(
 
 
 class RBLNScheduler(Scheduler):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        kv_cache_config: KVCacheConfig,
-        structured_output_manager: StructuredOutputManager,
-        block_size: int,
-        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
-        include_finished_set: bool = False,
-        log_stats: bool = False,
-    ) -> None:
-        # FIXME(RBLN): adjust max_model_len temporarily for speculative decoding
-        if vllm_config.speculative_config is not None and (
-            num_speculative_tokens
-            := vllm_config.speculative_config.num_speculative_tokens
-        ):
-            vllm_config = deepcopy(vllm_config)
-            vllm_config.model_config.max_model_len -= num_speculative_tokens - 1
-
-        super().__init__(
-            vllm_config,
-            kv_cache_config,
-            structured_output_manager,
-            block_size,
-            mm_registry,
-            include_finished_set,
-            log_stats,
-        )
-
     def schedule(self) -> SchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.13.0/vllm/v1/core/sched/scheduler.py#L216-L757
         # The only differences are:
@@ -276,16 +243,20 @@ class RBLNScheduler(Scheduler):
             token_budget -= num_new_tokens
             req_index += 1
 
-            # NOTE(RBLN): Update spec_decode_cap with this request's remaining
-            # space in the current block. Done here (after confirmed scheduling)
+            # NOTE(RBLN): Update spec_decode_cap with the tightest constraint
+            # for this request: remaining space in the current block and remaining
+            # tokens until max_model_len. Done here (after confirmed scheduling)
             # so that only actually scheduled requests affect the cap, and
-            # num_new_tokens reflects all prior adjustments (max_model_len, etc.).
-            # Even single-token decode requests must constrain the cap because
-            # the runner pads all requests to max_spec_decode_len.
+            # num_new_tokens reflects all prior adjustments. Even single-token
+            # decode requests must constrain the cap because the runner pads all
+            # requests to max_spec_decode_len.
             if not is_prefill(request):
                 tokens_used_in_block = request.num_computed_tokens % self.block_size
                 remaining_in_block = self.block_size - tokens_used_in_block
-                spec_decode_cap = min(remaining_in_block, spec_decode_cap)
+                remaining_in_maxlen = self.max_model_len - request.num_computed_tokens
+                spec_decode_cap = min(
+                    remaining_in_block, remaining_in_maxlen, spec_decode_cap
+                )
 
             # Speculative decode related.
             if request.spec_token_ids:

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -13,15 +13,20 @@
 # limitations under the License.
 
 import time
+from copy import deepcopy
 
+from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request, RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_rbln.logger import init_logger
@@ -58,6 +63,34 @@ def undo_uncomputed_block_caching(
 
 
 class RBLNScheduler(Scheduler):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        structured_output_manager: StructuredOutputManager,
+        block_size: int,
+        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+        include_finished_set: bool = False,
+        log_stats: bool = False,
+    ) -> None:
+        # FIXME(RBLN): adjust max_model_len temporarily for speculative decoding
+        if vllm_config.speculative_config is not None and (
+            num_speculative_tokens
+            := vllm_config.speculative_config.num_speculative_tokens
+        ):
+            vllm_config = deepcopy(vllm_config)
+            vllm_config.model_config.max_model_len -= num_speculative_tokens - 1
+
+        super().__init__(
+            vllm_config,
+            kv_cache_config,
+            structured_output_manager,
+            block_size,
+            mm_registry,
+            include_finished_set,
+            log_stats,
+        )
+
     def schedule(self) -> SchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.13.0/vllm/v1/core/sched/scheduler.py#L216-L757
         # The only differences are:

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -137,6 +137,14 @@ class RBLNScheduler(Scheduler):
             if self.running and is_prefill(self.running[-1])
             else 0
         )
+        # NOTE(RBLN): spec_decode_cap prevents block boundary crossing caused by
+        # runner-side padding. The runner pads all requests in the batch to the
+        # maximum scheduled token length (max_spec_decode_len). If any request
+        # is trimmed due to a block boundary, other requests with more tokens
+        # would cause that trimmed request to be padded beyond its boundary.
+        # spec_decode_cap propagates the tightest remaining_in_block constraint
+        # to all subsequent requests so no request exceeds it.
+        spec_decode_cap = self.block_size
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
 
@@ -268,6 +276,17 @@ class RBLNScheduler(Scheduler):
             token_budget -= num_new_tokens
             req_index += 1
 
+            # NOTE(RBLN): Update spec_decode_cap with this request's remaining
+            # space in the current block. Done here (after confirmed scheduling)
+            # so that only actually scheduled requests affect the cap, and
+            # num_new_tokens reflects all prior adjustments (max_model_len, etc.).
+            # Even single-token decode requests must constrain the cap because
+            # the runner pads all requests to max_spec_decode_len.
+            if not is_prefill(request):
+                tokens_used_in_block = request.num_computed_tokens % self.block_size
+                remaining_in_block = self.block_size - tokens_used_in_block
+                spec_decode_cap = min(remaining_in_block, spec_decode_cap)
+
             # Speculative decode related.
             if request.spec_token_ids:
                 num_scheduled_spec_tokens = (
@@ -300,6 +319,60 @@ class RBLNScheduler(Scheduler):
                     self.encoder_cache_manager.allocate(request, i)
                     if self.ec_connector is not None:
                         self.ec_connector.update_state_after_alloc(request, i)
+
+        # NOTE(RBLN): Retroactively apply spec_decode_cap to requests scheduled
+        # before the cap was tightened. Only needed when spec decode is active
+        # this step (scheduled_spec_decode_tokens non-empty), since that is when
+        # the runner pads all requests to max_spec_decode_len. A request processed
+        # earlier in the loop may have been allocated more tokens than
+        # spec_decode_cap allows; if left uncorrected, the runner would pad a
+        # constrained request up to that larger length, causing it to cross its
+        # block boundary.
+        if spec_decode_cap < self.block_size and scheduled_spec_decode_tokens:
+            for req in scheduled_running_reqs:
+                req_id = req.request_id
+                old_n = num_scheduled_tokens[req_id]
+                if old_n <= spec_decode_cap:
+                    continue
+                new_n = spec_decode_cap
+
+                # Check whether the reduced count requires freeing blocks.
+                # Extra blocks exist only when ceil reduces (edge case).
+                old_num_blocks = (
+                    req.num_computed_tokens + old_n + self.block_size - 1
+                ) // self.block_size
+                new_num_blocks = (
+                    req.num_computed_tokens + new_n + self.block_size - 1
+                ) // self.block_size
+
+                if old_num_blocks > new_num_blocks:
+                    # Extra blocks were allocated for the original token count but
+                    # are no longer needed. Invalidate their prefix cache hash so
+                    # they are not reused incorrectly; the blocks remain allocated
+                    # and will be reused when this request needs them in a future step.
+                    undo_uncomputed_block_caching(
+                        req,
+                        self.kv_cache_manager,
+                        req.num_computed_tokens + new_n,
+                    )
+
+                token_budget += old_n - new_n
+                num_scheduled_tokens[req_id] = new_n
+
+                # Re-trim spec tokens to match the reduced token count.
+                num_spec = (
+                    new_n
+                    + req.num_computed_tokens
+                    - req.num_tokens
+                    - req.num_output_placeholders
+                )
+                if num_spec > 0:
+                    if req_id in scheduled_spec_decode_tokens:
+                        scheduled_spec_decode_tokens[req_id] = (
+                            scheduled_spec_decode_tokens[req_id][:num_spec]
+                        )
+                else:
+                    scheduled_spec_decode_tokens.pop(req_id, None)
 
         # Record the LoRAs in scheduled_running_reqs
         scheduled_loras: set[int] = set()

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1800,7 +1800,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # compile decode graph considering decode batch buckets
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
-            decode_max_seq_len = self.max_model_len
+            decode_max_seq_len = self.max_model_len // 2
 
             dummy_decode_requests: list[NewRequestData] = []
             dummy_decode_num_scheduled_tokens: dict[str, int] = {}
@@ -1849,7 +1849,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # compile sampler for all possible decode batches
         max_decode_batch = self.bucketing_manager.decode_batch_buckets[-1]
         for decode_batch in range(1, max_decode_batch + 1):
-            decode_max_seq_len = self.max_model_len
+            decode_max_seq_len = self.max_model_len // 2
             dummy_decode_requests = []
             dummy_decode_num_scheduled_tokens = {}
             num_speculative_tokens = (

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1798,23 +1798,23 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
 
+        # FIXME(RBLN): At the moment, a single request can’t access multiple
+        # blocks per layer under the current implementation, so we’re forced
+        # to reduce the warmup length to a reasonable value for now.
+        # This is mainly because we still have to run the computation over
+        # the padded tokens in speculative decoing scenario as well.
+        decode_max_seq_len = self.max_model_len // 2
+
         # compile decode graph considering decode batch buckets
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
-            decode_max_seq_len = self.max_model_len // 2
-
             dummy_decode_requests: list[NewRequestData] = []
             dummy_decode_num_scheduled_tokens: dict[str, int] = {}
-            num_speculative_tokens = (
-                self.speculative_config.num_speculative_tokens
-                if self.speculative_config is not None
-                else 0
-            )
             for _ in range(batch_bucket_size):
                 self._add_dummy_requests(
                     requests=dummy_decode_requests,
                     num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
-                    total_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
-                    num_computed_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
+                    total_tokens=decode_max_seq_len,
+                    num_computed_tokens=decode_max_seq_len,
                     num_kv_cache_groups=num_kv_cache_groups,
                     sampling_params=None
                     if self.is_pooling_model
@@ -1824,7 +1824,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                     if self.is_pooling_model
                     else None,
-                    num_speculative_tokens=num_speculative_tokens,
                 )
             so, cso = self._make_dummy_scheduler_outputs(
                 dummy_decode_requests,
@@ -1849,20 +1848,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # compile sampler for all possible decode batches
         max_decode_batch = self.bucketing_manager.decode_batch_buckets[-1]
         for decode_batch in range(1, max_decode_batch + 1):
-            decode_max_seq_len = self.max_model_len // 2
             dummy_decode_requests = []
             dummy_decode_num_scheduled_tokens = {}
-            num_speculative_tokens = (
-                self.speculative_config.num_speculative_tokens
-                if self.speculative_config is not None
-                else 0
-            )
             for _ in range(decode_batch):
                 self._add_dummy_requests(
                     requests=dummy_decode_requests,
                     num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
-                    total_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
-                    num_computed_tokens=decode_max_seq_len - 1 - num_speculative_tokens,
+                    total_tokens=decode_max_seq_len,
+                    num_computed_tokens=decode_max_seq_len,
                     num_kv_cache_groups=num_kv_cache_groups,
                     sampling_params=None
                     if self.is_pooling_model
@@ -1872,7 +1865,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                     if self.is_pooling_model
                     else None,
-                    num_speculative_tokens=num_speculative_tokens,
                 )
             so, cso = self._make_dummy_scheduler_outputs(
                 dummy_decode_requests,
@@ -1894,7 +1886,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_kv_cache_groups: int,
         sampling_params: SamplingParams | None = None,
         pooling_params: PoolingParams | None = None,
-        num_speculative_tokens: int = 0,
     ) -> None:
         num_blocks = (
             round_up(total_tokens, self.cache_config.block_size)
@@ -1916,7 +1907,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         requests.append(req)
         num_scheduled_tokens[req.req_id] = (
-            (1 + num_speculative_tokens)
+            (1 + self.num_spec_tokens)
             if total_tokens - num_computed_tokens == 0
             else total_tokens - num_computed_tokens
         )

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1802,7 +1802,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # blocks per layer under the current implementation, so we’re forced
         # to reduce the warmup length to a reasonable value for now.
         # This is mainly because we still have to run the computation over
-        # the padded tokens in speculative decoing scenario as well.
+        # the padded tokens in speculative decoding scenario as well.
         decode_max_seq_len = self.max_model_len // 2
 
         # compile decode graph considering decode batch buckets

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2535,8 +2535,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         is_prefills = self.is_prefills()
 
         # Padding length for speculative decoding by num_speculative_tokens
-        if self.speculative_config is not None and not is_prefills[0]:
-            max_spec_decode_len = self.speculative_config.num_speculative_tokens + 1
+        if scheduler_output.scheduled_spec_decode_tokens:
+            max_spec_decode_len = (
+                max(
+                    len(s)
+                    for s in scheduler_output.scheduled_spec_decode_tokens.values()
+                )
+                + 1
+            )
             num_scheduled_tokens_per_req = torch.tensor(
                 [
                     scheduler_output.num_scheduled_tokens[i]

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1807,43 +1807,56 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # compile decode graph considering decode batch buckets
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
-            dummy_decode_requests: list[NewRequestData] = []
-            dummy_decode_num_scheduled_tokens: dict[str, int] = {}
-            for _ in range(batch_bucket_size):
-                self._add_dummy_requests(
-                    requests=dummy_decode_requests,
-                    num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
-                    total_tokens=decode_max_seq_len,
-                    num_computed_tokens=decode_max_seq_len,
-                    num_kv_cache_groups=num_kv_cache_groups,
-                    sampling_params=None
-                    if self.is_pooling_model
-                    else SamplingParams(temperature=0.0),
-                    pooling_params=PoolingParams(
-                        task=self.get_supported_pooling_tasks()[0]
+            query_len_range = (
+                range(1, self.num_spec_tokens + 2) if self.num_spec_tokens > 0 else [1]
+            )
+            for query_len in query_len_range:
+                dummy_decode_requests: list[NewRequestData] = []
+                dummy_decode_num_scheduled_tokens: dict[str, int] = {}
+                for _ in range(batch_bucket_size):
+                    self._add_dummy_requests(
+                        requests=dummy_decode_requests,
+                        num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
+                        total_tokens=decode_max_seq_len,
+                        num_computed_tokens=decode_max_seq_len,
+                        num_kv_cache_groups=num_kv_cache_groups,
+                        sampling_params=None
+                        if self.is_pooling_model
+                        else SamplingParams(temperature=0.0),
+                        pooling_params=PoolingParams(
+                            task=self.get_supported_pooling_tasks()[0]
+                        )
+                        if self.is_pooling_model
+                        else None,
                     )
-                    if self.is_pooling_model
-                    else None,
-                )
-            so, cso = self._make_dummy_scheduler_outputs(
-                dummy_decode_requests,
-                dummy_decode_num_scheduled_tokens,
-                num_kv_cache_groups,
-            )
-            current_intermediate_tensors = self.decode_intermediate_tensors.get(
-                batch_bucket_size
-            )
-            assert current_intermediate_tensors is not None
+                for req_id in dummy_decode_num_scheduled_tokens:
+                    dummy_decode_num_scheduled_tokens[req_id] = query_len
 
-            if self.specialized_moe_decode:
-                self._execute_dummy_requests(
-                    so,
-                    cso,
-                    current_intermediate_tensors,
-                    num_padded_tokens=self.max_num_batched_tokens,
+                spec_tokens = (
+                    {req.req_id: [0] * (query_len - 1) for req in dummy_decode_requests}
+                    if query_len > 1
+                    else {}
                 )
+                so, cso = self._make_dummy_scheduler_outputs(
+                    dummy_decode_requests,
+                    dummy_decode_num_scheduled_tokens,
+                    num_kv_cache_groups,
+                    scheduled_spec_decode_tokens=spec_tokens,
+                )
+                current_intermediate_tensors = self.decode_intermediate_tensors.get(
+                    batch_bucket_size
+                )
+                assert current_intermediate_tensors is not None
 
-            self._execute_dummy_requests(so, cso, current_intermediate_tensors)
+                if self.specialized_moe_decode:
+                    self._execute_dummy_requests(
+                        so,
+                        cso,
+                        current_intermediate_tensors,
+                        num_padded_tokens=self.max_num_batched_tokens,
+                    )
+
+                self._execute_dummy_requests(so, cso, current_intermediate_tensors)
 
         # compile sampler for all possible decode batches
         max_decode_batch = self.bucketing_manager.decode_batch_buckets[-1]
@@ -1907,7 +1920,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         requests.append(req)
         num_scheduled_tokens[req.req_id] = (
-            (1 + self.num_spec_tokens)
+            1
             if total_tokens - num_computed_tokens == 0
             else total_tokens - num_computed_tokens
         )
@@ -1917,13 +1930,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         requests: list[NewRequestData],
         num_scheduled_tokens: dict[str, int],
         num_kv_cache_groups: int,
+        scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
     ) -> tuple[SchedulerOutput, SchedulerOutput]:
         sched_output = SchedulerOutput(
             scheduled_new_reqs=requests,
             scheduled_cached_reqs=CachedRequestData.make_empty(),
             num_scheduled_tokens=num_scheduled_tokens,
             total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
-            scheduled_spec_decode_tokens={},
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens or {},
             scheduled_encoder_inputs={},
             num_common_prefix_blocks=[0] * num_kv_cache_groups,
             finished_req_ids=set(),


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

- Scheduler block boundary fix for spec decode
  - Added `spec_decode_cap` in `RBLNScheduler` to ensure no scheduled decode request exceeds the tightest in the batch - both `remaining_in_block` and `remaining_in_maxlen`, preventing runner-side padding from pushing a constrained request beyond its block boundary or max model length
  - Retroactive pass applies the final cap to requests scheduled before it was tightened; uses `undo_uncomputed_block_caching` to invalidate extra allocated blocks without discarding computed KV cache data
- Model runner padding fix for spec decode
  - Changed `max_spec_decode_len` from a fixed `num_speculative_tokens + 1` to the actual maximum scheduled spec token count, preventing shape mismatches when the scheduler trims spec tokens due to block boundary constraints
  - Skips padding entirely when no spec tokens are scheduled in the current step
  - Updated the decode warm-up loop to iterate over all possible query lengths (1 to `num_spec_tokens + 1`) for each batch bucket size, compiling the decode graph for every valid speculative token count
- Attention metadata `seq_idx` fix
  - Fixed incorrect assumption of one token per request; now uses `query_start_loc` to correctly index the first position of each request, fixing wrong `seq_idx` value for req1 and beyond in multi-token-per-request cases (e.g., spec decode with batch > 1)
- Removed `tl.static_assert(QUERY_LEN == 1)` in the triton flash causal attention kernel to allow query lengths greater than 1, as required by spec decode
- Reduced `block_size` in the ngram spec decode example from 2048 to 1024, removing the workaround that was no longer needed after the scheduler fix 

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #398 

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `examples/experimental/run_specdec_ngram_test.py` after setting `max_tokens` to `max_model_len` and `ignore_eos` in sampling parameter.
2. Verify output: generates text sequences without error
3. Edge case tested: None

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- `max_spec_decode_len` may now vary across steps, which can result in **multiple decode graphs being compiled** - one for each distinct token length observed at runtime. ~A warmup refactor to pre-compile all possible cases upfront is intended to address this.~
- This PR is a follow-up to #434

---
