### PR TITLE
feature: sub-block prefix caching

### DIFF
--- a/docs/sub_block_prefix_caching.md
+++ b/docs/sub_block_prefix_caching.md
@@ -49,6 +49,10 @@ so that each prefill does not span multiple blocks.
 │  │  │  per sub-blk) │  │         block_ids        │  │  │
 │  │  └───────────────┘  └──────────────────────────┘  │  │
 │  └───────────────────────────────────────────────────┘  │
+│          ↕ arbitration (connector vs sub-block)         │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │  KV Connector (optional)                          │  │
+│  └───────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────┘
               │  RBLNSchedulerOutput (kv_cache_copy_ops)
               ▼
@@ -66,14 +70,17 @@ so that each prefill does not span multiple blocks.
    * `SubBlockIndex`:
      Maps sub-block hashes to sets of physical block IDs containing the sub-block.
      Supports `insert`, `pop`, and `longest_match`.
-   * `RBLNKVCacheManager`: Extends upstream `KVCacheManager`. Overrides
-     `get_computed_blocks` (adds sub-block matching after full-block matching),
-     `allocate_slots` (schedules copy ops), and
-     `free` (caches partial blocks).
-     The sub-block machinery is hidden in the manager for compatibility with the original interface,
-     except that the scheduler should `drain_pending_copy_ops()` to retrieve
-     the KV cache copy ops accumulated in the current scheduling step.
-     Additionally, the manager provides `can_use_sub_block_caching()` for checking eligibility.
+   * `RBLNKVCacheManager`: Extends upstream `KVCacheManager`.
+        * Overrides
+            * `allocate_slots` indexes newly cached blocks' sub-block hashes.
+            * `free` caches partial blocks.
+            * `reset_prefix_cache` clears sub-block indices.
+        * New methods
+            * `get_computed_blocks_sub_block(request, num_computed_tokens)`
+              discovers sub-block matches and returns a `SubBlockMatch` handle.
+            * `apply_sub_block_match` / `release_sub_block_match` consume or discard the handle.
+            * `drain_pending_copy_ops()` retrieves the KV cache copy ops accumulated in the current scheduling step.
+            * `can_use_sub_block_caching()` checks eligibility.
    * `KVCacheCopyOp`: Dataclass describing a sub-block KV data copy:
      `(group_id, src_block_id, dst_block_id, num_tokens)`.
 * `vllm_rbln.v1.core.rbln_scheduler`
