### PR TITLE
fix: fix RSD context issue in torch-rbln environment

### DIFF
--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # isort: off
 import inspect
+import os
 import torch
 import torch.nn as nn
 
@@ -166,9 +167,18 @@ class RBLNTopKTopPSampler(nn.Module):
         if envs.VLLM_RBLN_COMPILE_STRICT_MODE:
             options["mode"] = "strict"
 
+        # FIXME: this should be removed after next compiler release
+        if not envs.VLLM_DISABLE_COMPILE_CACHE:
+            logger.info(
+                "Once the model is compiled for the first time, "
+                "the cached compiled binary will be reused."
+            )
+            options["cache_dir"] = os.path.join(envs.VLLM_CACHE_ROOT, "rbln")
+
         if has_torch_rbln:
             options["use_global_ctx"] = True
             options["global_device_id"] = 0
+            options["tensor_parallel_size"] = 1
 
         self._compiled_rbln_topk_topp_sampler = torch.compile(
             rbln_top_k_top_p_sample,

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # isort: off
 import inspect
-import os
 import torch
 import torch.nn as nn
 
@@ -166,14 +165,6 @@ class RBLNTopKTopPSampler(nn.Module):
         }
         if envs.VLLM_RBLN_COMPILE_STRICT_MODE:
             options["mode"] = "strict"
-
-        # FIXME: this should be removed after next compiler release
-        if not envs.VLLM_DISABLE_COMPILE_CACHE:
-            logger.info(
-                "Once the model is compiled for the first time, "
-                "the cached compiled binary will be reused."
-            )
-            options["cache_dir"] = os.path.join(envs.VLLM_CACHE_ROOT, "rbln")
 
         if has_torch_rbln:
             options["use_global_ctx"] = True

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -155,14 +155,15 @@ class RBLNWorker(WorkerBase):
         world_size = self.local_world_size
         env_var = current_platform.device_control_env_var
 
-        total_device_count = world_size * envs.VLLM_RBLN_TP_SIZE
+        rbln_tp_size = envs.VLLM_RBLN_TP_SIZE
+        total_device_count = world_size * rbln_tp_size
 
         if env_var not in os.environ:
             dev_begin = total_device_count * self.parallel_config.data_parallel_rank
             dev_end = dev_begin + total_device_count
             device_ids = [str(i) for i in range(dev_begin, dev_end)]
-            start_idx = self.local_rank * envs.VLLM_RBLN_TP_SIZE
-            end_idx = start_idx + envs.VLLM_RBLN_TP_SIZE
+            start_idx = self.local_rank * rbln_tp_size
+            end_idx = start_idx + rbln_tp_size
             selected_devices = ",".join(device_ids[start_idx:end_idx])
         else:
             device_ids = os.environ[env_var].split(",")
@@ -171,8 +172,8 @@ class RBLNWorker(WorkerBase):
             )
             try:
                 device_id = int(device_ids[self.local_rank])
-                start_idx = device_id * envs.VLLM_RBLN_TP_SIZE
-                end_idx = start_idx + envs.VLLM_RBLN_TP_SIZE
+                start_idx = device_id * rbln_tp_size
+                end_idx = start_idx + rbln_tp_size
                 device_ids = [str(i) for i in range(start_idx, end_idx)]
                 selected_devices = ",".join(device_ids)
             except ValueError as e:
@@ -186,6 +187,9 @@ class RBLNWorker(WorkerBase):
             self.local_rank,
             selected_devices,
         )
+
+        if has_torch_rbln and rbln_tp_size > 1:
+            os.environ["RBLN_NPUS_PER_DEVICE"] = str(rbln_tp_size)
 
     def init_device(self) -> None:
         set_cpu_affinity(


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes
- RSD context
  - set RBLN_NPUS_PER_DEVICE to match VLLM_RBLN_TP_SIZE
- Sampler
  - add an option so that the sampler is compiled as non-RSD even
  when RSD context is used
<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
