### PR TITLE
fix: pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dynamic = ["version"]
 dependencies = [
     "setuptools>=64",
@@ -39,6 +39,9 @@ dependencies = [
     "datasets",
     "qwen_vl_utils",
     "vllm==0.13.0+cpu",
+    "torch==2.9.1",
+    "torchvision==0.24.1",
+    "torchaudio==2.9.1",
     "optimum-rbln>=0.10.2a1",
 ]
 
@@ -123,18 +126,19 @@ check_untyped_defs = true
 follow_imports = "silent"
 
 [tool.uv]
-index-strategy = "unsafe-best-match"
-required-environments = [
+environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'"
 ]
 
 [[tool.uv.index]]
 name = "vllm-cpu"
 url = "https://wheels.vllm.ai/0.13.0/cpu"
+explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [tool.uv.sources]
 vllm = { index = "vllm-cpu" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ dependencies = [
     "datasets",
     "qwen_vl_utils",
     "vllm==0.13.0+cpu",
-    "torch==2.9.1",
-    "torchvision==0.24.1",
-    "torchaudio==2.9.1",
+    "torch",
+    "torchvision",
+    "torchaudio",
     "optimum-rbln>=0.10.2a1",
 ]
 


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

## Summary

Fix `pyproject.toml` to resolve `uv sync` failures and clean up index configuration.

## Issues & Fixes

### 1. `markupsafe` installation failure
- **Symptom**: `markupsafe==3.0.3` fetched from pytorch-cpu index, which had no cp312 wheel
- **Cause**: `index-strategy = "unsafe-best-match"` searched all indexes, pulling in pytorch-cpu's markupsafe
- **Fix**: Added `explicit = true` to pytorch-cpu index — only mapped packages use that index

### 2. Removed `unsafe-best-match`
- **Reason**: With `explicit = true` isolating indexes, this strategy is no longer needed
- **Fix**: Removed `index-strategy = "unsafe-best-match"` → defaults to `first-match`

### 3. macOS/darwin resolution failure
- **Symptom**: `uv lock` failed trying to resolve torch for darwin
- **Fix**: Added `environments` to restrict resolution to Linux x86_64 only

### 4. Python 3.14 resolution failure
- **Symptom**: No torchaudio cp314 wheel available
- **Fix**: Set `requires-python = ">=3.10,<3.14"`

### 5. torch/torchvision/torchaudio must remain as direct dependencies
- **Attempt**: Remove them since optimum-rbln already pins versions
- **Failed**: With `explicit = true`, `[tool.uv.sources]` mappings only apply to direct dependencies — transitive deps can't reach pytorch-cpu index
- **`explicit = false` also failed**: `first-match` checks non-default indexes before PyPI, causing cmake and other packages to resolve from pytorch-cpu
- **Fix**: Keep `"torch"`, `"torchvision"`, `"torchaudio"` as unversioned direct dependencies (versions determined by vllm and optimum-rbln)
---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