@@ -119,22 +126,21 @@ The last partial block of a request (the one that doesn't fill a full block)
 is indexed during `free()` per group and given a synthetic `block_hash` so
 upstream's LRU preserves it for potential reuse.
 
-### Step 3: Partial-match lookup (get_computed_blocks)
+### Step 3: Partial-match lookup
 
-`get_computed_blocks(request)`
-1.  Call upstream → full-block matches, `num_computed_tokens`
-2.  Compute sub-block hashes for the request
-3.  For each group:
+`get_computed_blocks_sub_block(request, num_computed_tokens)`
+1.  Compute sub-block hashes for the request
+2.  For each group:
     1. Starting after the last full-block boundary,
        query the group's index with up to `sub_blocks_per_block − 1` hashes
     2. Record the match length
-4.  Extension = min match length across all groups
-5.  If match found → record `_PendingPartialMatch`
+3.  Extension = min match length across all groups
+4.  If match found → return a `SubBlockMatch` handle
     (with per-group `_GroupPartialMatch`),
     bump `src_block`s' ref counts to prevent eviction
-6.  Return `num_computed_tokens` + matched sub-block tokens
-    (capped at `request.num_tokens − 1` to preserve the upstream
-    "must recompute last token" invariant)
+5.  Return the sub-block extension in tokens (0 if no match),
+    capped at `request.num_tokens − 1` to preserve the upstream
+    "must recompute last token" invariant.
 
 The query is limited to `sub_blocks_per_block - 1` because a match of all
 sub-blocks would be a full-block match, which upstream handles already. The
@@ -142,16 +148,14 @@ cap at `num_tokens - 1` ensures the scheduler always schedules at least one
 token for computation (upstream requires the last token to be recomputed to
 produce logits).
 
-### Step 4: Copy op scheduling (allocate_slots)
+### Step 4: Copy op scheduling
 
-allocate_slots(request, ...)
-1.  Snapshot per-group cached block counts
-2.  Call upstream → allocates blocks
-3.  Index any newly cached full blocks for each group
-4.  If `_PendingPartialMatch` exists for this request,
-    for each group:
-    1. Look up the destination block (newly allocated at the match boundary)
-    2. Append `KVCacheCopyOp(group_id, src_block_id, dst_block_id, num_tokens)`
+After `allocate_slots` succeeds, the scheduler calls
+`apply_sub_block_match(match, request)` which, for each group:
+1.  Looks up the destination block (newly allocated at the match boundary)
+2.  Appends `KVCacheCopyOp(group_id, src_block_id, dst_block_id, num_tokens)`
+
+(`allocate_slots` itself only indexes any newly cached full blocks.)
 
 ### Step 5: Copy execution (model runner)
 
@@ -176,6 +180,28 @@ kv_cache[:, dst_block_id, :, :, :num_tokens, :] = \
   `SubBlockIndex.pop()` whenever the upstream evicts a cached block.
 - **Reset**: `reset_prefix_cache()` clears all sub-block indices.
 
+## Interaction with KV Connectors
+
+Sub-block prefix caching and KV connectors are conflicting in that
+both attempt to extend the full-block prefix cache hit with additional tokens.
+Ideally, they should cooperate:
+sub-block match first extends the cache hit,
+then the connector extends the match further from there.
+However, sub-block caching is RBLN custom extension,
+so we cannot assume that all KV connectors will work properly
+when the starting position of their match is not full-block-aligned.
+
+**Compromise: mutual-exclusion arbitration.**
+The scheduler picks whichever offers more tokens.
+On ties, sub-block wins because a local memcpy is cheaper than a remote transfer.
+The worst case performance loss due to this compromise is the diff between
+a remote transfer of `block_size - sub_block_size + 1` tokens (current) vs.
+a local memcpy of `block_size - sub_block_size` tokens + a remote transfer of 1 token (ideal).
+
+In the future, we can allow-list KV connectors
+that are verified to be compatible with sub-block caching,
+or patch existing connectors as needed.
+
 ## Limitations
 
 - To simplify `SubBlockIndex` maintenance,
@@ -188,10 +214,3 @@ kv_cache[:, dst_block_id, :, :, :num_tokens, :] = \
       Currently it copies for all layers, so it is not applicable to multi-group setups.
     - **Synchronous.**
       Currently it is blocking.
-- **Incompatible with KV connector.**
-  Currently, the sub-blocks are not exposed outside of the manager,
-  but KV connector works at the block level.
-  To fix this, the sub-blocks should be exposed as the "canonical" blocks to
-  the rest of the system, and `RBLNKVCacheManager` should ensure that
-  consecutive sub-blocks are contiguous in memory.
-  This requires a complete redesign.

--- a/docs/sub_block_prefix_caching.md
+++ b/docs/sub_block_prefix_caching.md
@@ -69,12 +69,13 @@ so that each prefill does not span multiple blocks.
      Uses the same `hash_block_tokens` as upstream.
    * `SubBlockIndex`:
      Maps sub-block hashes to sets of physical block IDs containing the sub-block.
-     Supports `insert`, `pop`, and `longest_match`.
+     Supports `update`, `pop`, and `longest_match`.
    * `RBLNKVCacheManager`: Extends upstream `KVCacheManager`.
         * Overrides
             * `allocate_slots` queues the request for sub-block indexing work
               to be processed by `do_pending_indexing`.
-            * `free` caches partial blocks.
+            * `free` indexes all blocks (full + partial) for the finishing request
+              and assigns a synthetic `block_hash` to the partial block.
             * `reset_prefix_cache` clears sub-block indices and pending indexing.
         * New methods
             * `get_computed_blocks_sub_block(request, num_computed_tokens)`
@@ -84,7 +85,7 @@ so that each prefill does not span multiple blocks.
             * `release_copy_ops()` releases the source-block references after the model runner finishes copying.
             * `do_pending_indexing()` indexes sub-blocks for requests for which
               `allocate_slots` was called in the current scheduling step.
-              Must be called after `execute_model`.
+              Must be called after `super().update_from_output()`.
             * `can_use_sub_block_caching()` checks eligibility.
    * `KVCacheCopyOp`: Dataclass describing a sub-block KV data copy:
      `(group_id, src_block_id, dst_block_id, num_tokens)`.
@@ -93,8 +94,9 @@ so that each prefill does not span multiple blocks.
    * `RBLNScheduler.__init__`: Creates `RBLNKVCacheManager` when prefix caching is
      enabled and `can_use_sub_block_caching()` passes.
    * `RBLNScheduler.schedule`: Returns `RBLNSchedulerOutput`, draining copy ops from the manager.
-   * `RBLNScheduler.update_from_output`:
-     Triggers `do_pending_indexing` and releases source-block refs from copy ops.
+   * `RBLNScheduler.update_from_output`: Calls `super().update_from_output()`
+     (updates `num_computed_tokens`, `free()`s finished requests),
+     then `do_pending_indexing` and releases source-block refs from copy ops.
 * `vllm_rbln.v1.worker.rbln_model_runner`
    * `_process_kv_cache_copy_ops`: Copies KV data between blocks before the forward pass.
 
@@ -129,14 +131,19 @@ This ensures that concurrent prefills in the same scheduling step cannot match
 sub-blocks whose KV data has not yet been computed and thus should not be copied.
 
 During `allocate_slots`, requests are queued for deferred indexing.
-`RBLNScheduler.update_from_output` calls `do_pending_indexing`
-(before `super().update_from_output()`, which may `free()` the requests),
-inserting each newly cached full block's sub-block hashes into the per-group `SubBlockIndex`.
-Each hash at depth *k* maps to the set of physical blocks whose first *k* sub-blocks match.
+`RBLNScheduler.update_from_output` first calls `super().update_from_output()`
+(which updates `num_computed_tokens` and `free()`s finished requests),
+then calls `do_pending_indexing` for the remaining running requests.
 
-The last partial block of a request (the one that doesn't fill a full block)
-is indexed during `free()` per group and given a synthetic `block_hash` so
-upstream's LRU preserves it for potential reuse.
+`free()` consumes its own pending-indexing entry, indexes all blocks
+(full + partial), and assigns a synthetic `block_hash` to the partial block
+so upstream's LRU preserves it for potential reuse.
+
+`do_pending_indexing` processes each remaining running request:
+1. Indexes newly cached full blocks' sub-block hashes into the per-group `SubBlockIndex`.
+   Each hash at depth *k* maps to the set of physical blocks whose first *k* sub-blocks match.
+2. Indexes complete sub-blocks within the request's current partial block,
+   making them visible for matching by new requests.
 
 ### Step 3: Partial-match lookup
 
@@ -183,12 +190,13 @@ kv_cache[:, dst_block_id, :, :, :num_tokens, :] = \
 
 ### Block lifecycle
 
-- **Caching full blocks**: Sub-block indexing is deferred from `allocate_slots`
-  to `do_pending_indexing` (called in `update_from_output`, after `execute_model`
-  but before `free()`).
-- **Caching partial blocks**: Indexed during `free()`. A synthetic
-  `block_hash` is assigned so the block stays in the upstream LRU rather than
-  being immediately reused.
+- **Indexing running requests**:
+  Scheduled by `allocate_slots`, then executed by `do_pending_indexing`
+  (called after `super().update_from_output()`).
+  Indexes both full blocks and complete sub-blocks within partial blocks.
+- **Indexing finished requests**: `free()` consumes the pending-indexing
+  entry, indexes all blocks, and assigns a synthetic `block_hash` to the
+  partial block so the upstream LRU preserves it.
 - **Eviction**: A monkey-patched eviction hook calls
   `SubBlockIndex.pop()` whenever the upstream evicts a cached block.
 - **Reset**: `reset_prefix_cache()` clears all sub-block indices and pending
@@ -218,11 +226,6 @@ or patch existing connectors as needed.
 
 ## Limitations
 
-- To simplify `SubBlockIndex` maintenance,
-  **the last partial block of a running request is not indexed until `free()`.**
-  Eagerly indexing partial blocks of running requests would require
-  updating/replacing index entries on each sub-block boundary.
-  The reduction in cache hit rate caused by this is negligible.
 - KV cache copy implementation (`_copy_kv_cache`) limitations
     - **Per-tensor copy not yet implemented.**
       Currently it copies for all layers, so it is not applicable to multi-group setups.

--- a/docs/sub_block_prefix_caching.md
+++ b/docs/sub_block_prefix_caching.md
@@ -1,0 +1,197 @@
+# Sub-Block Prefix Caching
+
+Upstream vLLM prefix caching works only at the granularity of fully filled blocks.
+However, RBLN uses large KV cache blocks (1k–4k tokens),
+which can cause substantial prefix cache misses in the last, partially filled block.
+
+To address this,
+sub-block prefix caching adds a finer-grained (e.g., 128-token) caching layer
+on top of the upstream `KVCacheManager`.
+It first applies the upstream full-block prefix caching,
+then attempts to *extend* the cache hit at sub-block granularity.
+The matched sub-blocks are copied into a new block,
+since the block containing the partial matches cannot be reused directly.
+
+Sub-block prefix caching is automatically enabled when
+`enable_prefix_caching=True` and `VLLM_RBLN_SUB_BLOCK_CACHE=true` (default)
+and all KV cache groups have an *eligible spec type* with
+`block_size > sub_block_size` and `block_size % sub_block_size == 0`.
+
+A KV cache spec is *eligible* if it stores per-token KV data, i.e.,
+if the KV cache tensor has a token dimension that can be sliced for partial copying.
+* Eligible: `FullAttentionSpec`, `SlidingWindowSpec`, `ChunkedLocalAttentionSpec`
+* Ineligible
+    * `MambaSpec`: It stores one accumulated SSM state per block
+      (the checkpoint after processing `block_size` tokens).
+      This is not per-token data.
+    * `CrossAttentionSpec`: Prefix caching is entirely disabled for this.
+
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `VLLM_RBLN_SUB_BLOCK_CACHE` | `true` | Enable sub-block prefix caching. |
+
+The `sub_block_size` is automatically set to prefill chunk size (`max_num_batched_tokens`)
+so that each prefill does not span multiple blocks.
+
+## Key components
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  RBLNScheduler                                          │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │  RBLNKVCacheManager (extends KVCacheManager)      │  │
+│  │  ┌───────────────┐  ┌──────────────────────────┐  │  │
+│  │  │ SubBlockHasher│  │ Per-group SubBlockIndex  │  │  │
+│  │  │ (chained hash │  │ (hash → containing)      │  │  │
+│  │  │  per sub-blk) │  │         block_ids        │  │  │
+│  │  └───────────────┘  └──────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+              │  RBLNSchedulerOutput (kv_cache_copy_ops)
+              ▼
+┌─────────────────────────────────────────────────────────┐
+│  RBLNModelRunner                                        │
+│  execute_model() processes copy ops (memcpy sub-block   │
+│  KV data between physical blocks) before forward pass   │
+└─────────────────────────────────────────────────────────┘
+```
+
+* `vllm_rbln.v1.core.rbln_kv_cache_manager`
+   * `SubBlockHasher`:
+     Computes chained hashes at sub-block granularity.
+     Uses the same `hash_block_tokens` as upstream.
+   * `SubBlockIndex`:
+     Maps sub-block hashes to sets of physical block IDs containing the sub-block.
+     Supports `insert`, `pop`, and `longest_match`.
+   * `RBLNKVCacheManager`: Extends upstream `KVCacheManager`. Overrides
+     `get_computed_blocks` (adds sub-block matching after full-block matching),
+     `allocate_slots` (schedules copy ops), and
+     `free` (caches partial blocks).
+     The sub-block machinery is hidden in the manager for compatibility with the original interface,
+     except that the scheduler should `drain_pending_copy_ops()` to retrieve
+     the KV cache copy ops accumulated in the current scheduling step.
+     Additionally, the manager provides `can_use_sub_block_caching()` for checking eligibility.
+   * `KVCacheCopyOp`: Dataclass describing a sub-block KV data copy:
+     `(group_id, src_block_id, dst_block_id, num_tokens)`.
+* `vllm_rbln.v1.core.rbln_scheduler`
+   * `RBLNSchedulerOutput`: Extends `SchedulerOutput` with `kv_cache_copy_ops` field.
+   * `RBLNScheduler.__init__`: Creates `RBLNKVCacheManager` when prefix caching is
+     enabled and `can_use_sub_block_caching()` passes.
+   * `RBLNScheduler.schedule`: Returns `RBLNSchedulerOutput`, draining copy ops from the manager.
+* `vllm_rbln.v1.worker.rbln_model_runner`
+   * `_process_kv_cache_copy_ops`: Copies KV data between blocks before the forward pass.
+
+## How it works
+
+### Multi-group support
+
+Sub-block caching supports both single-group (`UnitaryKVCacheCoordinator`) and
+multi-group (`HybridKVCacheCoordinator`) setups. Each KV cache group
+independently maintains its own `SubBlockIndex`.
+
+Since `num_computed_tokens` must agree across all groups,
+sub-block caching either works for all groups or is disabled entirely, and
+the extension of `num_computed_tokens` by the sub-block match is the
+**minimum** match length across all groups.
+
+### Step 1: Sub-block hash computation
+
+`SubBlockHasher` splits a request's token sequence into fixed-size sub-blocks
+and computes a chained hash for each, similarly to upstream's block hashing.
+
+Hashes are computed incrementally and cached per-request in
+`RBLNKVCacheManager._req_sub_hashes`.
+
+Note that we do not exploit upstream's `hash_block_size`,
+because `UnitaryKVCacheCoordinator` asserts `hash_block_size == block_size`.
+
+### Step 2: Index maintenance
+
+When the upstream `allocate_slots` caches a full block (assigns it a
+`block_hash`), `RBLNKVCacheManager` also inserts that block's sub-block hashes
+into the per-group `SubBlockIndex`. Each hash at depth *k* maps to the set of
+physical blocks whose first *k* sub-blocks match.
+
+The last partial block of a request (the one that doesn't fill a full block)
+is indexed during `free()` per group and given a synthetic `block_hash` so
+upstream's LRU preserves it for potential reuse.
+
+### Step 3: Partial-match lookup (get_computed_blocks)
+
+`get_computed_blocks(request)`
+1.  Call upstream → full-block matches, `num_computed_tokens`
+2.  Compute sub-block hashes for the request
+3.  For each group:
+    1. Starting after the last full-block boundary,
+       query the group's index with up to `sub_blocks_per_block − 1` hashes
+    2. Record the match length
+4.  Extension = min match length across all groups
+5.  If match found → record `_PendingPartialMatch`
+    (with per-group `_GroupPartialMatch`),
+    bump `src_block`s' ref counts to prevent eviction
+6.  Return `num_computed_tokens` + matched sub-block tokens
+    (capped at `request.num_tokens − 1` to preserve the upstream
+    "must recompute last token" invariant)
+
+The query is limited to `sub_blocks_per_block - 1` because a match of all
+sub-blocks would be a full-block match, which upstream handles already. The
+cap at `num_tokens - 1` ensures the scheduler always schedules at least one
+token for computation (upstream requires the last token to be recomputed to
+produce logits).
+
+### Step 4: Copy op scheduling (allocate_slots)
+
+allocate_slots(request, ...)
+1.  Snapshot per-group cached block counts
+2.  Call upstream → allocates blocks
+3.  Index any newly cached full blocks for each group
+4.  If `_PendingPartialMatch` exists for this request,
+    for each group:
+    1. Look up the destination block (newly allocated at the match boundary)
+    2. Append `KVCacheCopyOp(group_id, src_block_id, dst_block_id, num_tokens)`
+
+### Step 5: Copy execution (model runner)
+
+The scheduler returns `RBLNSchedulerOutput` containing `kv_cache_copy_ops`.
+Before the forward pass, the model runner copies sub-block KV data:
+
+```python
+# For each copy op targeting a specific group's layers:
+# kv_cache tensor (shape: 2, num_blocks, H, 1, block_size, D):
+kv_cache[:, dst_block_id, :, :, :num_tokens, :] = \
+    kv_cache[:, src_block_id, :, :, :num_tokens, :]
+```
+
+### Block lifecycle
+
+- **Caching full blocks**: Indexed during `allocate_slots` when
+  upstream marks them as cached.
+- **Caching partial blocks**: Indexed during `free()`. A synthetic
+  `block_hash` is assigned so the block stays in the upstream LRU rather than
+  being immediately reused.
+- **Eviction**: A monkey-patched eviction hook calls
+  `SubBlockIndex.pop()` whenever the upstream evicts a cached block.
+- **Reset**: `reset_prefix_cache()` clears all sub-block indices.
+
+## Limitations
+
+- To simplify `SubBlockIndex` maintenance,
+  **the last partial block of a running request is not indexed until `free()`.**
+  Eagerly indexing partial blocks of running requests would require
+  updating/replacing index entries on each sub-block boundary.
+  The reduction in cache hit rate caused by this is negligible.
+- KV cache copy implementation (`_copy_kv_cache`) limitations
+    - **Per-tensor copy not yet implemented.**
+      Currently it copies for all layers, so it is not applicable to multi-group setups.
+    - **Synchronous.**
+      Currently it is blocking.
+- **Incompatible with KV connector.**
+  Currently, the sub-blocks are not exposed outside of the manager,
+  but KV connector works at the block level.
+  To fix this, the sub-blocks should be exposed as the "canonical" blocks to
+  the rest of the system, and `RBLNKVCacheManager` should ensure that
+  consecutive sub-blocks are contiguous in memory.
+  This requires a complete redesign.

--- a/docs/sub_block_prefix_caching.md
+++ b/docs/sub_block_prefix_caching.md
@@ -72,15 +72,19 @@ so that each prefill does not span multiple blocks.
      Supports `insert`, `pop`, and `longest_match`.
    * `RBLNKVCacheManager`: Extends upstream `KVCacheManager`.
         * Overrides
-            * `allocate_slots` indexes newly cached blocks' sub-block hashes.
+            * `allocate_slots` queues the request for sub-block indexing work
+              to be processed by `do_pending_indexing`.
             * `free` caches partial blocks.
-            * `reset_prefix_cache` clears sub-block indices.
+            * `reset_prefix_cache` clears sub-block indices and pending indexing.
         * New methods
             * `get_computed_blocks_sub_block(request, num_computed_tokens)`
               discovers sub-block matches and returns a `SubBlockMatch` handle.
             * `apply_sub_block_match` / `release_sub_block_match` consume or discard the handle.
             * `drain_pending_copy_ops()` retrieves the KV cache copy ops accumulated in the current scheduling step.
             * `release_copy_ops()` releases the source-block references after the model runner finishes copying.
+            * `do_pending_indexing()` indexes sub-blocks for requests for which
+              `allocate_slots` was called in the current scheduling step.
+              Must be called after `execute_model`.
             * `can_use_sub_block_caching()` checks eligibility.
    * `KVCacheCopyOp`: Dataclass describing a sub-block KV data copy:
      `(group_id, src_block_id, dst_block_id, num_tokens)`.
@@ -89,8 +93,8 @@ so that each prefill does not span multiple blocks.
    * `RBLNScheduler.__init__`: Creates `RBLNKVCacheManager` when prefix caching is
      enabled and `can_use_sub_block_caching()` passes.
    * `RBLNScheduler.schedule`: Returns `RBLNSchedulerOutput`, draining copy ops from the manager.
-   * `RBLNScheduler.update_from_output`: Releases source-block refs from copy ops
-     after the model runner finishes (safe for async scheduling / pipeline parallelism).
+   * `RBLNScheduler.update_from_output`:
+     Triggers `do_pending_indexing` and releases source-block refs from copy ops.
 * `vllm_rbln.v1.worker.rbln_model_runner`
    * `_process_kv_cache_copy_ops`: Copies KV data between blocks before the forward pass.
 
@@ -120,10 +124,15 @@ because `UnitaryKVCacheCoordinator` asserts `hash_block_size == block_size`.
 
 ### Step 2: Index maintenance
 
-When the upstream `allocate_slots` caches a full block (assigns it a
-`block_hash`), `RBLNKVCacheManager` also inserts that block's sub-block hashes
-into the per-group `SubBlockIndex`. Each hash at depth *k* maps to the set of
-physical blocks whose first *k* sub-blocks match.
+Sub-block indexing is **deferred** until after the forward pass writes KV data.
+This ensures that concurrent prefills in the same scheduling step cannot match
+sub-blocks whose KV data has not yet been computed and thus should not be copied.
+
+During `allocate_slots`, requests are queued for deferred indexing.
+`RBLNScheduler.update_from_output` calls `do_pending_indexing`
+(before `super().update_from_output()`, which may `free()` the requests),
+inserting each newly cached full block's sub-block hashes into the per-group `SubBlockIndex`.
+Each hash at depth *k* maps to the set of physical blocks whose first *k* sub-blocks match.
 
 The last partial block of a request (the one that doesn't fill a full block)
 is indexed during `free()` per group and given a synthetic `block_hash` so
@@ -158,7 +167,7 @@ After `allocate_slots` succeeds, the scheduler calls
 1.  Looks up the destination block (newly allocated at the match boundary)
 2.  Appends `KVCacheCopyOp(group_id, src_block_id, dst_block_id, num_tokens)`
 
-(`allocate_slots` itself only indexes any newly cached full blocks.)
+(`allocate_slots` itself only queues deferred sub-block indexing.)
 
 ### Step 5: Copy execution (model runner)
 
@@ -174,14 +183,16 @@ kv_cache[:, dst_block_id, :, :, :num_tokens, :] = \
 
 ### Block lifecycle
 
-- **Caching full blocks**: Indexed during `allocate_slots` when
-  upstream marks them as cached.
+- **Caching full blocks**: Sub-block indexing is deferred from `allocate_slots`
+  to `do_pending_indexing` (called in `update_from_output`, after `execute_model`
+  but before `free()`).
 - **Caching partial blocks**: Indexed during `free()`. A synthetic
   `block_hash` is assigned so the block stays in the upstream LRU rather than
   being immediately reused.
 - **Eviction**: A monkey-patched eviction hook calls
   `SubBlockIndex.pop()` whenever the upstream evicts a cached block.
-- **Reset**: `reset_prefix_cache()` clears all sub-block indices.
+- **Reset**: `reset_prefix_cache()` clears all sub-block indices and pending
+  indexing queue.
 
 ## Interaction with KV Connectors
 

--- a/docs/sub_block_prefix_caching.md
+++ b/docs/sub_block_prefix_caching.md
@@ -80,6 +80,7 @@ so that each prefill does not span multiple blocks.
               discovers sub-block matches and returns a `SubBlockMatch` handle.
             * `apply_sub_block_match` / `release_sub_block_match` consume or discard the handle.
             * `drain_pending_copy_ops()` retrieves the KV cache copy ops accumulated in the current scheduling step.
+            * `release_copy_ops()` releases the source-block references after the model runner finishes copying.
             * `can_use_sub_block_caching()` checks eligibility.
    * `KVCacheCopyOp`: Dataclass describing a sub-block KV data copy:
      `(group_id, src_block_id, dst_block_id, num_tokens)`.
@@ -88,6 +89,8 @@ so that each prefill does not span multiple blocks.
    * `RBLNScheduler.__init__`: Creates `RBLNKVCacheManager` when prefix caching is
      enabled and `can_use_sub_block_caching()` passes.
    * `RBLNScheduler.schedule`: Returns `RBLNSchedulerOutput`, draining copy ops from the manager.
+   * `RBLNScheduler.update_from_output`: Releases source-block refs from copy ops
+     after the model runner finishes (safe for async scheduling / pipeline parallelism).
 * `vllm_rbln.v1.worker.rbln_model_runner`
    * `_process_kv_cache_copy_ops`: Copies KV data between blocks before the forward pass.
 

--- a/examples/experimental/prefix_caching.py
+++ b/examples/experimental/prefix_caching.py
@@ -204,11 +204,12 @@ def main():
         model="Qwen/Qwen3-0.6B",
         max_num_seqs=2,
         max_model_len=2048,
-        block_size=256,
         enable_chunked_prefill=True,
         max_num_batched_tokens=128,
         num_gpu_blocks_override=32,
     )
+    # Can't directly pass this value due to validation
+    args.block_size = 1024  # type: ignore
 
     # Create an LLM without prefix caching as a baseline.
     args.enable_prefix_caching = False

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -871,9 +871,9 @@ class TestRBLNKVCacheManager:
         _, _, new_blocks = _prefill_request(manager, req1)
         assert new_blocks is not None
 
-    def test_src_block_protected_until_drain(self):
+    def test_src_block_protected_until_release(self):
         """Source block for a copy op must stay referenced until
-        drain_pending_copy_ops releases it."""
+        release_copy_ops is called (after the model runner copies data)."""
         manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
 
         req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
@@ -889,15 +889,19 @@ class TestRBLNKVCacheManager:
         src_block_id = manager.pending_copy_ops[0].src_block_id
         src_block = manager.block_pool.blocks[src_block_id]
         assert src_block.ref_cnt > 0
+        ref_before_drain = src_block.ref_cnt
 
         # Reset should fail due to pending copy op refs.
         assert not manager.reset_prefix_cache()
         assert len(_sub_block_index(manager)._block_hashes) > 0
 
-        # After drain, source block ref is released.
-        manager.drain_pending_copy_ops()
-        # ref_cnt should have decremented (may still be >0 if other refs exist).
-        assert src_block.ref_cnt >= 0
+        # drain returns ops but does NOT release refs.
+        ops = manager.drain_pending_copy_ops()
+        assert src_block.ref_cnt == ref_before_drain
+
+        # release_copy_ops releases the refs.
+        manager.release_copy_ops(ops)
+        assert src_block.ref_cnt == ref_before_drain - 1
 
     def test_exact_block_size_request_sub_block_recovery(self):
         """When num_tokens == block_size, upstream caps at num_tokens-1 and
@@ -943,6 +947,70 @@ class TestRBLNKVCacheManager:
         assert num_computed == 0  # Full-block path also skipped.
         sub_match = manager.get_computed_blocks_sub_block(req, num_computed)
         assert sub_match is None
+
+    def test_early_release_allows_src_eviction(self):
+        """Demonstrates the async-scheduling race: if copy-op source-block
+        refs are released before the model runner copies data, a subsequent
+        allocation can evict the source block.
+
+        The sequence simulates what happens when schedule(N+1) releases
+        step N's copy-op refs while execute_model(N) hasn't run yet:
+
+        1. Nearly fill memory, create a copy op (src block ref-held)
+        2. drain_pending_copy_ops  (scheduler builds output for step N)
+        3. release_copy_ops        (schedule N+1 starts, releases refs)
+        4. New allocation forces eviction → src block is reclaimed
+        5. The copy op now points to a recycled block — data is lost
+        """
+        # 4 blocks total: req0 uses 1, req1 uses 2 (with sub-block match),
+        # leaving 1 free.  After freeing req1 and releasing the copy-op ref,
+        # req2 needs 3 blocks → must evict the src block.
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=4)
+
+        # req0: fill 1 full block → cached & indexed.
+        req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)  # block cached in LRU + sub-block index
+
+        # req1: partial match on first sub-block → uses 2 blocks, copy op pending.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request(
+            "1", shared + [100 + i for i in range(self.BLOCK_SIZE)], self.BLOCK_SIZE
+        )
+        _prefill_request(manager, req1)
+        assert len(manager.pending_copy_ops) == 1
+
+        src_block_id = manager.pending_copy_ops[0].src_block_id
+        src_block = manager.block_pool.blocks[src_block_id]
+
+        # --- simulate scheduler building output (end of schedule N) ---
+        ops = manager.drain_pending_copy_ops()
+        # Source block still protected (drain doesn't release).
+        assert src_block.ref_cnt > 0
+
+        # --- simulate schedule(N+1) starting: premature release ---
+        manager.release_copy_ops(ops)
+        # Source block ref dropped — now an eviction candidate.
+
+        # Free req1 to make its 2 blocks available, but the cached src
+        # block (from req0) is also free now since we released its ref.
+        manager.free(req1)
+
+        # req2 needs 3 blocks → must evict the former src block.
+        req2 = _make_request(
+            "2", [200 + i for i in range(3 * self.BLOCK_SIZE)], self.BLOCK_SIZE
+        )
+        _prefill_request(manager, req2)
+
+        # The source block has been recycled for req2.
+        # Its block_hash was cleared by eviction, confirming reuse.
+        # In a real system, the model runner would now copy stale data
+        # from ops[0].src_block_id — a correctness bug.
+        assert src_block.ref_cnt > 0  # now held by req2
+        assert src_block.block_hash is not None  # re-cached for req2
+
+        # Verify the copy op still references the recycled block id.
+        assert ops[0].src_block_id == src_block.block_id
 
 
 # ---------------------------------------------------------------------------
@@ -1509,6 +1577,46 @@ class TestRBLNScheduler:
         uncomputed = [blk for blk in req_blocks if blk.block_hash is None]
         for blk in uncomputed:
             assert not index.contains(blk.block_id)
+
+    def test_copy_op_refs_released_in_update_from_output(self):
+        """Source-block refs from copy ops must be released in
+        update_from_output (after execution), not in schedule().
+
+        This is critical for async scheduling where schedule(N+1) runs
+        before execute_model(N) completes."""
+        scheduler = self._create_scheduler(num_blocks=10)
+        mgr = scheduler.kv_cache_manager
+        assert isinstance(mgr, RBLNKVCacheManager)
+
+        # Build a cached block.
+        req0 = _make_request("0", [0] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        out0 = scheduler.schedule()
+        scheduler.update_from_output(out0, create_runner_output(out0, 0))
+
+        # New request with sub-block match → copy op.
+        shared = [0] * self.SUB_BLOCK_SIZE
+        unique = [900 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req1)
+        out1 = scheduler.schedule()
+        assert len(out1.kv_cache_copy_ops) == 1
+
+        src_block_id = out1.kv_cache_copy_ops[0].src_block_id
+        src_block = mgr.block_pool.blocks[src_block_id]
+
+        # Before update_from_output: src block ref still held.
+        assert src_block.ref_cnt > 0
+        ref_before = src_block.ref_cnt
+
+        # Simulate schedule(N+1) starting BEFORE update_from_output(N).
+        # With the fix, schedule() does NOT release the refs.
+        # (Nothing to verify here — the key is that schedule() no longer
+        # touches _unreleased_copy_ops.)
+
+        # Now update_from_output releases the refs.
+        scheduler.update_from_output(out1, create_runner_output(out1, 1))
+        assert src_block.ref_cnt == ref_before - 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -357,7 +357,7 @@ def _prefill_request(manager: RBLNKVCacheManager, request: Request):
         computed_blocks,
     )
     if blocks is not None and sub_block_match is not None:
-        manager.apply_sub_block_match(sub_block_match, request)
+        manager.apply_sub_block_match(sub_block_match)
     elif sub_block_match is not None:
         manager.release_sub_block_match(sub_block_match)
     # Simulate execute_model completion.
@@ -436,7 +436,6 @@ class TestRBLNKVCacheManager:
         )
         assert sub_block_match is not None
         assert sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
-        assert sub_block_match.num_matched_sub_blocks == 1
 
     def test_copy_op_generated_on_partial_match(self):
         """After partial match detection + allocate_slots, a copy op should
@@ -624,7 +623,7 @@ class TestRBLNKVCacheManager:
             )
             # Whether it succeeds or fails, caller releases the match.
             if result is not None:
-                manager.apply_sub_block_match(match, req1)
+                manager.apply_sub_block_match(match)
             else:
                 manager.release_sub_block_match(match)
 
@@ -686,7 +685,6 @@ class TestRBLNKVCacheManager:
         )
         assert sub_block_match is not None
         assert sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
-        assert sub_block_match.num_matched_sub_blocks == 1
 
     def test_no_partial_block_cache_when_block_is_full(self):
         """free() should NOT double-cache a block that is already fully cached."""
@@ -762,7 +760,6 @@ class TestRBLNKVCacheManager:
         assert num_computed == 0
         sub_match = manager.get_computed_blocks_sub_block(req1, num_computed)
         assert sub_match is not None
-        assert sub_match.num_matched_sub_blocks == 2
         assert sub_match.num_tokens == 2 * SBS
         assert num_computed + sub_match.num_tokens <= req1.num_tokens - 1
         manager.release_sub_block_match(sub_match)
@@ -1506,7 +1503,6 @@ class TestMultiGroupRBLNKVCacheManager:
         sub_block_match = manager.get_computed_blocks_sub_block(req1, num_computed)
         assert sub_block_match is not None
         assert sub_block_match.num_tokens == sbs
-        assert sub_block_match.num_matched_sub_blocks == 1
 
     def test_hybrid_partial_block_indexed_on_free(self):
         """In multi-group setup, free() should index partial blocks in both

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -215,7 +215,7 @@ class TestSubBlockIndex:
     def test_insert_and_match(self):
         index = SubBlockIndex()
         hashes = self._make_hashes([[1, 2], [3, 4], [5, 6]])
-        index.insert(10, hashes)
+        index.update(10, hashes)
 
         # Full match.
         block_id, depth = index.longest_match(hashes)
@@ -225,7 +225,7 @@ class TestSubBlockIndex:
     def test_partial_match(self):
         index = SubBlockIndex()
         hashes_src = self._make_hashes([[1, 2], [3, 4], [5, 6]])
-        index.insert(10, hashes_src)
+        index.update(10, hashes_src)
 
         # Query with only the first 2 matching sub-blocks.
         block_id, depth = index.longest_match(hashes_src[:2])
@@ -235,8 +235,8 @@ class TestSubBlockIndex:
     def test_multiple_blocks_same_prefix(self):
         index = SubBlockIndex()
         hashes = self._make_hashes([[1, 2], [3, 4], [5, 6]])
-        index.insert(10, hashes)
-        index.insert(20, hashes)
+        index.update(10, hashes)
+        index.update(20, hashes)
 
         block_id, depth = index.longest_match(hashes)
         assert block_id in (10, 20)
@@ -245,7 +245,7 @@ class TestSubBlockIndex:
     def test_remove_block(self):
         index = SubBlockIndex()
         hashes = self._make_hashes([[1, 2], [3, 4]])
-        index.insert(10, hashes)
+        index.update(10, hashes)
         index.pop(10)
 
         block_id, depth = index.longest_match(hashes)
@@ -255,8 +255,8 @@ class TestSubBlockIndex:
     def test_remove_one_of_two_blocks(self):
         index = SubBlockIndex()
         hashes = self._make_hashes([[1, 2], [3, 4]])
-        index.insert(10, hashes)
-        index.insert(20, hashes)
+        index.update(10, hashes)
+        index.update(20, hashes)
         index.pop(10)
 
         block_id, depth = index.longest_match(hashes)
@@ -270,7 +270,7 @@ class TestSubBlockIndex:
     def test_longest_match_empty_query(self):
         index = SubBlockIndex()
         hashes = self._make_hashes([[1, 2], [3, 4]])
-        index.insert(10, hashes)
+        index.update(10, hashes)
 
         block_id, depth = index.longest_match([])
         assert block_id is None
@@ -629,8 +629,9 @@ class TestRBLNKVCacheManager:
                 manager.release_sub_block_match(match)
 
     def test_partial_block_cached_on_free(self):
-        """free() should index the last partial block's sub-blocks in the index
-        and mark it as cached so its KV data is preserved."""
+        """free() should mark the last partial block as cached with synthetic
+        block_hash so its KV data is preserved in the LRU.
+        Eager indexing already adds sub-block entries before free()."""
         manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
 
         # 1 full block (8 tokens) + 1 sub-block (4 tokens) = 12 tokens total.
@@ -638,21 +639,22 @@ class TestRBLNKVCacheManager:
         req0 = _make_request("0", tokens, self.BLOCK_SIZE)
         _prefill_request(manager, req0)
 
-        # Before free: only the full block (block index 0) is in the index.
+        # After prefill: full block is indexed AND partial block is eagerly
+        # indexed (sub-block entries exist), but not yet marked cached.
         blocks = manager.coordinator.get_blocks(req0.request_id)
         block_list = blocks[0]
         full_blk = block_list[0]
         partial_blk = block_list[1]
         assert full_blk.block_id in _sub_block_index(manager)._block_hashes
-        assert partial_blk.block_id not in _sub_block_index(manager)._block_hashes
-        assert partial_blk.block_hash is None  # Not cached yet.
+        assert partial_blk.block_id in _sub_block_index(manager)._block_hashes
+        assert partial_blk.block_hash is None  # Not cached yet (no synthetic hash).
 
         partial_blk_id = partial_blk.block_id
         manager.free(req0)
 
-        # After free: the partial block should now be in the index.
+        # After free: the partial block should still be in the index
+        # and now have a block_hash (cached in LRU).
         assert partial_blk_id in _sub_block_index(manager)._block_hashes
-        # And it should have a block_hash (cached in LRU).
         assert partial_blk.block_hash is not None
 
     def test_partial_block_reused_by_next_request(self):
@@ -937,6 +939,108 @@ class TestRBLNKVCacheManager:
             blk1 = blocks[0][1]
             if blk1.block_hash is not None:
                 assert _sub_block_index(manager).contains(blk1.block_id)
+
+    def test_eager_partial_block_visible_before_free(self):
+        """A running request's partial block sub-blocks should be visible
+        to new requests for matching before free() is called."""
+        BS, SBS = 8, 4
+        manager = _make_manager(BS, SBS, num_blocks=10)
+
+        # Request 0: 1 full block + 1 sub-block = 12 tokens.
+        tokens0 = list(range(BS + SBS))
+        req0 = _make_request("0", tokens0, BS, max_tokens=BS)
+        _prefill_request(manager, req0)
+
+        # req0 is still running (not freed).  Its partial block's sub-block
+        # should already be indexed eagerly.
+        blocks = manager.coordinator.get_blocks(req0.request_id)
+        partial_blk = blocks[0][1]
+        assert partial_blk.block_id in _sub_block_index(manager)._block_hashes
+        # But not cached (no synthetic hash).
+        assert partial_blk.block_hash is None
+
+        # Request 1: shares the full prefix including the partial sub-block.
+        tokens1 = list(range(BS + SBS)) + [100 + i for i in range(BS)]
+        req1 = _make_request("1", tokens1, BS)
+        _, num_computed = manager.get_computed_blocks(req1)
+        assert num_computed == BS  # Full block match only.
+        sub_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        # Should match the partial sub-block from the running request.
+        assert sub_match is not None
+        assert sub_match.num_tokens == SBS
+        manager.release_sub_block_match(sub_match)
+
+    def test_eager_partial_block_grows_during_decode(self):
+        """As a running request decodes and crosses sub-block boundaries,
+        the eagerly indexed partial block should grow incrementally."""
+        BS, SBS = 8, 4
+        manager = _make_manager(BS, SBS, num_blocks=10)
+
+        # Prompt: 1 full block + 1 token in partial block.
+        prompt = list(range(BS + 1))
+        req = _make_request("0", prompt, BS, max_tokens=2 * BS)
+        _prefill_request(manager, req)
+
+        # After prefill: partial block has 1 token < SBS, so 0 complete
+        # sub-blocks → not in index.
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        partial_blk = blocks[0][1]
+        assert partial_blk.block_id not in _sub_block_index(manager)._block_hashes
+
+        # Decode SBS-1 = 3 more tokens to complete the first sub-block.
+        for i in range(SBS - 1):
+            req.append_output_token_ids(200 + i)
+            num_before = req.num_computed_tokens
+            manager.allocate_slots(req, 1, 0)
+            req.num_computed_tokens = num_before + 1
+        manager.do_pending_indexing()
+
+        # Now partial block has SBS tokens → 1 complete sub-block in index.
+        idx = _sub_block_index(manager)
+        assert idx.contains(partial_blk.block_id)
+        assert len(idx._block_hashes[partial_blk.block_id]) == 1
+
+        # Decode SBS more tokens to complete a second sub-block.
+        for i in range(SBS):
+            req.append_output_token_ids(300 + i)
+            num_before = req.num_computed_tokens
+            manager.allocate_slots(req, 1, 0)
+            req.num_computed_tokens = num_before + 1
+        manager.do_pending_indexing()
+
+        # Now 2 complete sub-blocks.
+        assert len(idx._block_hashes[partial_blk.block_id]) == 2
+
+    def test_partial_to_full_transition_completes_indexing(self):
+        """When a partially indexed block becomes full, _on_block_cached
+        should complete the indexing with update()."""
+        BS, SBS = 8, 4  # 2 sub-blocks per block
+        manager = _make_manager(BS, SBS, num_blocks=10)
+
+        # Prompt: 1 full block + SBS tokens in partial block.
+        prompt = list(range(BS + SBS))
+        req = _make_request("0", prompt, BS, max_tokens=BS)
+        _prefill_request(manager, req)
+
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        partial_blk = blocks[0][1]
+
+        # After prefill: 1 sub-block indexed in the partial block.
+        idx = _sub_block_index(manager)
+        assert idx.contains(partial_blk.block_id)
+        assert len(idx._block_hashes[partial_blk.block_id]) == 1
+
+        # Decode SBS more tokens to fill the block completely.
+        for i in range(SBS):
+            req.append_output_token_ids(400 + i)
+            num_before = req.num_computed_tokens
+            manager.allocate_slots(req, 1, 0)
+            req.num_computed_tokens = num_before + 1
+        manager.do_pending_indexing()
+
+        # The block is now full and should have both sub-blocks indexed.
+        assert partial_blk.block_hash is not None  # Upstream marked it cached.
+        assert len(idx._block_hashes[partial_blk.block_id]) == 2
 
     def test_partial_match_tight_memory_no_assertion(self):
         """With tight block pool, partial match source block must survive
@@ -1406,7 +1510,7 @@ class TestMultiGroupRBLNKVCacheManager:
 
     def test_hybrid_partial_block_indexed_on_free(self):
         """In multi-group setup, free() should index partial blocks in both
-        groups' sub-block indices."""
+        groups' sub-block indices and mark them as cached."""
         manager = _make_hybrid_manager(
             self.BLOCK_SIZE,
             self.SUB_BLOCK_SIZE,
@@ -1419,18 +1523,20 @@ class TestMultiGroupRBLNKVCacheManager:
         req0 = _make_request("0", tokens, self.BLOCK_SIZE)
         _prefill_request(manager, req0)
 
-        # Before free: partial block not in index.
+        # After prefill: partial block is eagerly indexed but not yet cached.
         blocks = manager.coordinator.get_blocks(req0.request_id)
         partial_blk_ids = [
             blocks[gid][1].block_id for gid in range(len(manager._group_infos))
         ]
 
         for i, gi in enumerate(manager._group_infos):
-            assert partial_blk_ids[i] not in gi.sub_block_index._block_hashes
+            assert partial_blk_ids[i] in gi.sub_block_index._block_hashes
+            assert blocks[i][1].block_hash is None  # Not cached yet.
 
         manager.free(req0)
 
-        # After free: partial block should be in both group indices.
+        # After free: partial block should still be in both group indices
+        # and now have a block_hash (cached in LRU).
         for i, gi in enumerate(manager._group_infos):
             assert partial_blk_ids[i] in gi.sub_block_index._block_hashes
 

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -360,7 +360,9 @@ def _prefill_request(manager: RBLNKVCacheManager, request: Request):
         manager.apply_sub_block_match(sub_block_match, request)
     elif sub_block_match is not None:
         manager.release_sub_block_match(sub_block_match)
+    # Simulate execute_model completion.
     request.num_computed_tokens = request.num_tokens
+    manager.do_pending_indexing()
     return computed_blocks, total_computed, blocks
 
 
@@ -898,7 +900,7 @@ class TestRBLNKVCacheManager:
             assert new_hashes != old_hashes
 
     def test_index_newly_cached_blocks_during_decode(self):
-        """_index_newly_cached_blocks should correctly index new blocks
+        """Deferred sub-block indexing should correctly index new blocks
         when a decode step causes a block to become full."""
         BS, SBS = 8, 4
         manager = _make_manager(BS, SBS, num_blocks=10)
@@ -924,6 +926,9 @@ class TestRBLNKVCacheManager:
             result = manager.allocate_slots(req, 1, 0)
             assert result is not None
             req.num_computed_tokens = num_computed_before + 1
+
+        # Finish the current step
+        manager.do_pending_indexing()
 
         # After filling BS-1 decode tokens, the second block should now be full
         # and indexed in the index.
@@ -1139,6 +1144,57 @@ class TestRBLNKVCacheManager:
         assert num_computed == 0
         sub_match = manager.get_computed_blocks_sub_block(req1, num_computed)
         assert sub_match is None
+
+    def test_multi_prefill_no_stale_sub_block_match(self):
+        """When two prefills with overlapping tokens are scheduled in the
+        same step (before execute_model), the second request must NOT get
+        a sub-block match from the first request's blocks because the KV
+        data hasn't been computed yet.
+        In the next step, a third request should get the match.
+        """
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=100)
+
+        # Both requests share the same first sub-block prefix.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req0 = _make_request(
+            "0", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1
+        )
+        req1 = _make_request(
+            "1", shared + [200] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1
+        )
+
+        # --- Simulate scheduling both in the same step (multi-prefill) ---
+
+        # req0: get_computed_blocks → allocate_slots
+        cb0, nc0 = manager.get_computed_blocks(req0)
+        sm0 = manager.get_computed_blocks_sub_block(req0, nc0)
+        assert sm0 is None  # Cold cache.
+        manager.allocate_slots(req0, req0.num_tokens, 0, cb0)
+
+        # req1: scheduled in the same step.
+        # With deferred indexing, req0's sub-blocks are NOT indexed yet.
+        cb1, nc1 = manager.get_computed_blocks(req1)
+        sm1 = manager.get_computed_blocks_sub_block(req1, nc1)
+        assert sm1 is None  # Must NOT match — req0's KV data doesn't exist.
+        manager.allocate_slots(req1, req1.num_tokens, 0, cb1)
+
+        # --- Finish the step ---
+        req0.num_computed_tokens = req0.num_tokens
+        req1.num_computed_tokens = req1.num_tokens
+        manager.do_pending_indexing()
+
+        # After that, the index should be populated.
+        assert len(_sub_block_index(manager)._hash_to_blocks) > 0
+
+        # A third request should now get a sub-block match.
+        req2 = _make_request(
+            "2", shared + [300] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1
+        )
+        _, nc2 = manager.get_computed_blocks(req2)
+        sm2 = manager.get_computed_blocks_sub_block(req2, nc2)
+        assert sm2 is not None
+        assert sm2.num_tokens == self.SUB_BLOCK_SIZE
+        manager.release_sub_block_match(sm2)
 
 
 # ---------------------------------------------------------------------------
@@ -1696,7 +1752,11 @@ class TestRBLNScheduler:
         req = _make_request("req", tokens, BS, max_tokens=1)
         scheduler.add_request(req)
 
-        scheduler.schedule()
+        output = scheduler.schedule()
+
+        # After update_from_output (forward pass done), only block 0 is indexed.
+        runner_out = create_runner_output(output, 0)
+        scheduler.update_from_output(output, runner_out)
 
         req_blocks = mgr.coordinator.get_blocks("req")[0]
 

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -1,0 +1,1501 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for sub-block prefix caching components."""
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
+
+from vllm_rbln.v1.core.rbln_kv_cache_manager import (
+    RBLNKVCacheManager,
+    SubBlockHasher,
+    SubBlockIndex,
+)
+from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
+
+from .utils import create_runner_output, create_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _init_hash():
+    init_none_hash(sha256)
+
+
+# ---------------------------------------------------------------------------
+# SubBlockHasher tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubBlockHasher:
+    def setup_method(self):
+        self.hasher = SubBlockHasher(sha256, sub_block_size=4)
+
+    def test_hash_empty_tokens(self):
+        hashes = self.hasher.hash_tokens([])
+        assert hashes == []
+
+    def test_hash_fewer_than_sub_block(self):
+        hashes = self.hasher.hash_tokens([1, 2, 3])
+        assert hashes == []
+
+    def test_hash_exact_sub_block(self):
+        hashes = self.hasher.hash_tokens([1, 2, 3, 4])
+        assert len(hashes) == 1
+        assert isinstance(hashes[0], bytes)
+
+    def test_hash_multiple_sub_blocks(self):
+        hashes = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        assert len(hashes) == 2
+
+    def test_hash_partial_last_sub_block(self):
+        hashes = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6])
+        assert len(hashes) == 1  # Only the first full sub-block.
+
+    def test_hashes_are_chained(self):
+        # Hashing [1,2,3,4,5,6,7,8] should produce different h1 than
+        # hashing [5,6,7,8] alone (because the parent hash differs).
+        hashes_full = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes_second_only = self.hasher.hash_tokens([5, 6, 7, 8])
+        assert hashes_full[1] != hashes_second_only[0]
+
+    def test_incremental_hashing(self):
+        # Hash in one go.
+        hashes_all = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+
+        # Hash in two steps.
+        # Step 1: first sub-block only (only 4 tokens available).
+        h1 = self.hasher.hash_tokens(
+            [1, 2, 3, 4],
+            parent_hash=None,
+            num_hashed_tokens=0,
+        )
+        # Step 2: all 8 tokens available, start from offset 4.
+        h2 = self.hasher.hash_tokens(
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            parent_hash=h1[0],
+            num_hashed_tokens=4,
+        )
+        assert h1 + h2 == hashes_all
+
+    def test_deterministic(self):
+        tokens = list(range(100, 112))
+        h1 = self.hasher.hash_tokens(tokens)
+        h2 = self.hasher.hash_tokens(tokens)
+        assert h1 == h2
+
+    def test_different_tokens_different_hashes(self):
+        h1 = self.hasher.hash_tokens([1, 2, 3, 4])
+        h2 = self.hasher.hash_tokens([5, 6, 7, 8])
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# SubBlockIndex tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubBlockIndex:
+    def _make_hashes(self, tokens_per_sub_block: list[list[int]]) -> list[BlockHash]:
+        """Helper: compute chained sub-block hashes for a sequence of
+        sub-block token lists."""
+        hasher = SubBlockHasher(sha256, sub_block_size=len(tokens_per_sub_block[0]))
+        flat = [t for sub in tokens_per_sub_block for t in sub]
+        return hasher.hash_tokens(flat)
+
+    def test_empty_no_match(self):
+        index = SubBlockIndex()
+        hashes = self._make_hashes([[1, 2], [3, 4]])
+        block_id, depth = index.longest_match(hashes)
+        assert block_id is None
+        assert depth == 0
+
+    def test_insert_and_match(self):
+        index = SubBlockIndex()
+        hashes = self._make_hashes([[1, 2], [3, 4], [5, 6]])
+        index.insert(10, hashes)
+
+        # Full match.
+        block_id, depth = index.longest_match(hashes)
+        assert block_id == 10
+        assert depth == 3
+
+    def test_partial_match(self):
+        index = SubBlockIndex()
+        hashes_src = self._make_hashes([[1, 2], [3, 4], [5, 6]])
+        index.insert(10, hashes_src)
+
+        # Query with only the first 2 matching sub-blocks.
+        block_id, depth = index.longest_match(hashes_src[:2])
+        assert block_id == 10
+        assert depth == 2
+
+    def test_multiple_blocks_same_prefix(self):
+        index = SubBlockIndex()
+        hashes = self._make_hashes([[1, 2], [3, 4], [5, 6]])
+        index.insert(10, hashes)
+        index.insert(20, hashes)
+
+        block_id, depth = index.longest_match(hashes)
+        assert block_id in (10, 20)
+        assert depth == 3
+
+    def test_remove_block(self):
+        index = SubBlockIndex()
+        hashes = self._make_hashes([[1, 2], [3, 4]])
+        index.insert(10, hashes)
+        index.pop(10)
+
+        block_id, depth = index.longest_match(hashes)
+        assert block_id is None
+        assert depth == 0
+
+    def test_remove_one_of_two_blocks(self):
+        index = SubBlockIndex()
+        hashes = self._make_hashes([[1, 2], [3, 4]])
+        index.insert(10, hashes)
+        index.insert(20, hashes)
+        index.pop(10)
+
+        block_id, depth = index.longest_match(hashes)
+        assert block_id == 20
+        assert depth == 2
+
+    def test_remove_nonexistent_block(self):
+        index = SubBlockIndex()
+        index.pop(999)  # Should not raise.
+
+    def test_longest_match_empty_query(self):
+        index = SubBlockIndex()
+        hashes = self._make_hashes([[1, 2], [3, 4]])
+        index.insert(10, hashes)
+
+        block_id, depth = index.longest_match([])
+        assert block_id is None
+        assert depth == 0
+
+
+def _make_kv_cache_config(block_size: int, num_blocks: int) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            )
+        ],
+    )
+
+
+def _make_request(
+    request_id: str,
+    prompt_token_ids: list[int],
+    block_size: int,
+    max_tokens: int = 17,
+) -> Request:
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=prompt_token_ids,
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=max_tokens),
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(block_size, sha256),
+    )
+
+
+def _make_manager(
+    block_size: int,
+    sub_block_size: int,
+    num_blocks: int,
+    max_model_len: int = 8192,
+) -> RBLNKVCacheManager:
+    manager = RBLNKVCacheManager(
+        kv_cache_config=_make_kv_cache_config(block_size, num_blocks),
+        max_model_len=max_model_len,
+        hash_block_size=block_size,
+        sub_block_size=sub_block_size,
+        hash_fn=sha256,
+    )
+    return manager
+
+
+def _sub_block_index(manager: RBLNKVCacheManager) -> SubBlockIndex:
+    """Get the sub-block index for the single group (test helper)."""
+    return manager._group_infos[0].sub_block_index
+
+
+def _prefill_request(manager: RBLNKVCacheManager, request: Request):
+    """Run the full get_computed_blocks → allocate_slots flow for a
+    request (simulating what the scheduler does)."""
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(request)
+    num_new_computed = num_computed_tokens
+    num_new_tokens = request.num_tokens - num_computed_tokens
+    blocks = manager.allocate_slots(
+        request,
+        num_new_tokens,
+        num_new_computed,
+        computed_blocks,
+    )
+    request.num_computed_tokens = request.num_tokens
+    return computed_blocks, num_computed_tokens, blocks
+
+
+class TestRBLNKVCacheManager:
+    """Tests for the full get_computed_blocks → allocate_slots flow with
+    sub-block partial matching."""
+
+    # Use block_size=8, sub_block_size=4 for easy arithmetic.
+    BLOCK_SIZE = 8
+    SUB_BLOCK_SIZE = 4
+
+    def test_no_partial_match_on_first_request(self):
+        """First request should have no cache hits at all."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # 2 full blocks + 5 extra tokens
+        tokens = list(range(2 * self.BLOCK_SIZE + 5))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+
+        computed_blocks_before, num_computed_tokens_before, new_blocks = (
+            _prefill_request(manager, req)
+        )
+        assert num_computed_tokens_before == 0
+        assert not computed_blocks_before.blocks[0]
+        assert new_blocks is not None
+
+        # No copy ops should be generated.
+        ops = manager.drain_pending_copy_ops()
+        assert ops == []
+
+    def test_full_block_hit_indexes_sub_blocks(self):
+        """After a request fills full blocks, those blocks' sub-hashes should
+        appear in the index."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # 2 full blocks (16 tokens)
+        tokens = list(range(2 * self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+
+        # The index should now contain entries for the 2 full blocks.
+        assert len(_sub_block_index(manager)._block_hashes) == 2
+
+    def test_partial_match_detected(self):
+        """Second request sharing a sub-block prefix should get a partial
+        match and extra computed tokens."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Request 0: 1 full block (8 tokens) — will be cached.
+        tokens_full = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens_full, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request 1: shares first sub-block (4 tokens) with req0, then diverges.
+        # The first 4 tokens match the first sub-block of req0's block.
+        # But it has more tokens so no full-block match by upstream.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        unique = [100 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE)
+
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+        # Upstream should find 0 full block hits (different full-block hash).
+        assert len(computed_blocks.blocks[0]) == 0
+        # But sub-block matching should give us extra tokens.
+        assert num_computed_tokens == self.SUB_BLOCK_SIZE  # 4 tokens from partial match
+        # Pending partial should be set.
+        assert manager._pending_partial is not None
+        assert manager._pending_partial.num_matched_sub_blocks == 1
+
+    def test_copy_op_generated_on_partial_match(self):
+        """After partial match detection + allocate_slots, a copy op should
+        be queued."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Fill a full block.
+        tokens_full = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens_full, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # New request shares first sub-block only.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        unique = [100 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE)
+
+        _, _, new_blocks = _prefill_request(manager, req1)
+        assert new_blocks is not None
+
+        ops = manager.drain_pending_copy_ops()
+        assert len(ops) == 1
+        op = ops[0]
+        assert op.num_tokens == self.SUB_BLOCK_SIZE
+        # The source block should be the one from req0.
+        # The destination should be the first block allocated for req1.
+        assert op.dst_block_id != op.src_block_id
+
+    def test_no_partial_match_when_full_block_matches(self):
+        """If the upstream already matches the full block, no partial match
+        should be attempted (no double counting)."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Request 0: 2 full blocks.
+        tokens = list(range(2 * self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request 1: exact same 2 full blocks + a few extra.
+        req1 = _make_request("1", tokens + [99, 99, 99], self.BLOCK_SIZE)
+        _, num_computed_tokens = manager.get_computed_blocks(req1)
+
+        # All tokens in the 2 full blocks should be computed via upstream.
+        assert num_computed_tokens == 2 * self.BLOCK_SIZE
+        # No partial match (all full blocks matched by upstream).
+        assert manager._pending_partial is None
+
+    def test_partial_match_after_full_block_match(self):
+        """Partial match should work on the block boundary after full-block
+        matches."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Request 0: 2 full blocks.
+        tokens_2blocks = list(range(2 * self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens_2blocks, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request 1: same 2 full blocks + partial match into 3rd block.
+        # First sub-block of the 3rd block in req0 was tokens [16..19].
+        # We create a request that has 2 full blocks matching + first sub-block
+        # matching (from a different cached block).
+        #
+        # Actually, for this we need a 3rd cached block. Let's cache 3 blocks.
+        tokens_3blocks = list(range(3 * self.BLOCK_SIZE))
+        req0b = _make_request("0b", tokens_3blocks, self.BLOCK_SIZE)
+        _prefill_request(manager, req0b)
+        manager.free(req0b)
+
+        # Request 2: shares all 3 blocks' first sub-block in the 3rd block
+        # position, plus extra tokens that differ.
+        # The first 2 blocks match fully. The 3rd block's first sub-block [16..19]
+        # should match partially.
+        extra = [999] * (self.SUB_BLOCK_SIZE + 3)  # enough for partial + leftover
+        req2_tokens = (
+            tokens_3blocks[: 2 * self.BLOCK_SIZE + self.SUB_BLOCK_SIZE] + extra
+        )
+        req2 = _make_request("2", req2_tokens, self.BLOCK_SIZE)
+
+        _, num_computed_tokens = manager.get_computed_blocks(req2)
+        # 2 full blocks = 16 tokens from upstream + 4 tokens from partial match.
+        assert num_computed_tokens == 2 * self.BLOCK_SIZE + self.SUB_BLOCK_SIZE
+        assert manager._pending_partial is not None
+
+    def test_free_cleans_up_sub_hash_cache(self):
+        """free() should remove the request's sub-hash cache entry."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+        assert "0" in manager._req_sub_hashes
+        manager.free(req)
+        assert "0" not in manager._req_sub_hashes
+
+    def test_reset_prefix_cache_clears_index(self):
+        """reset_prefix_cache() should clear the sub-block index."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+        manager.free(req)
+        assert len(_sub_block_index(manager)._block_hashes) > 0
+
+        manager.reset_prefix_cache()
+        assert len(_sub_block_index(manager)._block_hashes) == 0
+
+    def test_eviction_removes_from_index(self):
+        """When blocks are evicted (due to pressure), they should be removed
+        from the sub-block index."""
+        # Only 3 blocks available (tight).
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=3)
+
+        # Fill 1 block.
+        req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+        assert len(_sub_block_index(manager)._block_hashes) == 1
+
+        # Fill all remaining blocks, forcing eviction of req0's block.
+        big_tokens = [100 + i for i in range(3 * self.BLOCK_SIZE)]
+        req1 = _make_request("1", big_tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req1)
+
+        # The original block from req0 should have been evicted from the index.
+        # req1 uses 3 blocks, so with only 3 total blocks, req0's freed block
+        # must have been reused.
+        # After allocating 3 blocks for req1, the index should contain
+        # entries only for req1's full blocks (at most 2 since 3rd may be partial).
+        for block_id in _sub_block_index(manager)._block_hashes:
+            # All remaining blocks in index should be from req1.
+            blk = manager.block_pool.blocks[block_id]
+            assert blk.ref_cnt > 0 or blk.block_hash is not None
+
+    def test_drain_pending_copy_ops(self):
+        """drain_pending_copy_ops should return ops and clear the list."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Set up a partial match to get a copy op.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        _prefill_request(manager, req1)
+        assert len(manager.pending_copy_ops) == 1
+
+        ops = manager.drain_pending_copy_ops()
+        assert len(ops) == 1
+        assert manager.pending_copy_ops == []
+
+    def test_pending_partial_released_on_failed_alloc(self):
+        """If allocate_slots fails (returns None), pending partial should be
+        released."""
+        # Only 1 block — not enough for a request that needs more.
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=2)
+
+        # Fill the one block first.
+        req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request needing 2+ blocks but we only have 2 total, and 1 is in use
+        # by the cache. Create a request that triggers a partial match, then
+        # force allocation failure by requesting too many blocks.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        # Need lots of tokens to require many blocks.
+        big = shared + [200 + i for i in range(3 * self.BLOCK_SIZE)]
+        req1 = _make_request("1", big, self.BLOCK_SIZE)
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+        if manager._pending_partial is not None:
+            # allocate_slots will likely fail due to insufficient blocks.
+            manager.allocate_slots(
+                req1,
+                len(big) - num_computed_tokens,
+                num_computed_tokens,
+                computed_blocks,
+            )
+            # Whether it succeeds or fails, pending_partial should be cleared.
+            assert manager._pending_partial is None
+
+    def test_partial_block_cached_on_free(self):
+        """free() should index the last partial block's sub-blocks in the index
+        and mark it as cached so its KV data is preserved."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # 1 full block (8 tokens) + 1 sub-block (4 tokens) = 12 tokens total.
+        tokens = list(range(self.BLOCK_SIZE + self.SUB_BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+
+        # Before free: only the full block (block index 0) is in the index.
+        blocks = manager.coordinator.get_blocks(req0.request_id)
+        block_list = blocks[0]
+        full_blk = block_list[0]
+        partial_blk = block_list[1]
+        assert full_blk.block_id in _sub_block_index(manager)._block_hashes
+        assert partial_blk.block_id not in _sub_block_index(manager)._block_hashes
+        assert partial_blk.block_hash is None  # Not cached yet.
+
+        partial_blk_id = partial_blk.block_id
+        manager.free(req0)
+
+        # After free: the partial block should now be in the index.
+        assert partial_blk_id in _sub_block_index(manager)._block_hashes
+        # And it should have a block_hash (cached in LRU).
+        assert partial_blk.block_hash is not None
+
+    def test_partial_block_reused_by_next_request(self):
+        """After freeing a request with a partial block, a new request
+        sharing that partial prefix should get a sub-block cache hit."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Request 0: 1 full block + 1 sub-block (partial block).
+        # Tokens: [0..7] (full block) + [8..11] (partial sub-block)
+        tokens0 = list(range(self.BLOCK_SIZE + self.SUB_BLOCK_SIZE))
+        req0 = _make_request("0", tokens0, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request 1: shares same prefix through the partial sub-block, then
+        # diverges.  Sub-block hashes are chained, so req1 must share the
+        # full prefix to get a hash match.
+        shared = list(range(self.BLOCK_SIZE + self.SUB_BLOCK_SIZE))
+        unique = [800 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE)
+
+        _, num_computed_tokens = manager.get_computed_blocks(req1)
+
+        # Upstream matches the first full block (8 tokens).  The sub-block
+        # index then matches 1 sub-block (4 tokens) from the partial block.
+        assert num_computed_tokens == self.BLOCK_SIZE + self.SUB_BLOCK_SIZE
+        assert manager._pending_partial is not None
+        assert manager._pending_partial.num_matched_sub_blocks == 1
+
+    def test_no_partial_block_cache_when_block_is_full(self):
+        """free() should NOT double-cache a block that is already fully cached."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Exactly 1 full block — no partial block.
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        block_list = blocks[0]
+        assert len(block_list) == 1
+        blk = block_list[0]
+        assert blk.block_hash is not None  # Already cached by upstream.
+
+        index_entries_before = set(_sub_block_index(manager)._block_hashes.keys())
+        manager.free(req)
+        index_entries_after = set(_sub_block_index(manager)._block_hashes.keys())
+
+        # Index should not have gained new entries from free().
+        assert index_entries_before == index_entries_after
+
+    def test_computed_tokens_capped_at_num_tokens_minus_one(self):
+        """Sub-block match must not push num_computed_tokens past
+        request.num_tokens - 1 (upstream invariant: recompute last token)."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Request 0: 1 full block (8 tokens).
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request 1: shares full block with req0, then only has 2 extra tokens.
+        # Upstream matches 1 full block (8 tokens).  Sub-block index would try
+        # to match sub-blocks in the second block.  But num_tokens = 10,
+        # cap = 9, upstream already gives 8, so at most 1 extra token from
+        # sub-blocks — which doesn't reach sub_block_size (4).  No match.
+        req1 = _make_request("1", tokens + [77, 78], self.BLOCK_SIZE)
+        _, num_computed = manager.get_computed_blocks(req1)
+        assert num_computed <= req1.num_tokens - 1
+
+        # Request 2: shares full block, then has exactly SUB_BLOCK_SIZE extra
+        # tokens.  num_tokens = 12, cap = 11.  Upstream gives 8.  Sub-block
+        # match gives 4 → 12 total.  Cap should reduce to 8 (no sub-block
+        # match since 11 - 8 = 3 < 4).
+        req2_tokens = tokens + list(
+            range(self.BLOCK_SIZE, self.BLOCK_SIZE + self.SUB_BLOCK_SIZE)
+        )
+        req2 = _make_request("2", req2_tokens, self.BLOCK_SIZE)
+        _, num_computed = manager.get_computed_blocks(req2)
+        assert num_computed <= req2.num_tokens - 1
+
+    def test_capping_sub_block_match_at_num_tokens_minus_one(self):
+        """Sub-block match must not push total computed tokens past
+        num_tokens - 1.  When it would, the match is truncated or
+        returns None."""
+        BS, SBS = 16, 4  # sbpb = 4
+        manager = _make_manager(BS, SBS, num_blocks=10)
+
+        # Cache a partial block with 3 sub-blocks (12 tokens).
+        tokens = list(range(3 * SBS))
+        req0 = _make_request("0", tokens, BS)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Case 1: match reduced from 3 to 2 sub-blocks.
+        # num_tokens = 12, max_total = 11, num_computed = 0.
+        # Raw match = 3 sub-blocks (12) > 11 → capped = 11 // 4 = 2.
+        req1 = _make_request("1", tokens, BS)
+        _, num_computed = manager.get_computed_blocks(req1)
+        assert num_computed == 0
+        sub_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_match is not None
+        assert sub_match.num_matched_sub_blocks == 2
+        assert sub_match.num_tokens == 2 * SBS
+        assert num_computed + sub_match.num_tokens <= req1.num_tokens - 1
+        manager.release_sub_block_match(sub_match)
+
+        # Case 2: capped to zero → None.
+        # num_tokens = 4, max_total = 3, num_computed = 0.
+        # Raw match = 1 sub-block (4) > 3 → capped = 3 // 4 = 0 → None.
+        short = tokens[:SBS]
+        req2 = _make_request("2", short, BS)
+        _, num_computed = manager.get_computed_blocks(req2)
+        assert num_computed == 0
+        assert manager.get_computed_blocks_sub_block(req2, num_computed) is None
+
+    def test_partial_block_fewer_tokens_than_sub_block(self):
+        """If the partial block has fewer tokens than a sub-block,
+        _cache_partial_block should be a no-op."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # 1 full block (8 tokens) + 2 extra tokens (< sub_block_size=4).
+        tokens = list(range(self.BLOCK_SIZE + 2))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        partial_blk = blocks[0][1]
+        partial_blk_id = partial_blk.block_id
+        assert partial_blk.block_hash is None
+
+        manager.free(req)
+
+        # Partial block should NOT be cached (too few tokens for a sub-block).
+        assert partial_blk_id not in _sub_block_index(manager)._block_hashes
+        assert partial_blk.block_hash is None
+
+    def test_partial_block_multiple_sub_blocks(self):
+        """A partial block with multiple sub-blocks should all be indexed."""
+        BS, SBS = 16, 4  # Bigger block for this test.
+        manager = _make_manager(BS, SBS, num_blocks=10)
+
+        # 1 full block (16 tokens) + 3 sub-blocks (12 tokens) in partial block.
+        tokens = list(range(BS + 3 * SBS))
+        req = _make_request("0", tokens, BS)
+        _prefill_request(manager, req)
+
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        partial_blk = blocks[0][1]
+        partial_blk_id = partial_blk.block_id
+        manager.free(req)
+
+        # Partial block should be indexed with 3 sub-block hashes.
+        assert partial_blk_id in _sub_block_index(manager)._block_hashes
+        assert len(_sub_block_index(manager)._block_hashes[partial_blk_id]) == 3
+
+        # A new request sharing the full prefix should match all 3 sub-blocks.
+        unique_tail = [999] * BS
+        req1 = _make_request("1", tokens + unique_tail, BS)
+        _, num_computed = manager.get_computed_blocks(req1)
+        # Full block (16) + 3 sub-blocks (12) = 28.
+        assert num_computed == BS + 3 * SBS
+
+    def test_stale_pending_partial_discarded(self):
+        """If get_computed_blocks sets _pending_partial for req A but
+        allocate_slots is called for req B, the stale state is discarded."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Trigger partial match for req1.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        manager.get_computed_blocks(req1)
+        assert manager._pending_partial is not None
+        assert manager._pending_partial.request_id == "1"
+
+        # Now allocate_slots for a DIFFERENT request (req2).
+        req2 = _make_request("2", [200] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        manager.get_computed_blocks(req2)
+        manager.allocate_slots(req2, req2.num_tokens, 0)
+
+        # Stale pending from req1 should have been discarded.
+        assert manager._pending_partial is None
+        # No copy ops should be generated for the stale partial.
+        assert manager.drain_pending_copy_ops() == []
+
+    def test_partial_block_evicted_under_pressure(self):
+        """A cached partial block should be evictable under memory pressure."""
+        # 5 blocks total: 1 null + 4 usable. req0 uses 2 blocks (1 full +
+        # 1 partial). After free, 2 cached + 2 free. req1 needs all 4
+        # usable blocks, forcing eviction of both cached blocks.
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=5)
+
+        # Fill a full block + partial block.
+        tokens = list(range(self.BLOCK_SIZE + self.SUB_BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        partial_blk_id = manager.coordinator.get_blocks(req0.request_id)[0][1].block_id
+        manager.free(req0)
+
+        # Partial block should be in index now.
+        assert partial_blk_id in _sub_block_index(manager)._block_hashes
+        old_hashes = list(_sub_block_index(manager)._block_hashes[partial_blk_id])
+
+        # Allocate all 4 usable blocks, forcing eviction.
+        big_tokens = [500 + i for i in range(4 * self.BLOCK_SIZE)]
+        req1 = _make_request("1", big_tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req1)
+
+        # The partial block's physical slot was reused by req1. The old
+        # sub-block hashes should have been evicted (via the eviction hook).
+        # The block_id may still be in the index if req1 reused the same
+        # physical block, but the hashes must be different.
+        if partial_blk_id in _sub_block_index(manager)._block_hashes:
+            new_hashes = _sub_block_index(manager)._block_hashes[partial_blk_id]
+            assert new_hashes != old_hashes
+
+    def test_ref_cnt_released_when_allocate_skipped(self):
+        """If get_computed_blocks sets _pending_partial but allocate_slots is
+        never called (simulating a scheduler continue/break), the next
+        get_computed_blocks call must release the source block ref_cnt."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Cache a full block.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Trigger partial match for req1.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        manager.get_computed_blocks(req1)
+        assert manager._pending_partial is not None
+        gm = manager._pending_partial.group_matches[0]
+        src_block = gm.src_block
+        ref_cnt_after_match = src_block.ref_cnt
+
+        # Simulate scheduler skipping allocate_slots (e.g. budget exhausted).
+        # Call get_computed_blocks for another request — this should release
+        # the old pending partial's ref_cnt.
+        req2 = _make_request("2", [200] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        manager.get_computed_blocks(req2)
+
+        assert manager._pending_partial is None
+        assert src_block.ref_cnt == ref_cnt_after_match - 1
+
+    def test_ref_cnt_released_when_get_computed_blocks_finds_no_match(self):
+        """If get_computed_blocks is called twice in a row (first finds a
+        match, second doesn't), the first partial's ref_cnt is released."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Cache a full block.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Trigger partial match.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        manager.get_computed_blocks(req1)
+        assert manager._pending_partial is not None
+        gm = manager._pending_partial.group_matches[0]
+        src_block = gm.src_block
+        ref_before = src_block.ref_cnt
+
+        # Call get_computed_blocks again for same request without allocate_slots.
+        # This simulates the scheduler re-evaluating the request.
+        manager.get_computed_blocks(req1)
+
+        # ref_cnt should have been decremented from the first pending partial
+        # and then re-incremented for the new one (net zero change if match
+        # found again, or -1 if no match found).
+        # Since the first get_computed_blocks released the old pending, and
+        # the second may or may not find a match, just verify no leak.
+        if manager._pending_partial is not None:
+            assert src_block.ref_cnt == ref_before
+        else:
+            assert src_block.ref_cnt == ref_before - 1
+
+    def test_index_newly_cached_blocks_during_decode(self):
+        """_index_newly_cached_blocks should correctly index new blocks
+        when a decode step causes a block to become full."""
+        BS, SBS = 8, 4
+        manager = _make_manager(BS, SBS, num_blocks=10)
+
+        # Start with a prompt that fills 1 full block + 1 partial token.
+        # block_size=8, so 9 tokens = 1 full block + 1 token in partial block.
+        prompt = list(range(BS + 1))
+        req = _make_request("0", prompt, BS, max_tokens=BS)
+        _prefill_request(manager, req)
+
+        # After prefill: block 0 should be in index (full block, cached).
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        blk0 = blocks[0][0]
+        assert _sub_block_index(manager).contains(blk0.block_id)
+
+        # Simulate decode steps that fill the second block.
+        # Each decode adds 1 token. We need 7 more tokens to fill the second
+        # block (currently has 1 token).
+        for i in range(BS - 1):
+            req.append_output_token_ids(200 + i)
+            num_computed_before = req.num_computed_tokens
+            # allocate_slots with 1 new token, 0 new computed tokens.
+            result = manager.allocate_slots(req, 1, 0)
+            assert result is not None
+            req.num_computed_tokens = num_computed_before + 1
+
+        # After filling BS-1 decode tokens, the second block should now be full
+        # and indexed in the index.
+        blocks = manager.coordinator.get_blocks(req.request_id)
+        if len(blocks[0]) > 1:
+            blk1 = blocks[0][1]
+            if blk1.block_hash is not None:
+                assert _sub_block_index(manager).contains(blk1.block_id)
+
+    def test_partial_match_tight_memory_no_assertion(self):
+        """With tight block pool, partial match source block must survive
+        allocation without hitting ref_cnt assertion."""
+        # 4 blocks total (1 null + 3 usable). req0 uses 1, caches it on free.
+        # req1 shares 1 sub-block and needs 2 blocks → must evict cached block.
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=4)
+
+        req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        rest = [100 + i for i in range(self.BLOCK_SIZE + self.SUB_BLOCK_SIZE)]
+        req1 = _make_request("1", shared + rest, self.BLOCK_SIZE)
+
+        # Must not crash with AssertionError on ref_cnt.
+        _, _, new_blocks = _prefill_request(manager, req1)
+        assert new_blocks is not None
+
+    def test_src_block_protected_until_drain(self):
+        """Source block for a copy op must stay referenced until
+        drain_pending_copy_ops releases it."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        _prefill_request(manager, req1)
+
+        # Copy op should exist; source block should still have ref_cnt > 0.
+        assert len(manager.pending_copy_ops) == 1
+        src_block_id = manager.pending_copy_ops[0].src_block_id
+        src_block = manager.block_pool.blocks[src_block_id]
+        assert src_block.ref_cnt > 0
+
+        # Reset should fail due to pending copy op refs.
+        assert not manager.reset_prefix_cache()
+        assert len(_sub_block_index(manager)._block_hashes) > 0
+
+        # After drain, source block ref is released.
+        manager.drain_pending_copy_ops()
+        # ref_cnt should have decremented (may still be >0 if other refs exist).
+        assert src_block.ref_cnt >= 0
+
+    def test_exact_block_size_request_sub_block_recovery(self):
+        """When num_tokens == block_size, upstream caps at num_tokens-1 and
+        matches 0 full blocks.  Sub-block matching should recover partial
+        tokens from the cached block."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        req1 = _make_request("1", tokens, self.BLOCK_SIZE)
+        _, num_computed = manager.get_computed_blocks(req1)
+
+        # Upstream matches 0 full blocks (num_tokens-1=7 < block_size=8).
+        # Sub-block matching recovers 1 sub-block (4 tokens), capped so
+        # that num_computed <= num_tokens - 1 = 7.
+        assert num_computed <= req1.num_tokens - 1
+        assert num_computed == self.SUB_BLOCK_SIZE  # 4 tokens from sub-block match
+        assert manager._pending_partial is not None
+
+
+# ---------------------------------------------------------------------------
+# Multi-group (hybrid) tests
+# ---------------------------------------------------------------------------
+
+
+def _make_hybrid_kv_cache_config(
+    block_size: int, num_blocks: int, sliding_window: int
+) -> KVCacheConfig:
+    """Create a 2-group config: full attention + sliding window."""
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_attn_layer"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["sw_layer"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=sliding_window,
+                ),
+            ),
+        ],
+    )
+
+
+def _make_hybrid_manager(
+    block_size: int,
+    sub_block_size: int,
+    num_blocks: int,
+    sliding_window: int,
+    max_model_len: int = 8192,
+) -> RBLNKVCacheManager:
+    """hash_block_size = block_size (same block_size for all groups)."""
+    return RBLNKVCacheManager(
+        kv_cache_config=_make_hybrid_kv_cache_config(
+            block_size, num_blocks, sliding_window
+        ),
+        max_model_len=max_model_len,
+        hash_block_size=block_size,
+        sub_block_size=sub_block_size,
+        hash_fn=sha256,
+    )
+
+
+class TestMultiGroupRBLNKVCacheManager:
+    """Tests for multi-group (hybrid) sub-block prefix caching."""
+
+    BLOCK_SIZE = 8
+    SUB_BLOCK_SIZE = 4
+    SLIDING_WINDOW = 16
+
+    def test_hybrid_full_block_hit_indexes_both_groups(self):
+        """After filling full blocks, both group indices should have entries."""
+        manager = _make_hybrid_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=20,
+            sliding_window=self.SLIDING_WINDOW,
+        )
+        tokens = list(range(2 * self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+
+        # Both groups should have indexed blocks.
+        idx0 = manager._group_infos[0].sub_block_index
+        idx1 = manager._group_infos[1].sub_block_index
+        assert len(idx0._block_hashes) > 0
+        assert len(idx1._block_hashes) > 0
+
+    def test_hybrid_partial_match_generates_copy_ops_per_group(self):
+        """Partial match in hybrid mode should generate copy ops for each group."""
+        manager = _make_hybrid_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=20,
+            sliding_window=self.SLIDING_WINDOW,
+        )
+
+        # First request: fill 1 full block.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Second request: shares first sub-block, different rest.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1_tokens = shared + [100] * (self.BLOCK_SIZE + 1)
+        req1 = _make_request("1", req1_tokens, self.BLOCK_SIZE)
+        _, num_computed, new_blocks = _prefill_request(manager, req1)
+
+        assert num_computed == self.SUB_BLOCK_SIZE
+        assert new_blocks is not None
+
+        ops = manager.drain_pending_copy_ops()
+        # Should have one copy op per group.
+        assert len(ops) == 2
+        for op in ops:
+            assert op.num_tokens == self.SUB_BLOCK_SIZE
+
+    def test_hybrid_reset_clears_all_indices(self):
+        """reset_prefix_cache should clear all per-group sub-block indices."""
+        manager = _make_hybrid_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=20,
+            sliding_window=self.SLIDING_WINDOW,
+        )
+        tokens = list(range(2 * self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        assert any(
+            len(gi.sub_block_index._block_hashes) > 0 for gi in manager._group_infos
+        )
+
+        manager.reset_prefix_cache()
+
+        for gi in manager._group_infos:
+            assert len(gi.sub_block_index._block_hashes) == 0
+
+    def test_hybrid_different_block_sizes_partial_match(self):
+        """When groups have different block sizes, sub-block matching should
+        use the minimum match across groups."""
+        # Group 0 (full attn): block_size=16, sub_blocks_per_block=4
+        # Group 1 (sliding window): block_size=8, sub_blocks_per_block=2
+        # hash_block_size=8 (must divide both)
+        full_bs = 16
+        sw_bs = 8
+        sbs = 4
+        hash_bs = 8  # GCD works as hash_block_size
+        sliding_window = 32
+        config = KVCacheConfig(
+            num_blocks=30,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full_attn_layer"],
+                    FullAttentionSpec(
+                        block_size=full_bs,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["sw_layer"],
+                    SlidingWindowSpec(
+                        block_size=sw_bs,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                        sliding_window=sliding_window,
+                    ),
+                ),
+            ],
+        )
+        manager = RBLNKVCacheManager(
+            kv_cache_config=config,
+            max_model_len=8192,
+            hash_block_size=hash_bs,
+            sub_block_size=sbs,
+            hash_fn=sha256,
+        )
+        assert manager._group_infos[0].sub_blocks_per_block == 4  # 16/4
+        assert manager._group_infos[1].sub_blocks_per_block == 2  # 8/4
+
+        # LCM of 16 and 8 is 16. Upstream aligns to LCM.
+        # Cache a request with exactly 16 tokens (1 full block for group 0,
+        # 2 full blocks for group 1).
+        tokens = list(range(full_bs))
+        req0 = _make_request("0", tokens, hash_bs)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Both groups should have indexed blocks.
+        assert len(manager._group_infos[0].sub_block_index._block_hashes) > 0
+        assert len(manager._group_infos[1].sub_block_index._block_hashes) > 0
+
+        # New request: shares first sub-block (4 tokens), then diverges.
+        # Group 0: next block boundary at 0 (no full blocks matched),
+        #   query up to 3 sub-blocks (sbpb-1=3).
+        # Group 1: next block boundary at 0,
+        #   query up to 1 sub-block (sbpb-1=1).
+        # min_matched should be capped by the group with fewer sub-blocks.
+        shared = list(range(sbs))
+        unique = [100 + i for i in range(full_bs)]
+        req1 = _make_request("1", shared + unique, hash_bs)
+        _, num_computed = manager.get_computed_blocks(req1)
+
+        # Should get 1 sub-block match (min across groups).
+        assert num_computed == sbs
+        assert manager._pending_partial is not None
+        assert manager._pending_partial.num_matched_sub_blocks == 1
+
+    def test_hybrid_partial_block_indexed_on_free(self):
+        """In multi-group setup, free() should index partial blocks in both
+        groups' sub-block indices."""
+        manager = _make_hybrid_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=20,
+            sliding_window=self.SLIDING_WINDOW,
+        )
+
+        # 1 full block + 1 sub-block (partial).
+        tokens = list(range(self.BLOCK_SIZE + self.SUB_BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+
+        # Before free: partial block not in index.
+        blocks = manager.coordinator.get_blocks(req0.request_id)
+        partial_blk_ids = [
+            blocks[gid][1].block_id for gid in range(len(manager._group_infos))
+        ]
+
+        for i, gi in enumerate(manager._group_infos):
+            assert partial_blk_ids[i] not in gi.sub_block_index._block_hashes
+
+        manager.free(req0)
+
+        # After free: partial block should be in both group indices.
+        for i, gi in enumerate(manager._group_infos):
+            assert partial_blk_ids[i] in gi.sub_block_index._block_hashes
+
+    def test_hybrid_capping_at_num_tokens_minus_one(self):
+        """In multi-group, sub-block match must still be capped at
+        request.num_tokens - 1."""
+        manager = _make_hybrid_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=20,
+            sliding_window=self.SLIDING_WINDOW,
+        )
+
+        # Cache a full block.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Request with exact same tokens (num_tokens=8, cap=7).
+        # Upstream matches 0 full blocks (7 < 8).
+        # Sub-block match: 1 sub-block (4 tokens), capped at 4 <= 7. OK.
+        req1 = _make_request("1", tokens, self.BLOCK_SIZE)
+        _, num_computed = manager.get_computed_blocks(req1)
+        assert num_computed <= req1.num_tokens - 1
+        assert num_computed == self.SUB_BLOCK_SIZE
+
+    def test_eligibility(self):
+        """Test the eligibility check with various configs."""
+        # Single group, eligible.
+        config1 = _make_kv_cache_config(block_size=8, num_blocks=10)
+        assert RBLNKVCacheManager.can_use_sub_block_caching(config1, 4)
+
+        # Single group, block_size == sub_block_size.
+        assert not RBLNKVCacheManager.can_use_sub_block_caching(config1, 8)
+
+        # Single group, not divisible.
+        assert not RBLNKVCacheManager.can_use_sub_block_caching(config1, 3)
+
+        # sub_block_size <= 0.
+        assert not RBLNKVCacheManager.can_use_sub_block_caching(config1, 0)
+        assert not RBLNKVCacheManager.can_use_sub_block_caching(config1, -1)
+
+        # Hybrid, both eligible.
+        config2 = _make_hybrid_kv_cache_config(
+            block_size=8, num_blocks=20, sliding_window=16
+        )
+        assert RBLNKVCacheManager.can_use_sub_block_caching(config2, 4)
+
+        # Ineligible spec type: MambaSpec stores recurrent state per block,
+        # not per-token KV, so sub-block partial copy is meaningless.
+        mamba_config = KVCacheConfig(
+            num_blocks=20,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["mamba_layer"],
+                    MambaSpec(
+                        block_size=8,
+                        shapes=((64,),),
+                        dtypes=(torch.float32,),
+                    ),
+                ),
+            ],
+        )
+        assert not RBLNKVCacheManager.can_use_sub_block_caching(mamba_config, 4)
+
+        # Hybrid with Mamba: full_attn + mamba — ineligible because of Mamba.
+        hybrid_mamba_config = KVCacheConfig(
+            num_blocks=20,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full_attn_layer"],
+                    FullAttentionSpec(
+                        block_size=8,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["mamba_layer"],
+                    MambaSpec(
+                        block_size=8,
+                        shapes=((64,),),
+                        dtypes=(torch.float32,),
+                    ),
+                ),
+            ],
+        )
+        assert not RBLNKVCacheManager.can_use_sub_block_caching(hybrid_mamba_config, 4)
+
+
+# ---------------------------------------------------------------------------
+# RBLNScheduler integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRBLNScheduler:
+    """Tests for the RBLNScheduler with sub-block prefix caching through the
+    full schedule → update_from_output flow."""
+
+    BLOCK_SIZE = 16
+    SUB_BLOCK_SIZE = 4
+
+    def _create_scheduler(
+        self, num_blocks=100, max_model_len=None, max_num_batched_tokens=None
+    ):
+        if max_model_len is None:
+            max_model_len = self.BLOCK_SIZE * num_blocks
+        if max_num_batched_tokens is None:
+            max_num_batched_tokens = max_model_len
+        return create_scheduler(
+            block_size=self.BLOCK_SIZE,
+            num_blocks=num_blocks,
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
+            enable_prefix_caching=True,
+            sub_block_size=self.SUB_BLOCK_SIZE,
+        )
+
+    def test_scheduler_uses_rbln_kv_cache_manager(self):
+        """When prefix caching is enabled and block_size > sub_block_size,
+        the scheduler should use RBLNKVCacheManager."""
+        scheduler = self._create_scheduler()
+        assert isinstance(scheduler.kv_cache_manager, RBLNKVCacheManager)
+
+    def test_schedule_returns_rbln_scheduler_output(self):
+        """schedule() should return an RBLNSchedulerOutput."""
+        scheduler = self._create_scheduler()
+        req = _make_request("0", [0] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req)
+        output = scheduler.schedule()
+        assert isinstance(output, RBLNSchedulerOutput)
+        assert hasattr(output, "kv_cache_copy_ops")
+
+    def test_no_copy_ops_on_first_request(self):
+        """The first request should have no copy ops (cold cache)."""
+        scheduler = self._create_scheduler()
+        req = _make_request(
+            "0", [0] * self.BLOCK_SIZE * 2, self.BLOCK_SIZE, max_tokens=1
+        )
+        scheduler.add_request(req)
+        output = scheduler.schedule()
+        assert isinstance(output, RBLNSchedulerOutput)
+        assert output.kv_cache_copy_ops == []
+
+    def test_no_copy_ops_on_full_block_match(self):
+        """Requests sharing full blocks should not generate copy ops
+        (handled by upstream prefix caching)."""
+        scheduler = self._create_scheduler()
+
+        # Both requests share 2 full blocks of zeros. req1 has an extra block
+        # of unique tokens so that max_cache_hit_length (num_tokens - 1)
+        # allows upstream to match both shared full blocks.
+        shared = [0] * (self.BLOCK_SIZE * 2)
+        req0 = _make_request("0", shared, self.BLOCK_SIZE, max_tokens=1)
+        # req1 extends shared prefix with unique tokens (no sub-block overlap).
+        unique_tail = [7000 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique_tail, self.BLOCK_SIZE, max_tokens=1)
+
+        # Schedule + finish request 0.
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Schedule request 1 — upstream matches 2 full blocks, unique tail
+        # doesn't match any cached sub-blocks → no copy ops.
+        scheduler.add_request(req1)
+        output1 = scheduler.schedule()
+        assert isinstance(output1, RBLNSchedulerOutput)
+        assert output1.kv_cache_copy_ops == []
+
+    def test_partial_match_generates_copy_ops(self):
+        """A request sharing only a sub-block prefix with a cached block
+        should trigger a copy op."""
+        scheduler = self._create_scheduler()
+
+        # Request 0: exactly 1 full block of zeros.
+        req0 = _make_request("0", [0] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Request 1: first sub-block matches (4 zeros), rest diverges.
+        # The full block hash differs (because the remaining 12 tokens differ),
+        # so upstream won't match. But the sub-block index should.
+        shared = [0] * self.SUB_BLOCK_SIZE
+        unique = [900 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req1)
+        output1 = scheduler.schedule()
+        assert isinstance(output1, RBLNSchedulerOutput)
+        assert len(output1.kv_cache_copy_ops) == 1
+
+        op = output1.kv_cache_copy_ops[0]
+        assert op.num_tokens == self.SUB_BLOCK_SIZE
+        assert op.src_block_id != op.dst_block_id
+
+    def test_partial_block_reused_after_free(self):
+        """After a request with a partial block is freed, the next request
+        sharing that prefix should get a sub-block hit from the cached
+        partial block."""
+        scheduler = self._create_scheduler()
+
+        # Request 0: 1 full block + 1 sub-block (partial).
+        prompt0 = [0] * (self.BLOCK_SIZE + self.SUB_BLOCK_SIZE)
+        req0 = _make_request("0", prompt0, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Request 1: shares same prefix + extra unique tokens.
+        prompt1 = prompt0 + [900 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", prompt1, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req1)
+        output1 = scheduler.schedule()
+        assert isinstance(output1, RBLNSchedulerOutput)
+
+        # Should get a copy op from the cached partial block.
+        assert len(output1.kv_cache_copy_ops) == 1
+        op = output1.kv_cache_copy_ops[0]
+        assert op.num_tokens == self.SUB_BLOCK_SIZE
+
+    def test_scheduler_no_sub_block_when_equal_sizes(self):
+        """When sub_block_size == block_size, sub-block caching should NOT
+        activate (sub-block matching is meaningless)."""
+        scheduler = create_scheduler(
+            block_size=self.BLOCK_SIZE,
+            num_blocks=100,
+            max_num_batched_tokens=self.BLOCK_SIZE * 10,
+            max_model_len=self.BLOCK_SIZE * 10,
+            enable_prefix_caching=True,
+            sub_block_size=self.BLOCK_SIZE,
+        )
+        assert not isinstance(scheduler.kv_cache_manager, RBLNKVCacheManager)
+
+    def test_multi_turn_conversation(self):
+        """Multi-turn chat: turn 2's prefix includes turn 1's entire
+        prompt + generated output.  The partial block cached when turn 1
+        finishes should produce a sub-block hit for turn 2."""
+        BS = self.BLOCK_SIZE  # 16
+        SBS = self.SUB_BLOCK_SIZE  # 4
+
+        scheduler = self._create_scheduler(num_blocks=100)
+        mgr = scheduler.kv_cache_manager
+        assert isinstance(mgr, RBLNKVCacheManager)
+
+        # --- Turn 1 ---
+        # Prompt: 1 full block + 1 sub-block = 20 tokens.
+        # After generating 1 + BS tokens:
+        #   block 0  [0..15]                    full (prompt)
+        #   block 1  [16..19, 1000..1011]       full (prompt tail + decode)
+        #   block 2  [1012..1015]               partial (1 sub-block)
+        prompt_1 = list(range(BS + SBS))
+        num_gen = 1 + BS  # 1 from prefill, BS from decode, adding BS tokens in KV cache
+        req1 = _make_request("turn1", prompt_1, BS, max_tokens=num_gen)
+        scheduler.add_request(req1)
+
+        generated_tokens = []
+        for step in range(num_gen):
+            output = scheduler.schedule()
+            tok = 1000 + step
+            generated_tokens.append(tok)
+            runner_out = create_runner_output(output, tok)
+            scheduler.update_from_output(output, runner_out)
+
+        # Request finished (max_tokens reached) → freed → partial block cached.
+        assert "turn1" not in scheduler.requests
+
+        # --- Turn 2 ---
+        # Prompt = turn 1's full content + new user message.
+        # Upstream matches 2 full blocks (32 tokens).
+        # Sub-block index matches the cached partial block (4 tokens).
+        new_user_msg = [2000 + i for i in range(BS)]
+        turn2_prompt = prompt_1 + generated_tokens + new_user_msg
+        req2 = _make_request("turn2", turn2_prompt, BS, max_tokens=1)
+        scheduler.add_request(req2)
+
+        output2 = scheduler.schedule()
+        assert isinstance(output2, RBLNSchedulerOutput)
+
+        # Sub-block copy op from the cached partial block.
+        assert len(output2.kv_cache_copy_ops) == 1
+        assert output2.kv_cache_copy_ops[0].num_tokens == SBS
+
+        # Verify prefill savings: fewer tokens scheduled than full prompt.
+        num_computed = 2 * BS + SBS  # 2 full blocks + 1 sub-block
+        expected_scheduled = req2.num_tokens - num_computed
+        assert output2.num_scheduled_tokens["turn2"] == expected_scheduled
+
+    def test_speculative_alloc_undo_cleans_sub_block_index(self):
+        """Speculative allocate_slots + undo_uncomputed_block_caching must not
+        leave stale sub-block index entries for blocks that were never computed.
+        """
+        BS = self.BLOCK_SIZE  # 16
+        SBS = self.SUB_BLOCK_SIZE  # 4
+
+        scheduler = self._create_scheduler(num_blocks=100, max_num_batched_tokens=BS)
+        mgr = scheduler.kv_cache_manager
+        assert isinstance(mgr, RBLNKVCacheManager)
+        index = mgr._group_infos[0].sub_block_index
+
+        # 3 full blocks + 1 partial block.
+        # The scheduler pre-allocates blocks for ALL tokens but only computes
+        # one chunk (BS tokens) per iteration.
+        # After undo_uncomputed_block_caching:
+        #   block 0: computed and indexed
+        #   blocks 1-2: full but uncomputed and unindexed
+        #   block 3: partial, never got indexed
+        tokens = list(range(3 * BS + SBS))
+        req = _make_request("req", tokens, BS, max_tokens=1)
+        scheduler.add_request(req)
+
+        scheduler.schedule()
+
+        req_blocks = mgr.coordinator.get_blocks("req")[0]
+
+        # Only four sub-blocks from block 0
+        assert len(index._hash_to_blocks) == 4
+        uncomputed = [blk for blk in req_blocks if blk.block_hash is None]
+        for blk in uncomputed:
+            assert not index.contains(blk.block_id)

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -39,7 +39,7 @@ from vllm_rbln.v1.core.rbln_kv_cache_manager import (
 )
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
 
-from .utils import create_runner_output, create_scheduler
+from .utils import MockKVConfig, create_runner_output, create_scheduler
 
 
 @pytest.fixture(autouse=True)
@@ -223,12 +223,16 @@ def _make_request(
     prompt_token_ids: list[int],
     block_size: int,
     max_tokens: int = 17,
+    prompt_logprobs: int | None = None,
 ) -> Request:
     return Request(
         request_id=request_id,
         prompt_token_ids=prompt_token_ids,
         mm_features=None,
-        sampling_params=SamplingParams(max_tokens=max_tokens),
+        sampling_params=SamplingParams(
+            max_tokens=max_tokens,
+            prompt_logprobs=prompt_logprobs,
+        ),
         pooling_params=None,
         block_hasher=get_request_block_hasher(block_size, sha256),
     )
@@ -259,16 +263,24 @@ def _prefill_request(manager: RBLNKVCacheManager, request: Request):
     """Run the full get_computed_blocks → allocate_slots flow for a
     request (simulating what the scheduler does)."""
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(request)
-    num_new_computed = num_computed_tokens
-    num_new_tokens = request.num_tokens - num_computed_tokens
+    sub_block_match = manager.get_computed_blocks_sub_block(
+        request, num_computed_tokens
+    )
+    sub_block_extra = sub_block_match.num_tokens if sub_block_match else 0
+    total_computed = num_computed_tokens + sub_block_extra
+    num_new_tokens = request.num_tokens - total_computed
     blocks = manager.allocate_slots(
         request,
         num_new_tokens,
-        num_new_computed,
+        total_computed,
         computed_blocks,
     )
+    if blocks is not None and sub_block_match is not None:
+        manager.apply_sub_block_match(sub_block_match, request)
+    elif sub_block_match is not None:
+        manager.release_sub_block_match(sub_block_match)
     request.num_computed_tokens = request.num_tokens
-    return computed_blocks, num_computed_tokens, blocks
+    return computed_blocks, total_computed, blocks
 
 
 class TestRBLNKVCacheManager:
@@ -333,11 +345,15 @@ class TestRBLNKVCacheManager:
 
         # Upstream should find 0 full block hits (different full-block hash).
         assert len(computed_blocks.blocks[0]) == 0
-        # But sub-block matching should give us extra tokens.
-        assert num_computed_tokens == self.SUB_BLOCK_SIZE  # 4 tokens from partial match
-        # Pending partial should be set.
-        assert manager._pending_partial is not None
-        assert manager._pending_partial.num_matched_sub_blocks == 1
+        # get_computed_blocks returns only full-block count (0 here).
+        assert num_computed_tokens == 0
+        # Sub-block match is available separately.
+        sub_block_match = manager.get_computed_blocks_sub_block(
+            req1, num_computed_tokens
+        )
+        assert sub_block_match is not None
+        assert sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
+        assert sub_block_match.num_matched_sub_blocks == 1
 
     def test_copy_op_generated_on_partial_match(self):
         """After partial match detection + allocate_slots, a copy op should
@@ -384,7 +400,10 @@ class TestRBLNKVCacheManager:
         # All tokens in the 2 full blocks should be computed via upstream.
         assert num_computed_tokens == 2 * self.BLOCK_SIZE
         # No partial match (all full blocks matched by upstream).
-        assert manager._pending_partial is None
+        sub_block_match = manager.get_computed_blocks_sub_block(
+            req1, num_computed_tokens
+        )
+        assert sub_block_match is None
 
     def test_partial_match_after_full_block_match(self):
         """Partial match should work on the block boundary after full-block
@@ -419,9 +438,14 @@ class TestRBLNKVCacheManager:
         req2 = _make_request("2", req2_tokens, self.BLOCK_SIZE)
 
         _, num_computed_tokens = manager.get_computed_blocks(req2)
-        # 2 full blocks = 16 tokens from upstream + 4 tokens from partial match.
-        assert num_computed_tokens == 2 * self.BLOCK_SIZE + self.SUB_BLOCK_SIZE
-        assert manager._pending_partial is not None
+        # 2 full blocks = 16 tokens from upstream.
+        assert num_computed_tokens == 2 * self.BLOCK_SIZE
+        # Sub-block match adds 4 tokens separately.
+        sub_block_match = manager.get_computed_blocks_sub_block(
+            req2, num_computed_tokens
+        )
+        assert sub_block_match is not None
+        assert sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
 
     def test_free_cleans_up_sub_hash_cache(self):
         """free() should remove the request's sub-hash cache entry."""
@@ -492,36 +516,34 @@ class TestRBLNKVCacheManager:
         assert len(ops) == 1
         assert manager.pending_copy_ops == []
 
-    def test_pending_partial_released_on_failed_alloc(self):
-        """If allocate_slots fails (returns None), pending partial should be
-        released."""
-        # Only 1 block — not enough for a request that needs more.
+    def test_sub_block_match_released_on_failed_alloc(self):
+        """If allocate_slots fails, the caller must release the match."""
         manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=2)
 
-        # Fill the one block first.
         req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
         _prefill_request(manager, req0)
         manager.free(req0)
 
-        # Request needing 2+ blocks but we only have 2 total, and 1 is in use
-        # by the cache. Create a request that triggers a partial match, then
-        # force allocation failure by requesting too many blocks.
         shared = list(range(self.SUB_BLOCK_SIZE))
-        # Need lots of tokens to require many blocks.
         big = shared + [200 + i for i in range(3 * self.BLOCK_SIZE)]
         req1 = _make_request("1", big, self.BLOCK_SIZE)
         computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+        match = manager.get_computed_blocks_sub_block(req1, num_computed_tokens)
 
-        if manager._pending_partial is not None:
-            # allocate_slots will likely fail due to insufficient blocks.
-            manager.allocate_slots(
+        if match is not None:
+            sub_extra = match.num_tokens
+            total_computed = num_computed_tokens + sub_extra
+            result = manager.allocate_slots(
                 req1,
-                len(big) - num_computed_tokens,
-                num_computed_tokens,
+                len(big) - total_computed,
+                total_computed,
                 computed_blocks,
             )
-            # Whether it succeeds or fails, pending_partial should be cleared.
-            assert manager._pending_partial is None
+            # Whether it succeeds or fails, caller releases the match.
+            if result is not None:
+                manager.apply_sub_block_match(match, req1)
+            else:
+                manager.release_sub_block_match(match)
 
     def test_partial_block_cached_on_free(self):
         """free() should index the last partial block's sub-blocks in the index
@@ -573,9 +595,13 @@ class TestRBLNKVCacheManager:
 
         # Upstream matches the first full block (8 tokens).  The sub-block
         # index then matches 1 sub-block (4 tokens) from the partial block.
-        assert num_computed_tokens == self.BLOCK_SIZE + self.SUB_BLOCK_SIZE
-        assert manager._pending_partial is not None
-        assert manager._pending_partial.num_matched_sub_blocks == 1
+        assert num_computed_tokens == self.BLOCK_SIZE
+        sub_block_match = manager.get_computed_blocks_sub_block(
+            req1, num_computed_tokens
+        )
+        assert sub_block_match is not None
+        assert sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
+        assert sub_block_match.num_matched_sub_blocks == 1
 
     def test_no_partial_block_cache_when_block_is_full(self):
         """free() should NOT double-cache a block that is already fully cached."""
@@ -709,41 +735,61 @@ class TestRBLNKVCacheManager:
         unique_tail = [999] * BS
         req1 = _make_request("1", tokens + unique_tail, BS)
         _, num_computed = manager.get_computed_blocks(req1)
-        # Full block (16) + 3 sub-blocks (12) = 28.
-        assert num_computed == BS + 3 * SBS
+        # Full block (16) from upstream.
+        assert num_computed == BS
+        # 3 sub-blocks (12) from sub-block match.
+        sub_block_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_block_match is not None
+        assert sub_block_match.num_tokens == 3 * SBS
 
-    def test_stale_pending_partial_discarded(self):
-        """If get_computed_blocks sets _pending_partial for req A but
-        allocate_slots is called for req B, the stale state is discarded."""
+    def test_ref_cnt_released_by_release_sub_block_match(self):
+        """release_sub_block_match should release source block ref_cnt."""
         manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
-
         tokens = list(range(self.BLOCK_SIZE))
         req0 = _make_request("0", tokens, self.BLOCK_SIZE)
         _prefill_request(manager, req0)
         manager.free(req0)
 
-        # Trigger partial match for req1.
         shared = list(range(self.SUB_BLOCK_SIZE))
         req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        _, num_computed = manager.get_computed_blocks(req1)
+        match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert match is not None
+        src_block = match.group_matches[0].src_block
+        ref_cnt_after_match = src_block.ref_cnt
+
+        # Release the match — should decrement ref_cnt.
+        manager.release_sub_block_match(match)
+        assert src_block.ref_cnt == ref_cnt_after_match - 1
+
+    def test_ref_cnt_managed_by_caller(self):
+        """Caller manages match lifecycle — ref_cnt is properly maintained."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
+        _, num_computed = manager.get_computed_blocks(req1)
+        match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert match is not None
+        src_block = match.group_matches[0].src_block
+        ref_before = src_block.ref_cnt
+
+        # Calling get_computed_blocks again does NOT release the match
+        # (caller owns it). Ref_cnt unchanged.
         manager.get_computed_blocks(req1)
-        assert manager._pending_partial is not None
-        assert manager._pending_partial.request_id == "1"
+        assert src_block.ref_cnt == ref_before
 
-        # Now allocate_slots for a DIFFERENT request (req2).
-        req2 = _make_request("2", [200] * self.BLOCK_SIZE, self.BLOCK_SIZE)
-        manager.get_computed_blocks(req2)
-        manager.allocate_slots(req2, req2.num_tokens, 0)
-
-        # Stale pending from req1 should have been discarded.
-        assert manager._pending_partial is None
-        # No copy ops should be generated for the stale partial.
-        assert manager.drain_pending_copy_ops() == []
-
-    def test_partial_block_evicted_under_pressure(self):
-        """A cached partial block should be evictable under memory pressure."""
-        # 5 blocks total: 1 null + 4 usable. req0 uses 2 blocks (1 full +
-        # 1 partial). After free, 2 cached + 2 free. req1 needs all 4
-        # usable blocks, forcing eviction of both cached blocks.
+        # Explicit release decrements.
+        manager.release_sub_block_match(match)
+        assert src_block.ref_cnt == ref_before - 1
+        # A cached partial block should be evictable under memory pressure.
+        # 5 blocks total: 1 null + 4 usable. req0 uses 2 blocks (1 full + 1 partial).
+        # After free, 2 cached + 2 free. req1 needs all 4 usable blocks,
+        # forcing eviction of both cached blocks.
         manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=5)
 
         # Fill a full block + partial block.
@@ -769,70 +815,6 @@ class TestRBLNKVCacheManager:
         if partial_blk_id in _sub_block_index(manager)._block_hashes:
             new_hashes = _sub_block_index(manager)._block_hashes[partial_blk_id]
             assert new_hashes != old_hashes
-
-    def test_ref_cnt_released_when_allocate_skipped(self):
-        """If get_computed_blocks sets _pending_partial but allocate_slots is
-        never called (simulating a scheduler continue/break), the next
-        get_computed_blocks call must release the source block ref_cnt."""
-        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
-
-        # Cache a full block.
-        tokens = list(range(self.BLOCK_SIZE))
-        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
-        _prefill_request(manager, req0)
-        manager.free(req0)
-
-        # Trigger partial match for req1.
-        shared = list(range(self.SUB_BLOCK_SIZE))
-        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
-        manager.get_computed_blocks(req1)
-        assert manager._pending_partial is not None
-        gm = manager._pending_partial.group_matches[0]
-        src_block = gm.src_block
-        ref_cnt_after_match = src_block.ref_cnt
-
-        # Simulate scheduler skipping allocate_slots (e.g. budget exhausted).
-        # Call get_computed_blocks for another request — this should release
-        # the old pending partial's ref_cnt.
-        req2 = _make_request("2", [200] * self.BLOCK_SIZE, self.BLOCK_SIZE)
-        manager.get_computed_blocks(req2)
-
-        assert manager._pending_partial is None
-        assert src_block.ref_cnt == ref_cnt_after_match - 1
-
-    def test_ref_cnt_released_when_get_computed_blocks_finds_no_match(self):
-        """If get_computed_blocks is called twice in a row (first finds a
-        match, second doesn't), the first partial's ref_cnt is released."""
-        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
-
-        # Cache a full block.
-        tokens = list(range(self.BLOCK_SIZE))
-        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
-        _prefill_request(manager, req0)
-        manager.free(req0)
-
-        # Trigger partial match.
-        shared = list(range(self.SUB_BLOCK_SIZE))
-        req1 = _make_request("1", shared + [100] * self.BLOCK_SIZE, self.BLOCK_SIZE)
-        manager.get_computed_blocks(req1)
-        assert manager._pending_partial is not None
-        gm = manager._pending_partial.group_matches[0]
-        src_block = gm.src_block
-        ref_before = src_block.ref_cnt
-
-        # Call get_computed_blocks again for same request without allocate_slots.
-        # This simulates the scheduler re-evaluating the request.
-        manager.get_computed_blocks(req1)
-
-        # ref_cnt should have been decremented from the first pending partial
-        # and then re-incremented for the new one (net zero change if match
-        # found again, or -1 if no match found).
-        # Since the first get_computed_blocks released the old pending, and
-        # the second may or may not find a match, just verify no leak.
-        if manager._pending_partial is not None:
-            assert src_block.ref_cnt == ref_before
-        else:
-            assert src_block.ref_cnt == ref_before - 1
 
     def test_index_newly_cached_blocks_during_decode(self):
         """_index_newly_cached_blocks should correctly index new blocks
@@ -933,10 +915,34 @@ class TestRBLNKVCacheManager:
 
         # Upstream matches 0 full blocks (num_tokens-1=7 < block_size=8).
         # Sub-block matching recovers 1 sub-block (4 tokens), capped so
-        # that num_computed <= num_tokens - 1 = 7.
-        assert num_computed <= req1.num_tokens - 1
-        assert num_computed == self.SUB_BLOCK_SIZE  # 4 tokens from sub-block match
-        assert manager._pending_partial is not None
+        # that total_computed <= num_tokens - 1 = 7.
+        assert num_computed == 0  # Full-block count only.
+        sub_block_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_block_match is not None
+        assert num_computed + sub_block_match.num_tokens <= req1.num_tokens - 1
+        assert (
+            sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
+        )  # 4 tokens from sub-block match
+
+    def test_prompt_logprobs_skips_sub_block_cache(self):
+        """Requests with prompt_logprobs must not get sub-block hits,
+        matching upstream's behaviour for full-block prefix caching."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # Populate the cache with a full block.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # with prompt_logprobs: must NOT get any cache hit.
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        unique = [100 + i for i in range(self.BLOCK_SIZE)]
+        req = _make_request("2", shared + unique, self.BLOCK_SIZE, prompt_logprobs=5)
+        _, num_computed = manager.get_computed_blocks(req)
+        assert num_computed == 0  # Full-block path also skipped.
+        sub_match = manager.get_computed_blocks_sub_block(req, num_computed)
+        assert sub_match is None
 
 
 # ---------------------------------------------------------------------------
@@ -1139,11 +1145,12 @@ class TestMultiGroupRBLNKVCacheManager:
         unique = [100 + i for i in range(full_bs)]
         req1 = _make_request("1", shared + unique, hash_bs)
         _, num_computed = manager.get_computed_blocks(req1)
-
-        # Should get 1 sub-block match (min across groups).
-        assert num_computed == sbs
-        assert manager._pending_partial is not None
-        assert manager._pending_partial.num_matched_sub_blocks == 1
+        # Should get 0 from full-block matching, 1 sub-block match separately.
+        assert num_computed == 0
+        sub_block_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_block_match is not None
+        assert sub_block_match.num_tokens == sbs
+        assert sub_block_match.num_matched_sub_blocks == 1
 
     def test_hybrid_partial_block_indexed_on_free(self):
         """In multi-group setup, free() should index partial blocks in both
@@ -1196,8 +1203,11 @@ class TestMultiGroupRBLNKVCacheManager:
         # Sub-block match: 1 sub-block (4 tokens), capped at 4 <= 7. OK.
         req1 = _make_request("1", tokens, self.BLOCK_SIZE)
         _, num_computed = manager.get_computed_blocks(req1)
-        assert num_computed <= req1.num_tokens - 1
-        assert num_computed == self.SUB_BLOCK_SIZE
+        sub_block_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_block_match is not None
+        assert num_computed + sub_block_match.num_tokens <= req1.num_tokens - 1
+        assert num_computed == 0  # Full-block count only.
+        assert sub_block_match.num_tokens == self.SUB_BLOCK_SIZE
 
     def test_eligibility(self):
         """Test the eligibility check with various configs."""
@@ -1499,3 +1509,187 @@ class TestRBLNScheduler:
         uncomputed = [blk for blk in req_blocks if blk.block_hash is None]
         for blk in uncomputed:
             assert not index.contains(blk.block_id)
+
+
+# ---------------------------------------------------------------------------
+# KV Connector + Sub-block prefix caching interaction tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubBlockWithKVConnector:
+    """Tests for the interaction between sub-block prefix caching and KV
+    connectors.  The scheduler picks whichever source (sub-block or connector)
+    provides more tokens; sub-block wins on ties since local copy is cheaper."""
+
+    BLOCK_SIZE = 16
+    SUB_BLOCK_SIZE = 4
+
+    def _create_scheduler(
+        self,
+        matched_tokens=0,
+        is_async=False,
+        num_blocks=100,
+        max_model_len=None,
+    ):
+        if max_model_len is None:
+            max_model_len = self.BLOCK_SIZE * num_blocks
+        return create_scheduler(
+            block_size=self.BLOCK_SIZE,
+            num_blocks=num_blocks,
+            max_num_batched_tokens=max_model_len,
+            max_model_len=max_model_len,
+            enable_prefix_caching=True,
+            sub_block_size=self.SUB_BLOCK_SIZE,
+            use_kv_connector=MockKVConfig(
+                matched_tokens=matched_tokens,
+                is_async=is_async,
+            ),
+        )
+
+    def test_connector_zero_tokens_sub_block_used(self):
+        """When the connector returns 0 external tokens, sub-block match
+        should be used as fallback."""
+        scheduler = self._create_scheduler(matched_tokens=0)
+        assert isinstance(scheduler.kv_cache_manager, RBLNKVCacheManager)
+        assert scheduler.connector is not None
+
+        # Cache a full block via request 0.
+        req0 = _make_request("0", [0] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Request 1: shares first sub-block, then diverges.
+        shared = [0] * self.SUB_BLOCK_SIZE
+        unique = [900 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req1)
+        output1 = scheduler.schedule()
+        assert isinstance(output1, RBLNSchedulerOutput)
+
+        # Sub-block match should be active → copy op generated.
+        assert len(output1.kv_cache_copy_ops) == 1
+        assert output1.kv_cache_copy_ops[0].num_tokens == self.SUB_BLOCK_SIZE
+
+        # The connector provided nothing, so prefill should compute all
+        # tokens beyond the sub-block match.
+        expected_scheduled = len(shared + unique) - self.SUB_BLOCK_SIZE
+        assert output1.num_scheduled_tokens["1"] == expected_scheduled
+
+    def test_sub_block_beats_connector(self):
+        """When sub-block match provides more tokens than the connector,
+        sub-block should win and the connector's offer should be ignored."""
+        # Sub-block can provide up to 3 sub-blocks = 12 tokens (block=16, sub=4).
+        # Connector offers only 1 sub-block's worth = 4 tokens.
+        # Sub-block should win.
+        scheduler = self._create_scheduler(matched_tokens=self.SUB_BLOCK_SIZE)
+        assert isinstance(scheduler.kv_cache_manager, RBLNKVCacheManager)
+
+        # Cache a full block with 3 sub-blocks worth of known tokens.
+        num_shared = 3 * self.SUB_BLOCK_SIZE  # 12 tokens
+        req0_tokens = list(range(num_shared)) + [
+            800 + i for i in range(self.BLOCK_SIZE - num_shared)
+        ]
+        req0 = _make_request("0", req0_tokens, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Request 1: shares first 3 sub-blocks, then diverges.
+        # This triggers a 3-sub-block match = 12 tokens.
+        # The connector only offers SUB_BLOCK_SIZE = 4 tokens.
+        shared = list(range(num_shared))
+        unique = [900 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, max_tokens=1)
+        req1.kv_transfer_params = {"do_remote_prefill": True}
+        scheduler.add_request(req1)
+        output1 = scheduler.schedule()
+        assert isinstance(output1, RBLNSchedulerOutput)
+
+        # Sub-block wins → copy op generated, connector overridden.
+        assert len(output1.kv_cache_copy_ops) == 1
+        assert output1.kv_cache_copy_ops[0].num_tokens == num_shared
+
+        # Scheduled tokens = total - sub_block_match (connector ignored).
+        total = len(shared + unique)
+        expected_scheduled = total - num_shared
+        assert output1.num_scheduled_tokens["1"] == expected_scheduled
+
+    def test_connector_nonzero_tokens_sub_block_discarded(self):
+        """When the connector returns more external tokens than the sub-block
+        match, the sub-block should be discarded."""
+        # Connector claims to have 1 block's worth of external tokens.
+        scheduler = self._create_scheduler(matched_tokens=self.BLOCK_SIZE)
+        assert isinstance(scheduler.kv_cache_manager, RBLNKVCacheManager)
+        assert scheduler.connector is not None
+
+        # Cache a full block via request 0 (no remote prefill).
+        req0 = _make_request("0", [0] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Request 1: same sub-block prefix as req0 → would trigger sub-block
+        # match normally, but connector provides external tokens.
+        # Set kv_transfer_params to trigger the mock connector.
+        shared = [0] * self.SUB_BLOCK_SIZE
+        unique = [900 + i for i in range(2 * self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, max_tokens=1)
+        req1.kv_transfer_params = {"do_remote_prefill": True}
+        scheduler.add_request(req1)
+        output1 = scheduler.schedule()
+        assert isinstance(output1, RBLNSchedulerOutput)
+
+        # Sub-block match should be discarded → no copy ops.
+        assert output1.kv_cache_copy_ops == []
+
+        # Connector provides BLOCK_SIZE tokens, so scheduled tokens =
+        # total - (local_full_block + connector_tokens).
+        # local full-block matches: 0 (req1's first block hash differs).
+        # external: BLOCK_SIZE (from connector).
+        total = len(shared + unique)
+        expected_scheduled = total - self.BLOCK_SIZE
+        assert output1.num_scheduled_tokens["1"] == expected_scheduled
+
+    def test_connector_sees_block_aligned_count(self):
+        """The connector should receive a block-aligned num_computed_tokens
+        (not inflated by sub-block tokens)."""
+        # We'll use a custom connector that records the num_computed_tokens
+        # it receives.
+        recorded_computed: list[int] = []
+
+        scheduler = self._create_scheduler(matched_tokens=0)
+        assert scheduler.connector is not None
+
+        original_fn = scheduler.connector.get_num_new_matched_tokens
+
+        def recording_get_num_new_matched_tokens(request, num_computed_tokens):
+            recorded_computed.append(num_computed_tokens)
+            return original_fn(request, num_computed_tokens)
+
+        scheduler.connector.get_num_new_matched_tokens = (
+            recording_get_num_new_matched_tokens
+        )
+
+        # Cache a full block.
+        req0 = _make_request("0", [0] * self.BLOCK_SIZE, self.BLOCK_SIZE, max_tokens=1)
+        scheduler.add_request(req0)
+        output0 = scheduler.schedule()
+        runner_output0 = create_runner_output(output0, 0)
+        scheduler.update_from_output(output0, runner_output0)
+
+        # Request 1 shares first sub-block → triggers sub-block match.
+        # Set kv_transfer_params so the mock connector responds.
+        shared = [0] * self.SUB_BLOCK_SIZE
+        unique = [900 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, max_tokens=1)
+        req1.kv_transfer_params = {"do_remote_prefill": True}
+        scheduler.add_request(req1)
+        scheduler.schedule()
+
+        # The connector should have seen block-aligned count (0, not 4).
+        # recorded_computed may have entries from req0 too; check the last.
+        assert recorded_computed[-1] == 0  # Block-aligned, no sub-block inflation.

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -16,6 +16,12 @@
 
 import pytest
 import torch
+from vllm.lora.request import LoRARequest
+from vllm.multimodal.inputs import (
+    MultiModalFeatureSpec,
+    MultiModalKwargsItem,
+    PlaceholderRange,
+)
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import (
@@ -57,61 +63,131 @@ class TestSubBlockHasher:
         self.hasher = SubBlockHasher(sha256, sub_block_size=4)
 
     def test_hash_empty_tokens(self):
-        hashes = self.hasher.hash_tokens([])
+        hashes, _ = self.hasher.hash_tokens([])
         assert hashes == []
 
     def test_hash_fewer_than_sub_block(self):
-        hashes = self.hasher.hash_tokens([1, 2, 3])
+        hashes, _ = self.hasher.hash_tokens([1, 2, 3])
         assert hashes == []
 
     def test_hash_exact_sub_block(self):
-        hashes = self.hasher.hash_tokens([1, 2, 3, 4])
+        hashes, _ = self.hasher.hash_tokens([1, 2, 3, 4])
         assert len(hashes) == 1
         assert isinstance(hashes[0], bytes)
 
     def test_hash_multiple_sub_blocks(self):
-        hashes = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
         assert len(hashes) == 2
 
     def test_hash_partial_last_sub_block(self):
-        hashes = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6])
+        hashes, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6])
         assert len(hashes) == 1  # Only the first full sub-block.
 
     def test_hashes_are_chained(self):
         # Hashing [1,2,3,4,5,6,7,8] should produce different h1 than
         # hashing [5,6,7,8] alone (because the parent hash differs).
-        hashes_full = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
-        hashes_second_only = self.hasher.hash_tokens([5, 6, 7, 8])
+        hashes_full, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes_second_only, _ = self.hasher.hash_tokens([5, 6, 7, 8])
         assert hashes_full[1] != hashes_second_only[0]
 
     def test_incremental_hashing(self):
         # Hash in one go.
-        hashes_all = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes_all, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
 
         # Hash in two steps.
         # Step 1: first sub-block only (only 4 tokens available).
-        h1 = self.hasher.hash_tokens(
+        h1, _ = self.hasher.hash_tokens(
             [1, 2, 3, 4],
             parent_hash=None,
             num_hashed_tokens=0,
         )
         # Step 2: all 8 tokens available, start from offset 4.
-        h2 = self.hasher.hash_tokens(
+        h2, _ = self.hasher.hash_tokens(
             [1, 2, 3, 4, 5, 6, 7, 8],
             parent_hash=h1[0],
             num_hashed_tokens=4,
         )
         assert h1 + h2 == hashes_all
 
+    def test_incremental_hashing_with_extra_keys(self):
+        """Incremental hashing with extra_keys (via request=) must
+        produce the same result as one-shot hashing.
+
+        Uses images with gaps and one image spanning two sub-blocks
+        so that the incremental resume point lands *between* images.
+
+        Layout (sub_block_size=4):
+          tokens:     0..3   4..7   8..11  12..15  16..19
+          sub-blocks: sb0    sb1    sb2    sb3     sb4
+          image A:    [0, 4)
+          image B:                  [8,      14)
+          image C:                                 [16, 20)
+        """
+        tokens = list(range(20))
+
+        mm_features = [
+            MultiModalFeatureSpec(
+                data=MultiModalKwargsItem.dummy(),
+                modality="image",
+                identifier="hash_img_a",
+                mm_position=PlaceholderRange(offset=0, length=4),
+            ),
+            MultiModalFeatureSpec(
+                data=MultiModalKwargsItem.dummy(),
+                modality="image",
+                identifier="hash_img_b",
+                mm_position=PlaceholderRange(offset=8, length=6),
+            ),
+            MultiModalFeatureSpec(
+                data=MultiModalKwargsItem.dummy(),
+                modality="image",
+                identifier="hash_img_c",
+                mm_position=PlaceholderRange(offset=16, length=4),
+            ),
+        ]
+
+        req = Request(
+            request_id="mm",
+            prompt_token_ids=tokens,
+            mm_features=mm_features,
+            sampling_params=SamplingParams(max_tokens=17),
+            pooling_params=None,
+            block_hasher=get_request_block_hasher(8, sha256),
+        )
+
+        # One-shot: hash all 5 sub-blocks at once.
+        hashes_all, _ = self.hasher.hash_tokens(tokens, request=req)
+        assert len(hashes_all) == 5
+
+        # Incremental: one sub-block at a time.
+        # After sb0 mm_idx=1 (past A). Using mm_idx=-1 from here
+        # would jump to C (idx=2) and miss B entirely at sb2.
+        incremental: list[BlockHash] = []
+        parent = None
+        mm_idx = 0
+        for i in range(5):
+            off = i * 4
+            h, mm_idx = self.hasher.hash_tokens(
+                tokens[: off + 4],
+                parent_hash=parent,
+                num_hashed_tokens=off,
+                request=req,
+                start_mm_idx=mm_idx,
+            )
+            assert len(h) == 1
+            incremental.extend(h)
+            parent = h[-1]
+        assert incremental == hashes_all
+
     def test_deterministic(self):
         tokens = list(range(100, 112))
-        h1 = self.hasher.hash_tokens(tokens)
-        h2 = self.hasher.hash_tokens(tokens)
+        h1, _ = self.hasher.hash_tokens(tokens)
+        h2, _ = self.hasher.hash_tokens(tokens)
         assert h1 == h2
 
     def test_different_tokens_different_hashes(self):
-        h1 = self.hasher.hash_tokens([1, 2, 3, 4])
-        h2 = self.hasher.hash_tokens([5, 6, 7, 8])
+        h1, _ = self.hasher.hash_tokens([1, 2, 3, 4])
+        h2, _ = self.hasher.hash_tokens([5, 6, 7, 8])
         assert h1 != h2
 
 
@@ -126,7 +202,8 @@ class TestSubBlockIndex:
         sub-block token lists."""
         hasher = SubBlockHasher(sha256, sub_block_size=len(tokens_per_sub_block[0]))
         flat = [t for sub in tokens_per_sub_block for t in sub]
-        return hasher.hash_tokens(flat)
+        hashes, _ = hasher.hash_tokens(flat)
+        return hashes
 
     def test_empty_no_match(self):
         index = SubBlockIndex()
@@ -223,6 +300,8 @@ def _make_request(
     prompt_token_ids: list[int],
     block_size: int,
     max_tokens: int = 17,
+    cache_salt: str | None = None,
+    lora_request: LoRARequest | None = None,
     prompt_logprobs: int | None = None,
 ) -> Request:
     return Request(
@@ -234,6 +313,8 @@ def _make_request(
             prompt_logprobs=prompt_logprobs,
         ),
         pooling_params=None,
+        cache_salt=cache_salt,
+        lora_request=lora_request,
         block_hasher=get_request_block_hasher(block_size, sha256),
     )
 
@@ -1011,6 +1092,53 @@ class TestRBLNKVCacheManager:
 
         # Verify the copy op still references the recycled block id.
         assert ops[0].src_block_id == src_block.block_id
+
+    def test_cache_salt_isolation(self):
+        """Sub-block match must not cross cache_salt boundaries.
+        Also, a request without cache_salt must not match sub-blocks
+        cached by a request with cache_salt, and vice versa."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        # req0 with salt "A": fills a full block → sub-blocks indexed.
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE, cache_salt="A")
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # req1 with salt "B": same token prefix, different salt → no mat
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        unique = [100 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, cache_salt="B")
+        _, num_computed = manager.get_computed_blocks(req1)
+        assert num_computed == 0
+        sub_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_match is None
+
+        # Same tokens, no salt → no match
+        req2 = _make_request("2", shared + unique, self.BLOCK_SIZE)
+        _, num_computed2 = manager.get_computed_blocks(req2)
+        sub_match2 = manager.get_computed_blocks_sub_block(req2, num_computed2)
+        assert sub_match2 is None
+
+    def test_lora_isolation(self):
+        """Sub-block match must not cross LoRA boundaries."""
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+
+        lora_a = LoRARequest(lora_name="lora_a", lora_int_id=1, lora_path="/a")
+        lora_b = LoRARequest(lora_name="lora_b", lora_int_id=2, lora_path="/b")
+
+        tokens = list(range(self.BLOCK_SIZE))
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE, lora_request=lora_a)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        shared = list(range(self.SUB_BLOCK_SIZE))
+        unique = [100 + i for i in range(self.BLOCK_SIZE)]
+        req1 = _make_request("1", shared + unique, self.BLOCK_SIZE, lora_request=lora_b)
+        _, num_computed = manager.get_computed_blocks(req1)
+        assert num_computed == 0
+        sub_match = manager.get_computed_blocks_sub_block(req1, num_computed)
+        assert sub_match is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/torch_compile/unit/v1/core/utils.py
+++ b/tests/torch_compile/unit/v1/core/utils.py
@@ -18,16 +18,25 @@
 # Search for NOTE(RBLN) or TODO(RBLN) for changes
 
 
+from dataclasses import dataclass
+from itertools import chain
+
 import torch
 from vllm.config import (
     CacheConfig,
     # ECTransferConfig,
-    # KVTransferConfig,
+    KVTransferConfig,
     ModelConfig,
     ParallelConfig,
     SchedulerConfig,
     SpeculativeConfig,
     VllmConfig,
+)
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
 )
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
@@ -36,6 +45,7 @@ from vllm.multimodal.inputs import (
 )
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
@@ -53,6 +63,93 @@ from vllm_rbln.v1.core.rbln_scheduler import RBLNScheduler
 EOS_TOKEN_ID = 50256
 
 
+# ---------------------------------------------------------------------------
+# Mock KV Connector for testing sub-block ↔ connector interaction
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MockKVConfig:
+    """Config for MockKVConnector: how many tokens to report as externally
+    cached, and whether loading is async."""
+
+    matched_tokens: int = 0
+    is_async: bool = False
+
+
+class _MockKVConnectorMetadata(KVConnectorMetadata):
+    def __init__(self):
+        self.requests: list = []
+
+
+class MockKVConnector(KVConnectorBase_V1):
+    """Minimal mock KV connector for scheduler tests.
+
+    Returns ``config.matched_tokens`` as external tokens only for requests
+    whose ``kv_transfer_params`` contain ``do_remote_prefill=True``.
+    Other requests get 0 external tokens.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig | None = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+        extra = self._kv_transfer_config.kv_connector_extra_config
+        self.config = MockKVConfig(
+            matched_tokens=extra["matched_tokens"],
+            is_async=extra["is_async"],
+        )
+
+    def get_num_new_matched_tokens(
+        self, request: Request, num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
+        params = getattr(request, "kv_transfer_params", None)
+        if params and params.get("do_remote_prefill"):
+            return (self.config.matched_tokens, self.config.is_async)
+        return (0, False)
+
+    def update_state_after_alloc(
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
+    ):
+        pass
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        metadata = _MockKVConnectorMetadata()
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for req_id in chain(
+            (req.req_id for req in scheduler_output.scheduled_new_reqs),
+            (
+                req_id
+                for req_id in cached_reqs.req_ids
+                if req_id in cached_reqs.resumed_req_ids
+            ),
+        ):
+            metadata.requests.append({"req_id": req_id})
+        return metadata
+
+    def start_load_kv(self, forward_context, **kwargs):
+        pass
+
+    def wait_for_layer_load(self, layer_name):
+        pass
+
+    def save_kv_layer(self, layer_name, kv_layer, attn_metadata, **kwargs):
+        pass
+
+    def wait_for_save(self):
+        pass
+
+
+KVConnectorFactory.register_connector(
+    "MockKVConnector", __name__, MockKVConnector.__name__
+)
+
+
 def create_scheduler(
     model: str = "facebook/opt-125m",
     max_num_seqs: int = 16,
@@ -61,7 +158,7 @@ def create_scheduler(
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
     disable_chunked_mm_input: bool = False,
-    use_kv_connector: None | bool = None,
+    use_kv_connector: None | MockKVConfig = None,
     num_blocks: int = 10000,
     block_size: int = 16,
     max_model_len: int | None = None,
@@ -89,8 +186,8 @@ def create_scheduler(
 
     # TODO(RBLN): support async scheduling
     assert not async_scheduling
-    # TODO(RBLN): support kv transfer via kv connector
-    assert not use_kv_connector
+    # TODO(RBLN): support specluative decoding
+    assert not num_speculative_tokens
 
     model_config = ModelConfig(
         model=model,
@@ -119,21 +216,15 @@ def create_scheduler(
         enable_prefix_caching=enable_prefix_caching,
     )
     kv_transfer_config = None
-    # if isinstance(use_kv_connector, MockKVConfig):
-    #     kv_transfer_config = KVTransferConfig(
-    #         kv_connector="MockKVConnector",
-    #         kv_role="kv_both",
-    #         kv_connector_extra_config={
-    #             "matched_tokens": use_kv_connector.matched_tokens,
-    #             "is_async": use_kv_connector.is_async,
-    #         },
-    #     )
-    # elif use_kv_connector:
-    #     kv_transfer_config = KVTransferConfig(
-    #         kv_connector="ExampleConnector",
-    #         kv_role="kv_both",
-    #         kv_connector_extra_config={"shared_storage_path": "local_storage"},
-    #     )
+    if isinstance(use_kv_connector, MockKVConfig):
+        kv_transfer_config = KVTransferConfig(
+            kv_connector="MockKVConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "matched_tokens": use_kv_connector.matched_tokens,
+                "is_async": use_kv_connector.is_async,
+            },
+        )
 
     speculative_config: SpeculativeConfig | None = None
     if num_speculative_tokens is not None:

--- a/tests/torch_compile/unit/v1/core/utils.py
+++ b/tests/torch_compile/unit/v1/core/utils.py
@@ -71,6 +71,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    sub_block_size: int | None = None,
 ) -> RBLNScheduler:
     """Create scheduler under test.
 
@@ -184,6 +185,7 @@ def create_scheduler(
         block_size=block_size,
         log_stats=True,
         structured_output_manager=StructuredOutputManager(vllm_config),
+        sub_block_size=sub_block_size,
     )
 
 

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS: list[int] = []
     VLLM_RBLN_USE_CUSTOM_KERNEL: bool = False
     VLLM_RBLN_AUTO_PORT: bool = True
+    VLLM_RBLN_SUB_BLOCK_CACHE: bool = True
 
 
 def get_dp_impl() -> str:
@@ -256,6 +257,11 @@ environment_variables = {
     ),
     "VLLM_RBLN_PROFILER": (
         lambda: os.environ.get("RBLN_PROFILER", "False").lower() in ("true", "1")
+    ),
+    # Enable sub-block prefix caching.
+    # Sub-block size equals max_num_batched_tokens (prefill chunk size).
+    "VLLM_RBLN_SUB_BLOCK_CACHE": lambda: (
+        os.environ.get("VLLM_RBLN_SUB_BLOCK_CACHE", "True").lower() in ("true", "1")
     ),
 }
 

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -1,0 +1,622 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sub-block prefix caching for RBLN KV cache management.
+
+See docs/sub_block_prefix_caching.md for design overview and rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    hash_block_tokens,
+    make_block_hash_with_group_id,
+)
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
+
+from vllm_rbln.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+# Attention spec types whose KV cache stores per-token data and can be
+# partially copied at sub-block granularity.  Types NOT in this set (e.g.
+# MambaSpec — stores recurrent state per block, not per-token KV) are
+# incompatible with sub-block caching.
+_SUB_BLOCK_ELIGIBLE_SPECS: tuple[type[KVCacheSpec], ...] = (
+    FullAttentionSpec,  # includes MLAAttentionSpec (subclass)
+    SlidingWindowSpec,
+    ChunkedLocalAttentionSpec,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class KVCacheCopyOp:
+    """Describes a sub-block KV cache copy from a cached block to a new block."""
+
+    group_id: int
+    # NOTE: While pending, it holds a ref count of the source block to prevent eviction.
+    src_block_id: int
+    dst_block_id: int
+    # Number of tokens to copy (= num_matched_sub_blocks * sub_block_size).
+    num_tokens: int
+
+
+class SubBlockHasher:
+    """Computes chained sub-block hashes from token IDs.
+
+    Uses the same ``hash_block_tokens`` as upstream, but at sub-block
+    granularity.
+    """
+
+    def __init__(
+        self,
+        hash_fn: Callable,
+        sub_block_size: int,
+    ) -> None:
+        self.hash_fn = hash_fn
+        self.sub_block_size = sub_block_size
+
+    def hash_tokens(
+        self,
+        token_ids: Sequence[int],
+        *,
+        parent_hash: BlockHash | None = None,
+        num_hashed_tokens: int = 0,
+    ) -> list[BlockHash]:
+        """Return sub-block hashes for *full* sub-blocks in ``token_ids``.
+
+        Args:
+            token_ids: Full token sequence of the request.
+            parent_hash: Hash of the last sub-block before the range we
+                are hashing (``None`` for the very first sub-block).
+            num_hashed_tokens: Number of tokens already hashed (i.e. the
+                start offset into ``token_ids``).
+
+        Returns:
+            List of ``BlockHash`` values, one per full sub-block starting
+            from ``num_hashed_tokens``.
+        """
+        sbs = self.sub_block_size
+        hashes: list[BlockHash] = []
+        start = num_hashed_tokens
+        for i in range(start, len(token_ids) - sbs + 1, sbs):
+            parent_hash = hash_block_tokens(
+                self.hash_fn,
+                parent_hash,
+                token_ids[i : i + sbs],
+            )
+            hashes.append(parent_hash)
+        return hashes
+
+
+class SubBlockIndex:
+    """Index mapping sub-block hashes to physical block IDs that contain that
+    sub-block as a prefix.
+
+    Invariant: cached ↔ indexed.
+    """
+
+    def __init__(self) -> None:
+        # sub_block_hash → set of block IDs with that prefix cached.
+        self._hash_to_blocks: dict[BlockHash, set[int]] = {}
+        # Reverse index: block_id → list of sub-block hashes (for removal).
+        self._block_hashes: dict[int, list[BlockHash]] = {}
+
+    def insert(self, block_id: int, sub_block_hashes: list[BlockHash]) -> None:
+        """Index a block's sub-block hashes."""
+        assert block_id not in self._block_hashes
+        self._block_hashes[block_id] = sub_block_hashes
+        for h in sub_block_hashes:
+            self._hash_to_blocks.setdefault(h, set()).add(block_id)
+
+    def pop(self, block_id: int) -> None:
+        """Remove a block from the index (called on eviction)."""
+        hashes = self._block_hashes.pop(block_id, None)
+        if hashes is None:
+            return
+        for h in hashes:
+            s = self._hash_to_blocks.get(h)
+            if s is not None:
+                s.discard(block_id)
+                if not s:
+                    del self._hash_to_blocks[h]
+
+    def contains(self, block_id: int) -> bool:
+        """Return True if the block is indexed."""
+        return block_id in self._block_hashes
+
+    def longest_match(
+        self, sub_block_hashes: Sequence[BlockHash]
+    ) -> tuple[int | None, int]:
+        """Find a block with the longest prefix match.
+
+        Returns:
+            ``(block_id, num_matched)`` where ``block_id`` is any block
+            matching that prefix, or ``(None, 0)`` if no match.
+        """
+        best_block_id: int | None = None
+        best_depth = 0
+        for depth, h in enumerate(sub_block_hashes, start=1):
+            blocks = self._hash_to_blocks.get(h)
+            if not blocks:
+                break
+            # Pick an arbitrary block_id from the set.
+            best_block_id = next(iter(blocks))
+            best_depth = depth
+        return best_block_id, best_depth
+
+
+# ---------------------------------------------------------------------------
+# RBLNKVCacheManager
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _PendingPartialMatch:
+    """Temporary state between get_computed_blocks and allocate_slots.
+    Owns references to source blocks to prevent eviction during scheduling."""
+
+    request_id: str
+    num_matched_sub_blocks: int
+    group_matches: tuple[_GroupPartialMatch, ...]
+
+
+@dataclass(slots=True)
+class _GroupPartialMatch:
+    """Per-group partial match info."""
+
+    src_block_id: int
+    src_block: KVCacheBlock
+    # Index of the block (in the request's block list) that will receive
+    # the copied sub-blocks.
+    dst_block_index: int
+
+
+@dataclass(slots=True)
+class _GroupInfo:
+    """Per-group configuration for sub-block caching."""
+
+    block_size: int
+    sub_blocks_per_block: int
+    sub_block_index: SubBlockIndex
+
+
+class RBLNKVCacheManager(KVCacheManager):
+    """KVCacheManager with sub-block prefix caching for RBLN.
+
+    It first applies the upstream full-block prefix matching, then extends
+    matches at sub-block granularity, which are reused via copy operations
+    scheduled to the model runner.
+    """
+
+    @staticmethod
+    def can_use_sub_block_caching(
+        kv_cache_config: KVCacheConfig,
+        sub_block_size: int,
+    ) -> bool:
+        """Return True if sub-block caching is applicable to this config.
+
+        Sub-block caching requires:
+        1. Every group's spec type must store per-token KV data (allow-listed
+           in ``_SUB_BLOCK_ELIGIBLE_SPECS``).
+        2. Every group must have block_size > sub_block_size and
+           block_size % sub_block_size == 0.
+        """
+        if sub_block_size <= 0:
+            return False
+        for group in kv_cache_config.kv_cache_groups:
+            spec = group.kv_cache_spec
+            if not isinstance(spec, _SUB_BLOCK_ELIGIBLE_SPECS):
+                return False
+            bs = spec.block_size
+            if bs <= sub_block_size or bs % sub_block_size != 0:
+                return False
+        return True
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        hash_block_size: int,
+        sub_block_size: int,
+        hash_fn: Callable,
+        **kwargs,
+    ) -> None:
+        assert self.can_use_sub_block_caching(kv_cache_config, sub_block_size)
+
+        super().__init__(
+            kv_cache_config=kv_cache_config,
+            max_model_len=max_model_len,
+            hash_block_size=hash_block_size,
+            enable_caching=True,
+            **kwargs,
+        )
+
+        self.sub_block_size = sub_block_size
+
+        # Build per-group info.
+        self._group_infos: list[_GroupInfo] = []
+        for group in kv_cache_config.kv_cache_groups:
+            bs = group.kv_cache_spec.block_size
+            self._group_infos.append(
+                _GroupInfo(
+                    block_size=bs,
+                    sub_blocks_per_block=bs // sub_block_size,
+                    sub_block_index=SubBlockIndex(),
+                )
+            )
+
+        self.sub_block_hasher = SubBlockHasher(hash_fn, sub_block_size)
+
+        # Per-request sub-block hash cache (group-independent).
+        self._req_sub_hashes: dict[str, list[BlockHash]] = {}
+
+        # Pending partial match state (set by get_computed_blocks, consumed
+        # by allocate_slots).
+        self._pending_partial: _PendingPartialMatch | None = None
+
+        # Copy operations accumulated during a scheduling step; the scheduler
+        # drains this list when building SchedulerOutput. While pending, each
+        # copy op holds a ref count of its source block to prevent eviction.
+        self.pending_copy_ops: list[KVCacheCopyOp] = []
+
+        self._install_eviction_hook()
+
+    # -- overrides ----------------------------------------------------------
+
+    def get_computed_blocks(self, request: Request) -> tuple[KVCacheBlocks, int]:
+        # Release any stale pending partial from a prior get_computed_blocks
+        # that was never followed by allocate_slots (e.g. scheduler skipped
+        # the request via continue/break).
+        if self._pending_partial is not None:
+            self._release_pending_partial(self._pending_partial)
+            self._pending_partial = None
+
+        if request.skip_reading_prefix_cache:
+            return self.empty_kv_cache_blocks, 0
+
+        # Step 1: upstream full-block matching.
+        computed_blocks, num_computed_tokens = super().get_computed_blocks(request)
+
+        # Step 2: check for partial sub-block match in the next block
+        # across all groups. Extension = min across groups.
+        sub_hashes = self._get_or_compute_sub_hashes(request)
+
+        min_matched: int | None = None
+        group_matches: list[_GroupPartialMatch] = []
+
+        for gi in self._group_infos:
+            num_full_blocks = num_computed_tokens // gi.block_size
+            sbpb = gi.sub_blocks_per_block
+            next_sub_start = num_full_blocks * sbpb
+
+            # We need at least one sub-block hash beyond the full-block matches
+            # AND fewer than a full block (otherwise upstream would have matched).
+            query = sub_hashes[next_sub_start : next_sub_start + sbpb - 1]
+            if not query:
+                min_matched = 0
+                break
+
+            src_block_id, num_matched = gi.sub_block_index.longest_match(query)
+            if src_block_id is None:
+                min_matched = 0
+                break
+
+            if min_matched is None or num_matched < min_matched:
+                min_matched = num_matched
+
+            group_matches.append(
+                _GroupPartialMatch(
+                    src_block_id=src_block_id,
+                    src_block=self.block_pool.blocks[src_block_id],
+                    dst_block_index=num_full_blocks,
+                )
+            )
+
+        if not min_matched:
+            return computed_blocks, num_computed_tokens
+
+        # We have a partial match!
+        num_matched = min_matched
+        extra_tokens = num_matched * self.sub_block_size
+
+        # NOTE: Upstream guarantees num_computed_tokens <= num_tokens - 1,
+        # because at least the last token must be recomputed for logits.
+        # We enforce the same condition here.
+        max_allowed_extra_tokens = (request.num_tokens - 1) - num_computed_tokens
+        max_allowed_sub_blocks = max_allowed_extra_tokens // self.sub_block_size
+        num_matched = min(num_matched, max_allowed_sub_blocks)
+        if num_matched == 0:
+            return computed_blocks, num_computed_tokens
+        extra_tokens = num_matched * self.sub_block_size
+
+        # Touch source blocks to prevent eviction during allocate_slots.
+        # _PendingPartialMatch owns these references.
+        # This also lowers their eviction priority.
+        self.block_pool.touch([gm.src_block for gm in group_matches])
+        self._pending_partial = _PendingPartialMatch(
+            request_id=request.request_id,
+            num_matched_sub_blocks=num_matched,
+            group_matches=tuple(group_matches),
+        )
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Sub-block partial match for request %s: %d sub-blocks (%d tokens); %s",
+                request.request_id,
+                num_matched,
+                extra_tokens,
+                ", ".join(
+                    f"group {i} from block {gm.src_block_id}"
+                    for i, gm in enumerate(group_matches)
+                ),
+            )
+
+        return computed_blocks, num_computed_tokens + extra_tokens
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_lookahead_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+        delay_cache_blocks: bool = False,
+        num_encoder_tokens: int = 0,
+    ) -> KVCacheBlocks | None:
+        # Consume the pending partial match, releasing it if it doesn't
+        # belong to this request (stale from a skipped request).
+        partial = self._take_pending_partial(request.request_id)
+
+        num_full_blocks_before = tuple(
+            request.num_computed_tokens // gi.block_size for gi in self._group_infos
+        )
+
+        result = super().allocate_slots(
+            request,
+            num_new_tokens,
+            num_new_computed_tokens,
+            new_computed_blocks,
+            num_lookahead_tokens,
+            num_external_computed_tokens,
+            delay_cache_blocks,
+            num_encoder_tokens,
+        )
+
+        if result is None:
+            if partial is not None:
+                self._release_pending_partial(partial)
+            return None
+
+        self._index_newly_cached_blocks(request, num_full_blocks_before)
+
+        if partial is not None:
+            self._apply_partial(partial, request)
+
+        return result
+
+    def free(self, request: Request) -> None:
+        """Free blocks and clean up sub-block state for a request."""
+        # Before freeing, cache the last partial block's sub-blocks in the
+        # index so future requests can reuse them via sub-block matching.
+        self._index_partial_block(request)
+
+        # Clean up request sub-hash cache.
+        del self._req_sub_hashes[request.request_id]
+        super().free(request)
+
+    def reset_prefix_cache(self) -> bool:
+        """Reset prefix cache including all per-group sub-block indices."""
+        result = super().reset_prefix_cache()
+        if result:
+            for gi in self._group_infos:
+                gi.sub_block_index = SubBlockIndex()
+        return result
+
+    # -- sub-block hash helpers ---------------------------------------------
+
+    def _get_or_compute_sub_hashes(self, request: Request) -> list[BlockHash]:
+        """Return the sub-block hashes for the request, computing new ones if
+        the request has grown since the last call.  Group-independent."""
+        cached_hashes = self._req_sub_hashes.setdefault(request.request_id, [])
+        num_hashed_tokens = len(cached_hashes) * self.sub_block_size
+        parent_hash = cached_hashes[-1] if cached_hashes else None
+
+        new_hashes = self.sub_block_hasher.hash_tokens(
+            request.all_token_ids,
+            parent_hash=parent_hash,
+            num_hashed_tokens=num_hashed_tokens,
+        )
+        if new_hashes:
+            cached_hashes.extend(new_hashes)
+        return cached_hashes
+
+    # -- sub-block index maintenance ----------------------------------------
+
+    def _index_newly_cached_blocks(
+        self, request: Request, num_full_blocks_before: tuple[int, ...]
+    ) -> None:
+        """After allocate_slots caches new full blocks, index their sub-blocks."""
+        blocks = self.coordinator.get_blocks(request.request_id)
+        for gi, block_list, before in zip(
+            self._group_infos, blocks, num_full_blocks_before
+        ):
+            for blk_idx in range(before, len(block_list)):
+                blk = block_list[blk_idx]
+                # Only for newly cached full blocks.
+                # NOTE: For a new request, num_full_blocks_before is zero
+                # because num_computed_tokens is set after scheduling.
+                # So this doesn't tell us which blocks are newly cached.
+                # So we also check that the block is not already indexed.
+                if blk.block_hash is not None and not gi.sub_block_index.contains(
+                    blk.block_id
+                ):
+                    self._on_block_cached(request, blk_idx, blk, gi)
+
+    def _on_block_cached(
+        self,
+        request: Request,
+        blk_idx: int,
+        blk: KVCacheBlock,
+        gi: _GroupInfo,
+    ) -> None:
+        """Index a newly cached full block's sub-blocks."""
+        sub_hashes = self._get_or_compute_sub_hashes(request)
+        sbpb = gi.sub_blocks_per_block
+        sub_start = blk_idx * sbpb
+        sub_end = min(sub_start + sbpb, len(sub_hashes))
+        if sub_end <= sub_start:
+            return
+        blk_sub_hashes = sub_hashes[sub_start:sub_end]
+        gi.sub_block_index.insert(blk.block_id, blk_sub_hashes)
+
+    def _index_partial_block(self, request: Request) -> None:
+        """Index sub-blocks of the last partial block per group
+        and mark it as cached so the upstream LRU preserves it."""
+        num_computed_tokens = request.num_computed_tokens
+        sub_hashes = self._get_or_compute_sub_hashes(request)
+        blocks = self.coordinator.get_blocks(request.request_id)
+
+        for gid, gi in enumerate(self._group_infos):
+            remainder = num_computed_tokens % gi.block_size
+            if remainder == 0:
+                continue  # No partial block.
+
+            num_sub_blocks = remainder // self.sub_block_size
+            if num_sub_blocks == 0:
+                continue
+
+            block_list = blocks[gid]
+            last_blk_idx = num_computed_tokens // gi.block_size
+            if last_blk_idx >= len(block_list):
+                continue
+            blk = block_list[last_blk_idx]
+
+            sbpb = gi.sub_blocks_per_block
+            sub_start = last_blk_idx * sbpb
+            sub_end = min(sub_start + num_sub_blocks, len(sub_hashes))
+            if sub_end <= sub_start:
+                continue
+            partial_sub_hashes = sub_hashes[sub_start:sub_end]
+
+            # Index in the group's sub-block index.
+            gi.sub_block_index.insert(blk.block_id, partial_sub_hashes)
+
+            # Give the block a synthetic block_hash so the upstream block pool
+            # keeps it in the LRU cache instead of immediately reusing it.
+            # The actual value doesn't matter as long as it's unique so that it
+            # doesn't collide with any real full-block hash.
+            synthetic_hash = make_block_hash_with_group_id(
+                BlockHash(
+                    b"partial_block_"
+                    + str(blk.block_id).encode("ascii")
+                    + b"_"
+                    + partial_sub_hashes[-1]
+                ),
+                gid,
+            )
+            assert blk.block_hash is None
+            blk.block_hash = synthetic_hash
+            self.block_pool.cached_block_hash_to_block.insert(synthetic_hash, blk)
+
+    def _on_block_evicted(self, block_id: int) -> None:
+        """Called when a block is evicted — remove from index."""
+        for gi in self._group_infos:
+            gi.sub_block_index.pop(block_id)
+
+    def _install_eviction_hook(self) -> None:
+        # Monkey-patch the block pool's eviction method to also clean up the
+        # sub-block index. We can't simply override evict_blocks because we
+        # need to know if eviction actually happened.
+        original_evict = self.block_pool._maybe_evict_cached_block
+
+        def evict_with_index_cleanup(block: KVCacheBlock) -> bool:
+            block_id = block.block_id
+            result = original_evict(block)
+            if result:
+                self._on_block_evicted(block_id)
+            return result
+
+        self.block_pool._maybe_evict_cached_block = evict_with_index_cleanup
+
+    # -- pending partial match & copy ops lifecycle --------------------------
+
+    def _take_pending_partial(self, request_id: str) -> _PendingPartialMatch | None:
+        """Consume the pending partial match. If it belongs to a different
+        request (stale), release its source block and return None."""
+        partial = self._pending_partial
+        self._pending_partial = None
+        if partial is not None and partial.request_id != request_id:
+            self._release_pending_partial(partial)
+            return None
+        return partial
+
+    def _apply_partial(self, partial: _PendingPartialMatch, request: Request) -> None:
+        """Create copy ops from the partial match, one per group."""
+        blocks = self.coordinator.get_blocks(request.request_id)
+        num_matched_tokens = partial.num_matched_sub_blocks * self.sub_block_size
+
+        for i, gm in enumerate(partial.group_matches):
+            block_list = blocks[i]
+            # By this point, the destination block must have been allocated
+            dst_block = block_list[gm.dst_block_index]
+            self.pending_copy_ops.append(
+                # Ownership of src_block ref is transferred to KVCacheCopyOp
+                KVCacheCopyOp(
+                    group_id=i,
+                    src_block_id=gm.src_block_id,
+                    dst_block_id=dst_block.block_id,
+                    num_tokens=num_matched_tokens,
+                )
+            )
+
+        if self.log_stats:
+            assert self.prefix_cache_stats is not None
+            self.prefix_cache_stats.record(
+                num_tokens=0,  # already counted in get_computed_blocks
+                num_hits=num_matched_tokens,
+                preempted=request.num_preemptions > 0,
+            )
+
+    def _release_pending_partial(self, partial: _PendingPartialMatch) -> None:
+        """Release source block references held by a partial match."""
+        self.block_pool.free_blocks([gm.src_block for gm in partial.group_matches])
+
+    def drain_pending_copy_ops(self) -> list[KVCacheCopyOp]:
+        """Return and clear all pending copy operations, releasing source block refs."""
+        ops = self.pending_copy_ops
+        self.pending_copy_ops = []
+        if ops:
+            self.block_pool.free_blocks(
+                [self.block_pool.blocks[op.src_block_id] for op in ops]
+            )
+        return ops

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -391,7 +391,7 @@ class RBLNKVCacheManager(KVCacheManager):
 
         Call this after ``allocate_slots`` succeeds. The source-block refs
         owned by *match* are transferred to the pending copy ops (released
-        by ``drain_pending_copy_ops``).
+        by ``release_copy_ops``).
         """
         blocks = self.coordinator.get_blocks(request.request_id)
 
@@ -456,14 +456,22 @@ class RBLNKVCacheManager(KVCacheManager):
         return result
 
     def drain_pending_copy_ops(self) -> list[KVCacheCopyOp]:
-        """Return and clear all pending copy operations, releasing source block refs."""
+        """Return and clear all pending copy operations.
+
+        Source-block refs are **retained** so the data remains valid until
+        the model runner finishes the copies.  The caller must call
+        :meth:`release_copy_ops` afterwards to free the refs.
+        """
         ops = self.pending_copy_ops
         self.pending_copy_ops = []
+        return ops
+
+    def release_copy_ops(self, ops: list[KVCacheCopyOp]) -> None:
+        """Release source-block refs held by previously drained copy ops."""
         if ops:
             self.block_pool.free_blocks(
                 [self.block_pool.blocks[op.src_block_id] for op in ops]
             )
-        return ops
 
     def free(self, request: Request) -> None:
         """Free blocks and clean up sub-block state for a request."""

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -321,6 +321,11 @@ class RBLNKVCacheManager(KVCacheManager):
         # copy op holds a ref count of its source block to prevent eviction.
         self.pending_copy_ops: list[KVCacheCopyOp] = []
 
+        # Requests for which sub-block indexing is pending.
+        # Each entry stores the per-group full-block count snapshot
+        # taken before allocate_slots, used to narrow the scan range.
+        self._pending_indexing: dict[str, tuple[Request, tuple[int, ...]]] = {}
+
         self._install_eviction_hook()
 
     def get_computed_blocks_sub_block(
@@ -483,7 +488,13 @@ class RBLNKVCacheManager(KVCacheManager):
         )
 
         if result is not None:
-            self._index_newly_cached_blocks(request, num_full_blocks_before)
+            # Defer sub-block indexing until after execute_model writes KV cache,
+            # so that concurrent prefills in the same step cannot match sub-blocks
+            # whose KV data does not yet exist.
+            self._pending_indexing[request.request_id] = (
+                request,
+                num_full_blocks_before,
+            )
 
         return result
 
@@ -505,14 +516,26 @@ class RBLNKVCacheManager(KVCacheManager):
                 [self.block_pool.blocks[op.src_block_id] for op in ops]
             )
 
+    def do_pending_indexing(self) -> None:
+        """Index sub-blocks for requests whose indexing was deferred.
+
+        Must be called **after** execute_model so that the new KV data is
+        written before the index entries become visible to subsequent
+        scheduling steps.
+        """
+        for request, num_full_blocks_before in self._pending_indexing.values():
+            self._index_newly_cached_blocks(request, num_full_blocks_before)
+        self._pending_indexing.clear()
+
     def free(self, request: Request) -> None:
         """Free blocks and clean up sub-block state for a request."""
         # Before freeing, cache the last partial block's sub-blocks in the
         # index so future requests can reuse them via sub-block matching.
         self._index_partial_block(request)
 
-        # Clean up request sub-hash cache.
+        # Clean up request states
         del self._req_sub_hashes[request.request_id]
+        self._pending_indexing.pop(request.request_id, None)
         super().free(request)
 
     def reset_prefix_cache(self) -> bool:
@@ -521,6 +544,7 @@ class RBLNKVCacheManager(KVCacheManager):
         if result:
             for gi in self._group_infos:
                 gi.sub_block_index = SubBlockIndex()
+            self._pending_indexing.clear()
         return result
 
     # -- sub-block hash helpers ---------------------------------------------

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -143,10 +143,7 @@ class SubBlockHasher:
 
 class SubBlockIndex:
     """Index mapping sub-block hashes to physical block IDs that contain that
-    sub-block as a prefix.
-
-    Invariant: cached ↔ indexed.
-    """
+    sub-block as a prefix."""
 
     def __init__(self) -> None:
         # sub_block_hash → set of block IDs with that prefix cached.
@@ -154,11 +151,16 @@ class SubBlockIndex:
         # Reverse index: block_id → list of sub-block hashes (for removal).
         self._block_hashes: dict[int, list[BlockHash]] = {}
 
-    def insert(self, block_id: int, sub_block_hashes: list[BlockHash]) -> None:
-        """Index a block's sub-block hashes."""
-        assert block_id not in self._block_hashes
-        self._block_hashes[block_id] = sub_block_hashes
-        for h in sub_block_hashes:
+    def update(self, block_id: int, sub_block_hashes: list[BlockHash]) -> None:
+        """Index or extend a block's sub-block hashes (idempotent).
+
+        If the block is not yet indexed, inserts all hashes.
+        If already indexed, appends any new hashes beyond what is recorded.
+        """
+        existing = self._block_hashes.setdefault(block_id, [])
+        for i in range(len(existing), len(sub_block_hashes)):
+            h = sub_block_hashes[i]
+            existing.append(h)
             self._hash_to_blocks.setdefault(h, set()).add(block_id)
 
     def pop(self, block_id: int) -> None:
@@ -519,23 +521,28 @@ class RBLNKVCacheManager(KVCacheManager):
     def do_pending_indexing(self) -> None:
         """Index sub-blocks for requests whose indexing was deferred.
 
-        Must be called **after** execute_model so that the new KV data is
-        written before the index entries become visible to subsequent
-        scheduling steps.
+        Must be called **after** ``super().update_from_output()`` so that
+        ``num_computed_tokens`` is up-to-date and ``free()`` has already
+        consumed its own pending entries.
         """
         for request, num_full_blocks_before in self._pending_indexing.values():
             self._index_newly_cached_blocks(request, num_full_blocks_before)
+            self._index_partial_block(request, False)
         self._pending_indexing.clear()
 
     def free(self, request: Request) -> None:
-        """Free blocks and clean up sub-block state for a request."""
-        # Before freeing, cache the last partial block's sub-blocks in the
-        # index so future requests can reuse them via sub-block matching.
-        self._index_partial_block(request)
+        """Index any not-yet-indexed sub-blocks, free blocks, and clean up
+        sub-block state for the request."""
+        # Consume this request's pending indexing entry and index all blocks
+        # (full + partial) before releasing them.
+        pending = self._pending_indexing.pop(request.request_id, None)
+        if pending is not None:
+            _, num_full_blocks_before = pending
+            self._index_newly_cached_blocks(request, num_full_blocks_before)
+        self._index_partial_block(request, True)
 
         # Clean up request states
         del self._req_sub_hashes[request.request_id]
-        self._pending_indexing.pop(request.request_id, None)
         super().free(request)
 
     def reset_prefix_cache(self) -> bool:
@@ -588,10 +595,9 @@ class RBLNKVCacheManager(KVCacheManager):
                 # NOTE: For a new request, num_full_blocks_before is zero
                 # because num_computed_tokens is set after scheduling.
                 # So this doesn't tell us which blocks are newly cached.
-                # So we also check that the block is not already indexed.
-                if blk.block_hash is not None and not gi.sub_block_index.contains(
-                    blk.block_id
-                ):
+                # _on_block_cached uses update() which is idempotent,
+                # so re-processing already-indexed blocks is fine.
+                if blk.block_hash is not None:
                     self._on_block_cached(request, blk_idx, blk, gi)
 
     def _on_block_cached(
@@ -609,11 +615,15 @@ class RBLNKVCacheManager(KVCacheManager):
         if sub_end <= sub_start:
             return
         blk_sub_hashes = sub_hashes[sub_start:sub_end]
-        gi.sub_block_index.insert(blk.block_id, blk_sub_hashes)
+        gi.sub_block_index.update(blk.block_id, blk_sub_hashes)
 
-    def _index_partial_block(self, request: Request) -> None:
-        """Index sub-blocks of the last partial block per group
-        and mark it as cached so the upstream LRU preserves it."""
+    def _index_partial_block(self, request: Request, mark_cached: bool) -> None:
+        """Index sub-blocks of the last partial block per group.
+
+        Args:
+            mark_cached: Whether to assign a synthetic ``block_hash`` so the
+                upstream LRU preserves the block.
+        """
         num_computed_tokens = request.num_computed_tokens
         sub_hashes = self._get_or_compute_sub_hashes(request)
         blocks = self.coordinator.get_blocks(request.request_id)
@@ -641,24 +651,25 @@ class RBLNKVCacheManager(KVCacheManager):
             partial_sub_hashes = sub_hashes[sub_start:sub_end]
 
             # Index in the group's sub-block index.
-            gi.sub_block_index.insert(blk.block_id, partial_sub_hashes)
+            gi.sub_block_index.update(blk.block_id, partial_sub_hashes)
 
-            # Give the block a synthetic block_hash so the upstream block pool
-            # keeps it in the LRU cache instead of immediately reusing it.
-            # The actual value doesn't matter as long as it's unique so that it
-            # doesn't collide with any real full-block hash.
-            synthetic_hash = make_block_hash_with_group_id(
-                BlockHash(
-                    b"partial_block_"
-                    + str(blk.block_id).encode("ascii")
-                    + b"_"
-                    + partial_sub_hashes[-1]
-                ),
-                gid,
-            )
-            assert blk.block_hash is None
-            blk.block_hash = synthetic_hash
-            self.block_pool.cached_block_hash_to_block.insert(synthetic_hash, blk)
+            if mark_cached:
+                # Give the block a synthetic block_hash so the upstream block pool
+                # keeps it in the LRU cache instead of immediately reusing it.
+                # The actual value doesn't matter as long as it' unique so that it
+                # doesn't collide with any real full-block hash.
+                synthetic_hash = make_block_hash_with_group_id(
+                    BlockHash(
+                        b"partial_block_"
+                        + str(blk.block_id).encode("ascii")
+                        + b"_"
+                        + partial_sub_hashes[-1]
+                    ),
+                    gid,
+                )
+                assert blk.block_hash is None
+                blk.block_hash = synthetic_hash
+                self.block_pool.cached_block_hash_to_block.insert(synthetic_hash, blk)
 
     def _on_block_evicted(self, block_id: int) -> None:
         """Called when a block is evicted — remove from index."""

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -180,11 +180,16 @@ class SubBlockIndex:
 
 
 @dataclass(slots=True)
-class _PendingPartialMatch:
-    """Temporary state between get_computed_blocks and allocate_slots.
-    Owns references to source blocks to prevent eviction during scheduling."""
+class SubBlockMatch:
+    """Result of a sub-block partial match lookup.
 
-    request_id: str
+    Returned by ``RBLNKVCacheManager.get_computed_blocks_sub_block``.
+    The caller must either pass it to ``apply_sub_block_match`` (to create
+    copy ops) or ``release_sub_block_match`` (to discard it and free the
+    source-block references).
+    """
+
+    num_tokens: int
     num_matched_sub_blocks: int
     group_matches: tuple[_GroupPartialMatch, ...]
 
@@ -279,10 +284,6 @@ class RBLNKVCacheManager(KVCacheManager):
         # Per-request sub-block hash cache (group-independent).
         self._req_sub_hashes: dict[str, list[BlockHash]] = {}
 
-        # Pending partial match state (set by get_computed_blocks, consumed
-        # by allocate_slots).
-        self._pending_partial: _PendingPartialMatch | None = None
-
         # Copy operations accumulated during a scheduling step; the scheduler
         # drains this list when building SchedulerOutput. While pending, each
         # copy op holds a ref count of its source block to prevent eviction.
@@ -290,24 +291,24 @@ class RBLNKVCacheManager(KVCacheManager):
 
         self._install_eviction_hook()
 
-    # -- overrides ----------------------------------------------------------
+    def get_computed_blocks_sub_block(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> SubBlockMatch | None:
+        """Discover a sub-block partial match after full-block matching.
 
-    def get_computed_blocks(self, request: Request) -> tuple[KVCacheBlocks, int]:
-        # Release any stale pending partial from a prior get_computed_blocks
-        # that was never followed by allocate_slots (e.g. scheduler skipped
-        # the request via continue/break).
-        if self._pending_partial is not None:
-            self._release_pending_partial(self._pending_partial)
-            self._pending_partial = None
+        Looks for sub-block prefix matches in the block immediately after the
+        full-block boundary.  Returns a ``SubBlockMatch`` handle if found, or
+        ``None``.
 
+        The caller must pass the result to ``apply_sub_block_match`` (to
+        create copy ops) or ``release_sub_block_match`` (to free the
+        source-block references it holds).
+        """
         if request.skip_reading_prefix_cache:
-            return self.empty_kv_cache_blocks, 0
+            return None
 
-        # Step 1: upstream full-block matching.
-        computed_blocks, num_computed_tokens = super().get_computed_blocks(request)
-
-        # Step 2: check for partial sub-block match in the next block
-        # across all groups. Extension = min across groups.
         sub_hashes = self._get_or_compute_sub_hashes(request)
 
         min_matched: int | None = None
@@ -342,7 +343,7 @@ class RBLNKVCacheManager(KVCacheManager):
             )
 
         if not min_matched:
-            return computed_blocks, num_computed_tokens
+            return None
 
         # We have a partial match!
         num_matched = min_matched
@@ -355,15 +356,14 @@ class RBLNKVCacheManager(KVCacheManager):
         max_allowed_sub_blocks = max_allowed_extra_tokens // self.sub_block_size
         num_matched = min(num_matched, max_allowed_sub_blocks)
         if num_matched == 0:
-            return computed_blocks, num_computed_tokens
+            return None
         extra_tokens = num_matched * self.sub_block_size
 
         # Touch source blocks to prevent eviction during allocate_slots.
-        # _PendingPartialMatch owns these references.
-        # This also lowers their eviction priority.
+        # The SubBlockMatch owns these references until apply or release.
         self.block_pool.touch([gm.src_block for gm in group_matches])
-        self._pending_partial = _PendingPartialMatch(
-            request_id=request.request_id,
+        match = SubBlockMatch(
+            num_tokens=extra_tokens,
             num_matched_sub_blocks=num_matched,
             group_matches=tuple(group_matches),
         )
@@ -380,7 +380,49 @@ class RBLNKVCacheManager(KVCacheManager):
                 ),
             )
 
-        return computed_blocks, num_computed_tokens + extra_tokens
+        return match
+
+    def apply_sub_block_match(
+        self,
+        match: SubBlockMatch,
+        request: Request,
+    ) -> None:
+        """Create copy ops from a sub-block match.
+
+        Call this after ``allocate_slots`` succeeds. The source-block refs
+        owned by *match* are transferred to the pending copy ops (released
+        by ``drain_pending_copy_ops``).
+        """
+        blocks = self.coordinator.get_blocks(request.request_id)
+
+        for i, gm in enumerate(match.group_matches):
+            block_list = blocks[i]
+            # By this point, the destination block must have been allocated.
+            dst_block = block_list[gm.dst_block_index]
+            self.pending_copy_ops.append(
+                KVCacheCopyOp(
+                    group_id=i,
+                    src_block_id=gm.src_block_id,
+                    dst_block_id=dst_block.block_id,
+                    num_tokens=match.num_tokens,
+                )
+            )
+
+        if self.log_stats:
+            assert self.prefix_cache_stats is not None
+            self.prefix_cache_stats.record(
+                num_tokens=0,  # already counted in get_computed_blocks
+                num_hits=match.num_tokens,
+                preempted=request.num_preemptions > 0,
+            )
+
+    def release_sub_block_match(self, match: SubBlockMatch) -> None:
+        """Release source-block references held by a sub-block match.
+
+        Call this when discarding a match (e.g. connector provides better
+        coverage, or allocation failed).
+        """
+        self.block_pool.free_blocks([gm.src_block for gm in match.group_matches])
 
     def allocate_slots(
         self,
@@ -393,10 +435,6 @@ class RBLNKVCacheManager(KVCacheManager):
         delay_cache_blocks: bool = False,
         num_encoder_tokens: int = 0,
     ) -> KVCacheBlocks | None:
-        # Consume the pending partial match, releasing it if it doesn't
-        # belong to this request (stale from a skipped request).
-        partial = self._take_pending_partial(request.request_id)
-
         num_full_blocks_before = tuple(
             request.num_computed_tokens // gi.block_size for gi in self._group_infos
         )
@@ -412,17 +450,20 @@ class RBLNKVCacheManager(KVCacheManager):
             num_encoder_tokens,
         )
 
-        if result is None:
-            if partial is not None:
-                self._release_pending_partial(partial)
-            return None
-
-        self._index_newly_cached_blocks(request, num_full_blocks_before)
-
-        if partial is not None:
-            self._apply_partial(partial, request)
+        if result is not None:
+            self._index_newly_cached_blocks(request, num_full_blocks_before)
 
         return result
+
+    def drain_pending_copy_ops(self) -> list[KVCacheCopyOp]:
+        """Return and clear all pending copy operations, releasing source block refs."""
+        ops = self.pending_copy_ops
+        self.pending_copy_ops = []
+        if ops:
+            self.block_pool.free_blocks(
+                [self.block_pool.blocks[op.src_block_id] for op in ops]
+            )
+        return ops
 
     def free(self, request: Request) -> None:
         """Free blocks and clean up sub-block state for a request."""
@@ -567,56 +608,3 @@ class RBLNKVCacheManager(KVCacheManager):
             return result
 
         self.block_pool._maybe_evict_cached_block = evict_with_index_cleanup
-
-    # -- pending partial match & copy ops lifecycle --------------------------
-
-    def _take_pending_partial(self, request_id: str) -> _PendingPartialMatch | None:
-        """Consume the pending partial match. If it belongs to a different
-        request (stale), release its source block and return None."""
-        partial = self._pending_partial
-        self._pending_partial = None
-        if partial is not None and partial.request_id != request_id:
-            self._release_pending_partial(partial)
-            return None
-        return partial
-
-    def _apply_partial(self, partial: _PendingPartialMatch, request: Request) -> None:
-        """Create copy ops from the partial match, one per group."""
-        blocks = self.coordinator.get_blocks(request.request_id)
-        num_matched_tokens = partial.num_matched_sub_blocks * self.sub_block_size
-
-        for i, gm in enumerate(partial.group_matches):
-            block_list = blocks[i]
-            # By this point, the destination block must have been allocated
-            dst_block = block_list[gm.dst_block_index]
-            self.pending_copy_ops.append(
-                # Ownership of src_block ref is transferred to KVCacheCopyOp
-                KVCacheCopyOp(
-                    group_id=i,
-                    src_block_id=gm.src_block_id,
-                    dst_block_id=dst_block.block_id,
-                    num_tokens=num_matched_tokens,
-                )
-            )
-
-        if self.log_stats:
-            assert self.prefix_cache_stats is not None
-            self.prefix_cache_stats.record(
-                num_tokens=0,  # already counted in get_computed_blocks
-                num_hits=num_matched_tokens,
-                preempted=request.num_preemptions > 0,
-            )
-
-    def _release_pending_partial(self, partial: _PendingPartialMatch) -> None:
-        """Release source block references held by a partial match."""
-        self.block_pool.free_blocks([gm.src_block for gm in partial.group_matches])
-
-    def drain_pending_copy_ops(self) -> list[KVCacheCopyOp]:
-        """Return and clear all pending copy operations, releasing source block refs."""
-        ops = self.pending_copy_ops
-        self.pending_copy_ops = []
-        if ops:
-            self.block_pool.free_blocks(
-                [self.block_pool.blocks[op.src_block_id] for op in ops]
-            )
-        return ops

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -27,8 +27,10 @@ from typing import TYPE_CHECKING
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
+    generate_block_hash_extra_keys,
     hash_block_tokens,
     make_block_hash_with_group_id,
+    need_extra_keys,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
@@ -73,7 +75,9 @@ class SubBlockHasher:
     """Computes chained sub-block hashes from token IDs.
 
     Uses the same ``hash_block_tokens`` as upstream, but at sub-block
-    granularity.
+    granularity.  When a *request* is provided, per-sub-block
+    ``extra_keys`` (cache_salt, LoRA, multimodal, prompt_embeds) are
+    mixed in, mirroring upstream full-block hashing.
     """
 
     def __init__(
@@ -90,7 +94,9 @@ class SubBlockHasher:
         *,
         parent_hash: BlockHash | None = None,
         num_hashed_tokens: int = 0,
-    ) -> list[BlockHash]:
+        request: Request | None = None,
+        start_mm_idx: int = 0,
+    ) -> tuple[list[BlockHash], int]:
         """Return sub-block hashes for *full* sub-blocks in ``token_ids``.
 
         Args:
@@ -99,22 +105,40 @@ class SubBlockHasher:
                 are hashing (``None`` for the very first sub-block).
             num_hashed_tokens: Number of tokens already hashed (i.e. the
                 start offset into ``token_ids``).
+            request: When provided and the request carries extra hash
+                keys (LoRA, cache_salt, multimodal, prompt_embeds),
+                those keys are mixed into each sub-block hash.
+            start_mm_idx: Starting multimodal feature index for
+                incremental hashing with multimodal requests.
 
         Returns:
-            List of ``BlockHash`` values, one per full sub-block starting
-            from ``num_hashed_tokens``.
+            ``(hashes, mm_idx)`` — list of ``BlockHash`` values (one
+            per full sub-block) and the updated multimodal index.
         """
+        # Based on upstream request_block_hasher() in get_request_block_hasher().
+
         sbs = self.sub_block_size
         hashes: list[BlockHash] = []
+        use_extra = request is not None and need_extra_keys(request)
+        # NOTE: We can't simply use `mm_idx=-1`,
+        # because it means the last mm input in the entire prompt,
+        # which is meant to be used during decode phase.
+        mm_idx = start_mm_idx
         start = num_hashed_tokens
         for i in range(start, len(token_ids) - sbs + 1, sbs):
+            extra_keys = None
+            if use_extra:
+                extra_keys, mm_idx = generate_block_hash_extra_keys(
+                    request, i, i + sbs, mm_idx
+                )
             parent_hash = hash_block_tokens(
                 self.hash_fn,
                 parent_hash,
                 token_ids[i : i + sbs],
+                extra_keys,
             )
             hashes.append(parent_hash)
-        return hashes
+        return hashes, mm_idx
 
 
 class SubBlockIndex:
@@ -177,6 +201,14 @@ class SubBlockIndex:
 # ---------------------------------------------------------------------------
 # RBLNKVCacheManager
 # ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _SubHashState:
+    """Per-request cached sub-block hashes and multimodal index."""
+
+    hashes: list[BlockHash]
+    mm_idx: int = 0
 
 
 @dataclass(slots=True)
@@ -282,7 +314,7 @@ class RBLNKVCacheManager(KVCacheManager):
         self.sub_block_hasher = SubBlockHasher(hash_fn, sub_block_size)
 
         # Per-request sub-block hash cache (group-independent).
-        self._req_sub_hashes: dict[str, list[BlockHash]] = {}
+        self._req_sub_hashes: dict[str, _SubHashState] = {}
 
         # Copy operations accumulated during a scheduling step; the scheduler
         # drains this list when building SchedulerOutput. While pending, each
@@ -496,18 +528,25 @@ class RBLNKVCacheManager(KVCacheManager):
     def _get_or_compute_sub_hashes(self, request: Request) -> list[BlockHash]:
         """Return the sub-block hashes for the request, computing new ones if
         the request has grown since the last call.  Group-independent."""
-        cached_hashes = self._req_sub_hashes.setdefault(request.request_id, [])
-        num_hashed_tokens = len(cached_hashes) * self.sub_block_size
-        parent_hash = cached_hashes[-1] if cached_hashes else None
+        state = self._req_sub_hashes.get(request.request_id)
+        if state is None:
+            state = _SubHashState(hashes=[])
+            self._req_sub_hashes[request.request_id] = state
 
-        new_hashes = self.sub_block_hasher.hash_tokens(
+        num_hashed_tokens = len(state.hashes) * self.sub_block_size
+        parent_hash = state.hashes[-1] if state.hashes else None
+
+        new_hashes, new_mm_idx = self.sub_block_hasher.hash_tokens(
             request.all_token_ids,
             parent_hash=parent_hash,
             num_hashed_tokens=num_hashed_tokens,
+            request=request,
+            start_mm_idx=state.mm_idx,
         )
         if new_hashes:
-            cached_hashes.extend(new_hashes)
-        return cached_hashes
+            state.hashes.extend(new_hashes)
+            state.mm_idx = new_mm_idx
+        return state.hashes
 
     # -- sub-block index maintenance ----------------------------------------
 

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -223,8 +223,8 @@ class SubBlockMatch:
     source-block references).
     """
 
+    request: Request
     num_tokens: int
-    num_matched_sub_blocks: int
     group_matches: tuple[_GroupPartialMatch, ...]
 
 
@@ -232,11 +232,10 @@ class SubBlockMatch:
 class _GroupPartialMatch:
     """Per-group partial match info."""
 
-    src_block_id: int
     src_block: KVCacheBlock
     # Index of the block (in the request's block list) that will receive
     # the copied sub-blocks.
-    dst_block_index: int
+    dst_req_block_index: int
 
 
 @dataclass(slots=True)
@@ -375,9 +374,8 @@ class RBLNKVCacheManager(KVCacheManager):
 
             group_matches.append(
                 _GroupPartialMatch(
-                    src_block_id=src_block_id,
                     src_block=self.block_pool.blocks[src_block_id],
-                    dst_block_index=num_full_blocks,
+                    dst_req_block_index=num_full_blocks,
                 )
             )
 
@@ -402,8 +400,8 @@ class RBLNKVCacheManager(KVCacheManager):
         # The SubBlockMatch owns these references until apply or release.
         self.block_pool.touch([gm.src_block for gm in group_matches])
         match = SubBlockMatch(
+            request=request,
             num_tokens=extra_tokens,
-            num_matched_sub_blocks=num_matched,
             group_matches=tuple(group_matches),
         )
 
@@ -414,34 +412,31 @@ class RBLNKVCacheManager(KVCacheManager):
                 num_matched,
                 extra_tokens,
                 ", ".join(
-                    f"group {i} from block {gm.src_block_id}"
+                    f"group {i} from block {gm.src_block.block_id}"
                     for i, gm in enumerate(group_matches)
                 ),
             )
 
         return match
 
-    def apply_sub_block_match(
-        self,
-        match: SubBlockMatch,
-        request: Request,
-    ) -> None:
+    def apply_sub_block_match(self, match: SubBlockMatch) -> None:
         """Create copy ops from a sub-block match.
 
         Call this after ``allocate_slots`` succeeds. The source-block refs
         owned by *match* are transferred to the pending copy ops (released
         by ``release_copy_ops``).
         """
+        request = match.request
         blocks = self.coordinator.get_blocks(request.request_id)
 
         for i, gm in enumerate(match.group_matches):
             block_list = blocks[i]
             # By this point, the destination block must have been allocated.
-            dst_block = block_list[gm.dst_block_index]
+            dst_block = block_list[gm.dst_req_block_index]
             self.pending_copy_ops.append(
                 KVCacheCopyOp(
                     group_id=i,
-                    src_block_id=gm.src_block_id,
+                    src_block_id=gm.src_block.block_id,
                     dst_block_id=dst_block.block_id,
                     num_tokens=match.num_tokens,
                 )

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -903,20 +903,20 @@ class RBLNScheduler(Scheduler):
         model_runner_output: ModelRunnerOutput,
     ) -> dict[int, EngineCoreOutputs]:
         assert isinstance(scheduler_output, RBLNSchedulerOutput)
+        result = super().update_from_output(scheduler_output, model_runner_output)
+
         if isinstance(self.kv_cache_manager, RBLNKVCacheManager):
-            # Index sub-blocks now that execute_model has written KV data,
-            # which is safe for copy for later steps.
+            # Now that execute_model has written KV data and
+            # super().update_from_output() has updated num_computed_tokens
+            # (and freed finished requests), index sub-blocks for the
+            # remaining running requests and release copy-op source refs.
             self.kv_cache_manager.do_pending_indexing()
-            # Release source-block refs from this step's copy ops now that the
-            # model runner has finished copying.  This is safe for async
-            # scheduling because update_from_output is called only after the
-            # execution future completes.
             if scheduler_output.kv_cache_copy_ops:
                 self.kv_cache_manager.release_copy_ops(
                     scheduler_output.kv_cache_copy_ops
                 )
 
-        return super().update_from_output(scheduler_output, model_runner_output)
+        return result
 
     def _try_sub_block_match(
         self,

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -24,7 +24,8 @@ from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.engine import EngineCoreEventType
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.utils import record_function_or_nullcontext
 
@@ -867,6 +868,9 @@ class RBLNScheduler(Scheduler):
         )
 
         # Drain pending copy ops from the KV cache manager.
+        # Source-block refs are kept alive until update_from_output(),
+        # which runs after the model runner finishes (safe for async
+        # scheduling / pipeline parallelism).
         if isinstance(self.kv_cache_manager, RBLNKVCacheManager):
             scheduler_output.kv_cache_copy_ops = (
                 self.kv_cache_manager.drain_pending_copy_ops()
@@ -892,6 +896,24 @@ class RBLNScheduler(Scheduler):
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
+
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        # Release source-block refs from this step's copy ops now that the
+        # model runner has finished copying.  This is safe for async
+        # scheduling because update_from_output is called only after the
+        # execution future completes.
+        if (
+            isinstance(scheduler_output, RBLNSchedulerOutput)
+            and scheduler_output.kv_cache_copy_ops
+        ):
+            assert isinstance(self.kv_cache_manager, RBLNKVCacheManager)
+            self.kv_cache_manager.release_copy_ops(scheduler_output.kv_cache_copy_ops)
+
+        return super().update_from_output(scheduler_output, model_runner_output)
 
     def _try_sub_block_match(
         self,

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -30,7 +30,11 @@ from vllm.v1.utils import record_function_or_nullcontext
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
-from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp, RBLNKVCacheManager
+from vllm_rbln.v1.core.rbln_kv_cache_manager import (
+    KVCacheCopyOp,
+    RBLNKVCacheManager,
+    SubBlockMatch,
+)
 
 logger = init_logger(__name__)
 
@@ -425,6 +429,7 @@ class RBLNScheduler(Scheduler):
             prefill_token_budget = self.max_num_scheduled_tokens
 
             step_skipped_waiting = create_request_queue(self.policy)
+            sub_block_match = None
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if len(self.running) == self.max_num_running_reqs:
@@ -467,10 +472,12 @@ class RBLNScheduler(Scheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                sub_block_match = None
+                num_sub_block_tokens = 0
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
-                    # Get locally-cached tokens.
+                    # Get locally-cached tokens (full-block matches only).
                     new_computed_blocks, num_new_local_computed_tokens = (
                         self.kv_cache_manager.get_computed_blocks(request)
                     )
@@ -499,9 +506,24 @@ class RBLNScheduler(Scheduler):
                         )
                         connector_prefix_cache_hits = num_external_computed_tokens
 
+                    # NOTE(RBLN): Arbitrate between sub-block match and KV connector.
+                    sub_block_match, num_sub_block_tokens = self._try_sub_block_match(
+                        request,
+                        num_new_local_computed_tokens,
+                        num_external_computed_tokens,
+                    )
+                    if num_sub_block_tokens > 0 and num_external_computed_tokens > 0:
+                        # Cancel the KV connector match in favor of the sub-block match
+                        request.num_external_computed_tokens = 0
+                        num_external_computed_tokens = 0
+                        load_kv_async = False
+                        connector_prefix_cache_hits = 0
+
                     # Total computed tokens (local + external).
                     num_computed_tokens = (
-                        num_new_local_computed_tokens + num_external_computed_tokens
+                        num_new_local_computed_tokens
+                        + num_sub_block_tokens
+                        + num_external_computed_tokens
                     )
                     assert num_computed_tokens <= request.num_tokens
                 else:
@@ -605,7 +627,9 @@ class RBLNScheduler(Scheduler):
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     request.num_tokens - num_computed_tokens,
-                    num_new_computed_tokens=num_new_local_computed_tokens,
+                    num_new_computed_tokens=(
+                        num_new_local_computed_tokens + num_sub_block_tokens
+                    ),
                     new_computed_blocks=new_computed_blocks,
                     num_lookahead_tokens=effective_lookahead_tokens,
                     num_external_computed_tokens=num_external_computed_tokens,
@@ -621,6 +645,14 @@ class RBLNScheduler(Scheduler):
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
                     break
+
+                # NOTE(RBLN): Apply sub-block match now that blocks are
+                # allocated (the destination block exists).
+                if sub_block_match is not None:
+                    self.kv_cache_manager.apply_sub_block_match(
+                        sub_block_match, request
+                    )
+                    sub_block_match = None
 
                 # NOTE(RBLN): By calling allocate_slots with
                 # request.num_tokens - num_computed_tokens instead of num_new_tokens,
@@ -744,6 +776,12 @@ class RBLNScheduler(Scheduler):
                 # NOTE(RBLN): we restrict the prefill batch size to 1 for now.
                 break
 
+            # NOTE(RBLN): Release any un-applied sub-block match from a
+            # break path (budget exhausted, allocation failure, etc.).
+            if sub_block_match is not None:
+                assert isinstance(self.kv_cache_manager, RBLNKVCacheManager)
+                self.kv_cache_manager.release_sub_block_match(sub_block_match)
+
             # re-queue requests skipped in this pass ahead of older skipped items.
             if step_skipped_waiting:
                 self.skipped_waiting.prepend_requests(step_skipped_waiting)
@@ -854,3 +892,31 @@ class RBLNScheduler(Scheduler):
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
+
+    def _try_sub_block_match(
+        self,
+        request: Request,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> tuple[SubBlockMatch | None, int]:
+        """Discover a sub-block match and arbitrate against a KV connector.
+
+        Returns ``(match, extra_tokens)``.
+        When *match* is not ``None`` the caller must later pass it to
+        ``kv_cache_manager.apply_sub_block_match`` or
+        ``kv_cache_manager.release_sub_block_match``.
+        """
+        if not isinstance(self.kv_cache_manager, RBLNKVCacheManager):
+            return None, 0
+
+        match = self.kv_cache_manager.get_computed_blocks_sub_block(
+            request, num_local_computed_tokens
+        )
+        if match is not None and match.num_tokens >= num_external_computed_tokens:
+            # sub-block wins on ties (local copy is cheaper than remote load)
+            return match, match.num_tokens
+
+        # Connector provides better coverage, or no sub-block match at all.
+        if match is not None:
+            self.kv_cache_manager.release_sub_block_match(match)
+        return None, 0

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -902,16 +902,19 @@ class RBLNScheduler(Scheduler):
         scheduler_output: SchedulerOutput,
         model_runner_output: ModelRunnerOutput,
     ) -> dict[int, EngineCoreOutputs]:
-        # Release source-block refs from this step's copy ops now that the
-        # model runner has finished copying.  This is safe for async
-        # scheduling because update_from_output is called only after the
-        # execution future completes.
-        if (
-            isinstance(scheduler_output, RBLNSchedulerOutput)
-            and scheduler_output.kv_cache_copy_ops
-        ):
-            assert isinstance(self.kv_cache_manager, RBLNKVCacheManager)
-            self.kv_cache_manager.release_copy_ops(scheduler_output.kv_cache_copy_ops)
+        assert isinstance(scheduler_output, RBLNSchedulerOutput)
+        if isinstance(self.kv_cache_manager, RBLNKVCacheManager):
+            # Index sub-blocks now that execute_model has written KV data,
+            # which is safe for copy for later steps.
+            self.kv_cache_manager.do_pending_indexing()
+            # Release source-block refs from this step's copy ops now that the
+            # model runner has finished copying.  This is safe for async
+            # scheduling because update_from_output is called only after the
+            # execution future completes.
+            if scheduler_output.kv_cache_copy_ops:
+                self.kv_cache_manager.release_copy_ops(
+                    scheduler_output.kv_cache_copy_ops
+                )
 
         return super().update_from_output(scheduler_output, model_runner_output)
 

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import time
+from dataclasses import dataclass, field
 
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
+from vllm.v1.core.kv_cache_utils import init_none_hash
 from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
@@ -25,9 +28,19 @@ from vllm.v1.engine import EngineCoreEventType
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.utils import record_function_or_nullcontext
 
+import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
+from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp, RBLNKVCacheManager
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class RBLNSchedulerOutput(SchedulerOutput):
+    """SchedulerOutput extended with KV cache copy operations for sub-block
+    prefix caching."""
+
+    kv_cache_copy_ops: list[KVCacheCopyOp] = field(default_factory=list)
 
 
 def is_prefill(request: Request) -> bool:
@@ -59,7 +72,51 @@ def undo_uncomputed_block_caching(
 
 
 class RBLNScheduler(Scheduler):
-    def schedule(self) -> SchedulerOutput:
+    def __init__(
+        self,
+        *args,
+        sub_block_size: int | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Replace the upstream KVCacheManager with RBLNKVCacheManager
+        # when sub-block prefix caching is enabled.
+        # Sub-block size equals the prefill chunk size (max_num_batched_tokens)
+        # so that each prefill does not span multiple blocks.
+        if sub_block_size is None and envs.VLLM_RBLN_SUB_BLOCK_CACHE:
+            sub_block_size = self.scheduler_config.max_num_batched_tokens
+        if (
+            self.cache_config.enable_prefix_caching
+            and sub_block_size
+            and RBLNKVCacheManager.can_use_sub_block_caching(
+                self.kv_cache_config, sub_block_size
+            )
+        ):
+            hash_fn = get_hash_fn_by_name(self.cache_config.prefix_caching_hash_algo)
+            init_none_hash(hash_fn)
+
+            self.kv_cache_manager = RBLNKVCacheManager(
+                kv_cache_config=self.kv_cache_config,
+                max_model_len=self.max_model_len,
+                hash_block_size=self.block_size,
+                sub_block_size=sub_block_size,
+                hash_fn=hash_fn,
+                use_eagle=self.use_eagle,
+                log_stats=self.log_stats,
+                enable_kv_cache_events=self.enable_kv_cache_events,
+                dcp_world_size=self.dcp_world_size,
+                pcp_world_size=self.pcp_world_size,
+                metrics_collector=self.kv_metrics_collector,
+            )
+
+            logger.info(
+                "Sub-block prefix caching enabled: block_size=%d, sub_block_size=%d",
+                self.block_size,
+                sub_block_size,
+            )
+
+    def schedule(self) -> RBLNSchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/v1/core/sched/scheduler.py#L338-L927
         # The only differences are:
         # - Disable mixed batching
@@ -753,7 +810,7 @@ class RBLNScheduler(Scheduler):
             else None
         )
 
-        scheduler_output = SchedulerOutput(
+        scheduler_output = RBLNSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
             num_scheduled_tokens=num_scheduled_tokens,
@@ -770,6 +827,12 @@ class RBLNScheduler(Scheduler):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
         )
+
+        # Drain pending copy ops from the KV cache manager.
+        if isinstance(self.kv_cache_manager, RBLNKVCacheManager):
+            scheduler_output.kv_cache_copy_ops = (
+                self.kv_cache_manager.drain_pending_copy_ops()
+            )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -650,9 +650,7 @@ class RBLNScheduler(Scheduler):
                 # NOTE(RBLN): Apply sub-block match now that blocks are
                 # allocated (the destination block exists).
                 if sub_block_match is not None:
-                    self.kv_cache_manager.apply_sub_block_match(
-                        sub_block_match, request
-                    )
+                    self.kv_cache_manager.apply_sub_block_match(sub_block_match)
                     sub_block_match = None
 
                 # NOTE(RBLN): By calling allocate_slots with

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -67,6 +67,11 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
 
+from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
+
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm.v1.kv_cache_interface import (
@@ -281,6 +286,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if "use_global_ctx" in inspect.signature(CompileContext).parameters:
             compile_ctx_args["use_global_ctx"] = True
         self.compile_context = CompileContext(**compile_ctx_args)
+        self.runtime_holder: list = []
 
         # Sampler
         self.use_rbln_sampler = envs.VLLM_RBLN_SAMPLER
@@ -1445,6 +1451,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
             "mode": "strict",
+            "_runtime_holder": self.runtime_holder,
         }
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             logger.info(
@@ -2651,6 +2658,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         return slot_mappings_by_gid, slot_mappings_by_layer
 
+    def _process_kv_cache_copy_ops(
+        self,
+        copy_ops: "list[KVCacheCopyOp]",
+    ) -> None:
+        if self.model_config.enforce_eager or not envs.VLLM_RBLN_COMPILE_MODEL:
+            for op in copy_ops:
+                for kv_cache in self.kv_caches:
+                    kv_cache[:, op.dst_block_id, :, :, : op.num_tokens, :] = kv_cache[
+                        :, op.src_block_id, :, :, : op.num_tokens, :
+                    ]
+        else:
+            runtime = self.runtime_holder[0]
+            for op in copy_ops:
+                runtime._copy_kv_cache(op.src_block_id, op.dst_block_id, op.num_tokens)
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -2667,6 +2689,15 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("Preprocess"):
             self._update_states(scheduler_output)
+
+            # Process sub-block KV cache copy operations before the forward
+            # pass so that partially cached blocks are populated.
+            if (
+                isinstance(scheduler_output, RBLNSchedulerOutput)
+                and scheduler_output.kv_cache_copy_ops
+            ):
+                self._process_kv_cache_copy_ops(scheduler_output.kv_cache_copy_ops)
+
             if not num_scheduled_tokens:
                 if not has_kv_transfer_group():
                     # Return empty ModelRunnerOutput if there's no work to do.
@@ -4138,8 +4169,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_attn_module,
         )
         if not self.model_config.enforce_eager and envs.VLLM_RBLN_COMPILE_MODEL:
-            for kv_cache in self.kv_caches:
-                self.compile_context.mark_static_address(kv_cache)
+            for i, kv_cache in enumerate(self.kv_caches):
+                self.compile_context.mark_static_address(kv_cache, f"kv_cache_{i}")
 
         return kv_caches
 
@@ -4178,6 +4209,15 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kv_cache_config: Configuration for the KV cache, including the KV
             cache size of each layer
         """
+        if envs.VLLM_RBLN_SUB_BLOCK_CACHE and (
+            len(kv_cache_config.kv_cache_groups) > 1
+        ):
+            raise NotImplementedError(
+                "Sub-block prefix caching does not support "
+                "multi-group KV caches yet.  "
+                "Set VLLM_RBLN_SUB_BLOCK_CACHE=false to disable."
+            )
+
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
         self.may_add_encoder_only_layers_to_kv_cache_config()


### PR DESCRIPTION
## 🚀 Summary of Changes
see the rendered design doc: https://github.com/RBLN-SW/vllm-rbln/blob/ab677e4d49ad9f09b41146cb131922728746c336/docs/sub_block_prefix_caching.md
 
**Configuration**: Default on. Disable with env var `VLLM_RBLN_SUB_BLOCK_CACHE=0`.

---

## 🧪 How to Test

### unit tests
```
pytest tests/torch_compile/v1/core/test_sub_block_prefix_caching.py
```

### e2e example

without sub-block caching (block_size=1024)
```
VLLM_RBLN_SUB_BLOCK_CACHE=0 VLLM_RBLN_SAMPLER=0 VLLM_RBLN_USE_VLLM_MODEL=1 python examples/experimental/prefix_caching.py
```
```
...
Prefix cache hit tokens during cached generate(): 4096
```

with sub-block caching (block_size=1024, sub_block_size=128):
```
VLLM_RBLN_SAMPLER=0 VLLM_RBLN_USE_VLLM_MODEL=1 python examples/experimental/prefix_caching.py
```
```
...
Prefix cache hit tokens during cached generate(): 6144
```
