### PR TITLE
fix: don't halve # of cpus twice

### DIFF
--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -198,9 +198,8 @@ class RBLNWorker(WorkerBase):
             self.parallel_config,
         )
 
-        # Use half of allocated CPUs to avoid oversubscription
         allocated_cpus = len(os.sched_getaffinity(0))
-        num_threads = max(2, allocated_cpus // 2)
+        num_threads = max(2, allocated_cpus)
         set_omp_num_threads(
             self.rank,
             self.local_rank,


### PR DESCRIPTION
Problem: set_cpu_affinity already halves the number of cpus for machine with hyperthreading. So halving again results in using only half of physical cores.

Solution: Don't halve again in init_device.