### PR TITLE
fix(scheduler): use prefill_token_budget for new request chunk size

### DIFF
--- a/tests/torch_compile/v1/core/test_scheduler.py
+++ b/tests/torch_compile/v1/core/test_scheduler.py
@@ -88,6 +88,44 @@ def test_schedule_chunked_prefill():
     assert output.num_scheduled_tokens[request.request_id] == 1
 
 
+def test_new_prefill_uses_full_budget_when_decode_running():
+    """When a decode request is running and a new prefill enters, the RBLN
+    scheduler kicks out the decode and gives the full token budget to the
+    prefill.  Before the fix, num_new_tokens was clipped to the
+    already-reduced token_budget (e.g. 127) instead of the restored
+    prefill_token_budget (128), causing an off-by-one in chunk positions.
+    """
+    max_num_batched_tokens = 128
+    scheduler = create_scheduler(
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_num_seqs=4,
+        block_size=16,
+        num_blocks=10000,
+    )
+
+    # First request: short prompt so it finishes prefill in one chunk.
+    req_a = create_requests(num_requests=1, num_tokens=64, req_ids=["A"])[0]
+    scheduler.add_request(req_a)
+
+    # Prefill req_a (64 < 128, fits in one chunk).
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[req_a.request_id] == 64
+    scheduler.update_from_output(output, create_runner_output(output, 1))
+
+    # req_a is now in decode.  Add req_b (long prompt, needs multiple chunks).
+    req_b = create_requests(num_requests=1, num_tokens=500, req_ids=["B"])[0]
+    scheduler.add_request(req_b)
+
+    # Schedule: running loop picks req_a (decode, 1 token), then new-request
+    # loop picks req_b (prefill) and kicks out req_a.
+    output = scheduler.schedule()
+
+    # req_a should have been kicked out (no mixed batching).
+    assert req_a.request_id not in output.num_scheduled_tokens
+    # req_b should get the FULL budget, not budget-minus-1.
+    assert output.num_scheduled_tokens[req_b.request_id] == max_num_batched_tokens
+
+
 def test_preempt_during_execution():
     # Test copied from https://github.com/vllm-project/vllm/blob/4fd9d6a85c00ac0186aa9abbeff73fc2ac6c721e/tests/v1/core/test_scheduler.py#L672-L728
 

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -482,7 +482,14 @@ class RBLNScheduler(Scheduler):
                         # we can stop the scheduling here.
                         break
 
-                    num_new_tokens = min(num_new_tokens, token_budget)
+                    # NOTE(RBLN): Use prefill_token_budget instead of
+                    # token_budget. Running decode requests may have already
+                    # consumed part of token_budget, but they will be kicked
+                    # out when this new prefill is scheduled (see the
+                    # "disable mixed batching" block below), restoring the
+                    # full budget. Using token_budget here would clip the
+                    # first prefill chunk short (e.g. 127 instead of 128).
+                    num_new_tokens = min(num_new_tokens, prefill_token_budget)
                     assert num_new_tokens > 0
 
                     # Schedule encoder inputs.


### PR DESCRIPTION

### 🚀 Summary of Changes
Problem:
When a new prefill request is scheduled, the RBLN scheduler kicks out all running decode requests and restores the full token budget. However, num_new_tokens was clipped using the already-reduced token_budget before the kick-out, causing the first prefill chunk to be short by the number of tokens consumed by decode requests (e.g. 127 instead of 128).

This off-by-one misaligned all subsequent chunk positions, eventually triggering a device runtime abort (SYS_TASK_ABORTED).

Solution:
Use prefill_token_budget instead of token_budget when computing num_new_tokens for new prefill requests.

### 🧪 How to Test
```
pytest tests/torch_compile/v1/core/test_scheduler.py::test_new_prefill_uses_full_budget_when_decode_running
```