### PR TITLE
other: ignore minor error in prefix cache example script

### DIFF
--- a/examples/experimental/prefix_caching.py
+++ b/examples/experimental/prefix_caching.py
@@ -233,7 +233,12 @@ def main():
 
     # Destroy the LLM object and free up the GPU memory.
     del regular_llm
-    cleanup_dist_env_and_memory()
+    try:
+        cleanup_dist_env_and_memory()
+    except RuntimeError as e:
+        # ignore error when not using torch-rbln
+        if "Cannot access accelerator device when none is available" not in str(e):
+            raise
 
     # Create an LLM with prefix caching enabled.
     args.enable_prefix_caching = True


### PR DESCRIPTION
### 🚀 Summary of Changes
vllm 0.18 does torch.accelerator.empty_cache(), which fails if
torch-rbln is not installed. This is not a critical issue for this
example script.


### 🧪 How to Test

```
VLLM_RBLN_USE_VLLM_MODEL=1 VLLM_RBLN_SAMPLER=0 python examples/experimental/prefix_caching.py
```
