### PR TITLE
feature: add E2E performance tracker

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -531,8 +531,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.performance_tracker: PerformanceTracker | None = None
         self.sampler_performance_tracker: PerformanceTracker | None = None
         self.e2e_performance_tracker: PerformanceTracker | None = None
-        self.e2e_start_time = None
-        self.e2e_end_time = None
+        self.e2e_start_time: float = 0.0
+        self.e2e_end_time: float = 0.0
 
         self.dummy_run_state: DummyRunState | None = None
 
@@ -549,8 +549,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.sampler_performance_tracker.register_cleanup()
             self.e2e_performance_tracker = PerformanceTracker("E2E")
             self.e2e_performance_tracker.register_cleanup()
-            self.e2e_start_time = None
-            self.e2e_end_time = None
 
     def _get_positions(self, num_tokens: Any):
         if isinstance(num_tokens, int):
@@ -2969,16 +2967,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kv_connector_output=kv_connector_output,
             num_nans_in_logits=num_nans_in_logits,
         )
-        self.e2e_end_time = time.perf_counter()
 
         if self.e2e_performance_tracker is not None:
+            self.e2e_end_time = time.perf_counter()
             self.collect_metrics(
                 self.e2e_performance_tracker,
                 is_prefills[0],
-                self.e2e_start_time,
-                self.e2e_end_time,
-                [],
-                scheduler_output.total_num_scheduled_tokens,
+                start_time=self.e2e_start_time,
+                end_time=self.e2e_end_time,
+                reports=[],
+                token_count=scheduler_output.total_num_scheduled_tokens,
             )
 
         if not self.use_async_scheduling:

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2723,7 +2723,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         and num_padded_tokens != batch_bucket_size
                     )
                     self.performance_tracker.record_decode(
-                        execution_time,
+                        model_execution_time,
                         num_scheduled_tokens,
                         host_time=host_time,
                         device_time=device_time,
@@ -2925,6 +2925,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 propose_draft_token_ids(sampled_token_ids)
 
         with record_function_or_nullcontext("Bookkeep"):
+            # NOTE:
+            # is_prefill is changed after bookkeeping
+            # so we need to get it before bookkeeping,
+            # and pass it to performance tracker.
+            is_prefills = self.is_prefills()
             (
                 num_nans_in_logits,
                 logprobs_lists,
@@ -2964,11 +2969,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kv_connector_output=kv_connector_output,
             num_nans_in_logits=num_nans_in_logits,
         )
+        self.e2e_end_time = time.perf_counter()
 
         if self.e2e_performance_tracker is not None:
             self.collect_metrics(
                 self.e2e_performance_tracker,
-                self.is_prefills()[0],
+                is_prefills[0],
                 self.e2e_start_time,
                 self.e2e_end_time,
                 [],

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -544,6 +544,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.performance_tracker.register_cleanup()
             self.sampler_performance_tracker = PerformanceTracker("SAMPLER")
             self.sampler_performance_tracker.register_cleanup()
+            self.e2e_performance_tracker = PerformanceTracker("E2E")
+            self.e2e_performance_tracker.register_cleanup()
+            self.e2e_start_time = None
+            self.e2e_end_time = None
 
     def _get_positions(self, num_tokens: Any):
         if isinstance(num_tokens, int):
@@ -1731,7 +1735,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             # use a dummy context manager that does nothing
             capture_ctx = contextlib.nullcontext()
-        start_time = time.perf_counter()
+        sampler_start_time = time.perf_counter()
         with capture_ctx as sampler_reports:
             if spec_decode_metadata is None:
                 sampler_output = self.sampler(
@@ -1752,7 +1756,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.collect_metrics(
                 self.sampler_performance_tracker,
                 self.is_prefills()[0],
-                start_time=start_time,
+                start_time=sampler_start_time,
                 end_time=time.perf_counter(),
                 reports=sampler_reports,
                 token_count=0,
@@ -2496,6 +2500,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         intermediate_tensors: IntermediateTensors | None = None,
         num_padded_tokens: int | None = None,
     ) -> Union[ModelRunnerOutput, IntermediateTensors, None]:
+        self.e2e_start_time = time.perf_counter()
         if self.execute_model_state is not None:
             raise RuntimeError(
                 "State error: sample_tokens() must be called "
@@ -2668,7 +2673,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 LoRAMask.set_lora_mask(lora_mask)
                 LoRAInputs.set_sampler_indices_padded(sampler_indices_padded)
 
-            start_time = time.perf_counter()
+            model_start_time = time.perf_counter()
             with capture_ctx as reports:
                 if not self.use_wrapped_compute_logits():
                     model_output = self.model_executable(
@@ -2689,8 +2694,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
             if self.performance_tracker is not None:
                 # Record performance metrics
-                end_time = time.perf_counter()
-                execution_time = end_time - start_time
+                model_end_time = time.perf_counter()
+                model_execution_time = model_end_time - model_start_time
                 host_time = None
                 device_time = None
                 ccl_time = None
@@ -2702,7 +2707,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
                 if is_prefills[0]:
                     self.performance_tracker.record_prefill(
-                        execution_time,
+                        model_execution_time,
                         num_scheduled_tokens,
                         host_time=host_time,
                         device_time=device_time,
@@ -2959,6 +2964,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         if not self.use_async_scheduling:
             return output
+
+        is_prefills = self.is_prefills()
+        self.collect_metrics(
+            self.e2e_performance_tracker,
+            is_prefills[0],
+            self.e2e_start_time,
+            self.e2e_end_time,
+            [],
+            scheduler_output.total_num_scheduled_tokens,
+        )
 
         return AsyncRBLNModelRunnerOutput(
             model_runner_output=output,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -530,6 +530,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self.performance_tracker: PerformanceTracker | None = None
         self.sampler_performance_tracker: PerformanceTracker | None = None
+        self.e2e_performance_tracker: PerformanceTracker | None = None
+        self.e2e_start_time = None
+        self.e2e_end_time = None
 
         self.dummy_run_state: DummyRunState | None = None
 
@@ -2962,18 +2965,18 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_nans_in_logits=num_nans_in_logits,
         )
 
+        if self.e2e_performance_tracker is not None:
+            self.collect_metrics(
+                self.e2e_performance_tracker,
+                self.is_prefills()[0],
+                self.e2e_start_time,
+                self.e2e_end_time,
+                [],
+                scheduler_output.total_num_scheduled_tokens,
+            )
+
         if not self.use_async_scheduling:
             return output
-
-        is_prefills = self.is_prefills()
-        self.collect_metrics(
-            self.e2e_performance_tracker,
-            is_prefills[0],
-            self.e2e_start_time,
-            self.e2e_end_time,
-            [],
-            scheduler_output.total_num_scheduled_tokens,
-        )
 
         return AsyncRBLNModelRunnerOutput(
             model_runner_output=output,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -479,6 +479,8 @@ class RBLNWorker(WorkerBase):
                 self.model_runner.performance_tracker.print_final_stats()
             if self.model_runner.sampler_performance_tracker:
                 self.model_runner.sampler_performance_tracker.print_final_stats()
+            if self.model_runner.e2e_performance_tracker:
+                self.model_runner.e2e_performance_tracker.print_final_stats()
 
 
 def init_worker_distributed_environment(


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

It shows E2E performance (execute_model ~ sample_tokens).
```
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [rbln_worker.py:476] v1 rbln_worker shutdown called
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:255] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:257] FINAL PERFORMANCE STATISTICS [MODEL]
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:260] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:137] PREFILL METRICS:
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:138]   Total call counts: X
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:139]   Average latency: XX.XX ms
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:141]   Total tokens processed: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:142]   Average throughput: XXX.XX tokens/sec
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:264] ----------------------------------------
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:137] DECODE METRICS:
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:138]   Total call counts: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:139]   Average latency: XX.XX ms
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:141]   Total tokens processed: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:142]   Average throughput: XX.XX tokens/sec
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:268] ----------------------------------------
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:154] PADDED DECODE METRICS: No data recorded
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:272] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:255] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,271 [metrics.py:257] FINAL PERFORMANCE STATISTICS [SAMPLER]
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:260] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:137] PREFILL METRICS:
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:138]   Total call counts: X
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:139]   Average latency: X.XX ms
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:264] ----------------------------------------
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:137] DECODE METRICS:
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:138]   Total call counts: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:139]   Average latency: X.XX ms
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:268] ----------------------------------------
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:154] PADDED DECODE METRICS: No data recorded
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:272] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:255] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:257] FINAL PERFORMANCE STATISTICS [E2E]
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:260] ================================================================================
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:137] PREFILL METRICS:
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:138]   Total call counts: X
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:139]   Average latency: XX.XX ms
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:141]   Total tokens processed: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:142]   Average throughput: XXX.XX tokens/sec
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:264] ----------------------------------------
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:137] DECODE METRICS:
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:138]   Total call counts: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:139]   Average latency: XX.XX ms
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:141]   Total tokens processed: XX
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:142]   Average throughput: XX.XX tokens/sec
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:268] ----------------------------------------
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:154] PADDED DECODE METRICS: No data recorded
[0;36m(EngineCore_DP0 pid=159683)[0;0m [vllm-rbln] INFO 2026-03-20 14:11:55,272 [metrics.py:272] ================================================================================
```

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `set VLLM_RBLN_SAMO`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
