### PR TITLE
fix: set num_threads in TP=1 & DP=1, and change env variable

### DIFF
--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -194,19 +194,14 @@ class RBLNWorker(WorkerBase):
             self.parallel_config,
         )
 
-        # Only set OMP_NUM_THREADS when TP > 1 or DP > 1
-        if (
-            self.parallel_config.tensor_parallel_size > 1
-            or self.parallel_config.data_parallel_size > 1
-        ):
-            # Use half of allocated CPUs to avoid oversubscription
-            allocated_cpus = len(os.sched_getaffinity(0))
-            num_threads = max(2, allocated_cpus // 2)
-            set_omp_num_threads(
-                self.rank,
-                self.local_rank,
-                num_threads,
-            )
+        # Use half of allocated CPUs to avoid oversubscription
+        allocated_cpus = len(os.sched_getaffinity(0))
+        num_threads = max(2, allocated_cpus // 2)
+        set_omp_num_threads(
+            self.rank,
+            self.local_rank,
+            num_threads,
+        )
 
         # NOTE(RBLN): numba is used throughout vllm code base (especially in spec-dec)
         # however accessing numba thread settings somewhat affects torch

--- a/vllm_rbln/v1/worker/utils.py
+++ b/vllm_rbln/v1/worker/utils.py
@@ -374,18 +374,18 @@ def set_omp_num_threads(
     Args:
         rank: Global rank of the worker.
         local_rank: Local rank of the worker.
-        default_num_threads: Number of threads to use if OMP_NUM_THREADS
+        default_num_threads: Number of threads to use if RBLN_NUM_THREADS
             is not set. Defaults to 2.
     """
     import torch
 
     # Determine the number of threads to use
-    if "OMP_NUM_THREADS" in os.environ:
-        num_threads = int(os.environ["OMP_NUM_THREADS"])
+    if "RBLN_NUM_THREADS" in os.environ:
+        num_threads = int(os.environ["RBLN_NUM_THREADS"])
     else:
         num_threads = default_num_threads
         # Set env var for any future subprocesses
-        os.environ["OMP_NUM_THREADS"] = str(num_threads)
+        os.environ["RBLN_NUM_THREADS"] = str(num_threads)
 
     # Directly set PyTorch's thread count for this process
     torch.set_num_threads(num_threads)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

1. Change num_threads env variable name: use RBLN_NUM_THREADS
2. always set num_threads (even though TP==1 and DP==1)

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
3. Verify output: `...`
4. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
