### PR TITLE
fix: free local block table id in _update_states function

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_manager.py
+++ b/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_manager.py
@@ -74,7 +74,7 @@ class AttentionManager(Generic[StrategyT, EntryT, Result1T, Result2T]):
         self._s.clear()
 
     def pop(self, request_id: str):
-        self._s.table.pop(request_id, None)
+        self._s.pop(request_id)
 
 
 class HybridAttentionImageManager(

--- a/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_manager.py
+++ b/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_manager.py
@@ -73,6 +73,9 @@ class AttentionManager(Generic[StrategyT, EntryT, Result1T, Result2T]):
     def clear(self):
         self._s.clear()
 
+    def pop(self, request_id: str):
+        self._s.table.pop(request_id, None)
+
 
 class HybridAttentionImageManager(
     AttentionManager[

--- a/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_strategy.py
+++ b/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_strategy.py
@@ -76,7 +76,7 @@ class AttentionStrategy(ABC, Generic[EntryT, Result1T, Result2T]):
         self,
         decoder_batch_size: int,
         is_prompt: bool,
-        finished_requests_ids: list[str], # FIXME to be removed
+        finished_requests_ids: list[str],  # FIXME to be removed
         running_requests_ids: list[str],
         get_entry_fn: Callable[[Any], Any] | None = None,
         get_extra_values_fn: Callable[[Any], Union[Any, tuple[Any, ...]]] | None = None,

--- a/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_strategy.py
+++ b/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_strategy.py
@@ -73,26 +73,18 @@ class AttentionStrategy(ABC, Generic[EntryT, Result1T, Result2T]):
         self,
         decoder_batch_size: int,
         is_prompt: bool,
-        finished_requests_ids: list[str],
+        finished_requests_ids: list[str], # FIXME to be removed
         running_requests_ids: list[str],
         get_entry_fn: Callable[[Any], Any] | None = None,
         get_extra_values_fn: Callable[[Any], Union[Any, tuple[Any, ...]]] | None = None,
     ) -> Union[list[int], tuple[list[int], ...]]:
         if is_prompt:
-            if finished_requests_ids:
-                first_id = finished_requests_ids[0]
-                first_entry = self.table[first_id]
-                table_id = get_entry_fn(first_entry) if get_entry_fn else first_entry
-
-                for request_id in finished_requests_ids:
-                    self.table.pop(request_id)
-            else:
-                used_ids = {
-                    get_entry_fn(v) if get_entry_fn else v for v in self.table.values()
-                }
-                available_ids = set(range(decoder_batch_size)) - used_ids
-                assert available_ids, "No available table IDs"
-                table_id = min(available_ids)
+            used_ids = {
+                get_entry_fn(v) if get_entry_fn else v for v in self.table.values()
+            }
+            available_ids = set(range(decoder_batch_size)) - used_ids
+            assert available_ids, "No available table IDs"
+            table_id = min(available_ids)
             return [table_id]
 
         table_ids = []

--- a/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_strategy.py
+++ b/vllm_rbln/model_executor/models/optimum/optimum_attention/optimum_attention_strategy.py
@@ -66,6 +66,9 @@ class AttentionStrategy(ABC, Generic[EntryT, Result1T, Result2T]):
         **kwargs,
     ) -> Result2T: ...
 
+    def pop(self, request_id: str) -> None:
+        self.table.pop(request_id, None)
+
     def clear(self):
         self.table.clear()
 

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -668,6 +668,10 @@ class RBLNOptimumModelRunner(LoRAModelRunnerMixin):
 
             self.requests.pop(req_id, None)
             self.num_prompt_logprobs.pop(req_id, None)
+            # In case of sliding window / hybrid attention models,
+            # free the local block table id managed in the model's attention manager.
+            if getattr(self.model, "attention_manager", None):
+                self.model.attention_manager.pop(req_id)
         # Remove the finished requests from the persistent batch.
         # NOTE(woosuk): There could be an edge case where finished_req_ids and
         # scheduled_req_ids overlap. This happens when a request is aborted and


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

In vllm serve, the local block table IDs of finished requests are not being released within the model code.
These should be explicitly freed in the `_update_states` function, consistent with how the original block table IDs are handled.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
