### PR TITLE
fix: use container-aware thread count to avoid host op performance degradation in pods

### DIFF
--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -112,7 +112,9 @@ class RBLNOptimumWorker(WorkerBase):
                 "Skipping set_cpu_affinity, setting threads to %d.",
                 allocated_cpus, reported_cpus, allocated_cpus,
             )
-            set_omp_num_threads(self.rank, self.local_rank, allocated_cpus)
+            allocated_cpus = len(os.sched_getaffinity(0))
+            num_threads = allocated_cpus // 2  # physical cores only, skip HT
+            set_omp_num_threads(self.rank, self.local_rank, max(2, num_threads))
         else:
             # Bare metal: use NUMA-aware binding
             set_cpu_affinity(self.rank, self.local_rank, self.parallel_config)

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from contextlib import nullcontext
 from types import NoneType
 from typing import Any
 
+import numba
 import torch
 import torch.distributed
 import torch.nn as nn
@@ -38,6 +40,7 @@ from vllm_rbln.logger import init_logger
 from vllm_rbln.utils.optimum.cache_blocks import sync_num_blocks
 from vllm_rbln.utils.optimum.rbln_params import get_rbln_params
 from vllm_rbln.v1.worker.optimum_model_runner import RBLNOptimumModelRunner
+from vllm_rbln.v1.worker.utils import set_cpu_affinity, set_omp_num_threads
 
 logger = init_logger(__name__)
 
@@ -96,6 +99,28 @@ class RBLNOptimumWorker(WorkerBase):
             self.profiler = None
 
     def init_device(self) -> None:
+        set_cpu_affinity(
+            self.rank,
+            self.local_rank,
+            self.parallel_config,
+        )
+
+        allocated_cpus = len(os.sched_getaffinity(0))
+        num_threads = max(2, allocated_cpus // 2)
+        set_omp_num_threads(
+            self.rank,
+            self.local_rank,
+            num_threads,
+        )
+
+        # NOTE(RBLN): numba is used throughout vllm code base (especially in spec-dec)
+        # however accessing numba thread settings somewhat affects torch
+        # thread settings and cause global state change leading to recompilation.
+        # Thus the only solution for now is to set both thread settings to identical
+        # value in correct order like below
+        numba.set_num_threads(torch.get_num_threads())
+        torch.set_num_threads(numba.get_num_threads())
+
         # Initialize the distributed environment.
         init_worker_distributed_environment(
             self.vllm_config, self.rank, self.distributed_init_method, self.local_rank

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -109,7 +109,9 @@ class RBLNOptimumWorker(WorkerBase):
                 "Container cpuset detected (%d/%d CPUs). "
                 "Skipping set_cpu_affinity, setting threads to %d "
                 "(physical cores only, excluding HT).",
-                allocated_cpus, reported_cpus, num_threads,
+                allocated_cpus,
+                reported_cpus,
+                num_threads,
             )
 
             # Set all thread pool environment variables

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -103,7 +103,6 @@ class RBLNOptimumWorker(WorkerBase):
         reported_cpus = os.cpu_count() or allocated_cpus
 
         if allocated_cpus < reported_cpus:
-            # Container: K8s cpuset already configured, don't override affinity.
             # Use physical cores only (exclude HT siblings).
             num_threads = max(2, allocated_cpus // 2)
             logger.info(

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -105,19 +105,15 @@ class RBLNOptimumWorker(WorkerBase):
             self.parallel_config,
         )
 
+        # set_cpu_affinity already selects physical cores only (no HT)
+        # so use the full affinity count
         allocated_cpus = len(os.sched_getaffinity(0))
-        num_threads = max(2, allocated_cpus // 2)
         set_omp_num_threads(
             self.rank,
             self.local_rank,
-            num_threads,
+            max(2, allocated_cpus),
         )
 
-        # NOTE(RBLN): numba is used throughout vllm code base (especially in spec-dec)
-        # however accessing numba thread settings somewhat affects torch
-        # thread settings and cause global state change leading to recompilation.
-        # Thus the only solution for now is to set both thread settings to identical
-        # value in correct order like below
         numba.set_num_threads(torch.get_num_threads())
         torch.set_num_threads(numba.get_num_threads())
 

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -101,29 +101,40 @@ class RBLNOptimumWorker(WorkerBase):
     def init_device(self) -> None:
         allocated_cpus = len(os.sched_getaffinity(0))
         reported_cpus = os.cpu_count() or allocated_cpus
-        logger.info(
-            "DEBUG: allocated_cpus=%d, reported_cpus=%d",
-            allocated_cpus, reported_cpus,
-        )
+
         if allocated_cpus < reported_cpus:
-            # Container: K8s cpuset already configured, don't override
+            # Container: K8s cpuset already configured, don't override affinity.
+            # Use physical cores only (exclude HT siblings).
+            num_threads = max(2, allocated_cpus // 2)
             logger.info(
                 "Container cpuset detected (%d/%d CPUs). "
-                "Skipping set_cpu_affinity, setting threads to %d.",
-                allocated_cpus, reported_cpus, allocated_cpus,
+                "Skipping set_cpu_affinity, setting threads to %d "
+                "(physical cores only, excluding HT).",
+                allocated_cpus, reported_cpus, num_threads,
             )
-            allocated_cpus = len(os.sched_getaffinity(0))
-            num_threads = allocated_cpus // 2  # physical cores only, skip HT
-            set_omp_num_threads(self.rank, self.local_rank, max(2, num_threads))
+
+            # Set all thread pool environment variables
+            os.environ["OMP_NUM_THREADS"] = str(num_threads)
+            os.environ["MKL_NUM_THREADS"] = str(num_threads)
+            os.environ["OPENBLAS_NUM_THREADS"] = str(num_threads)
+            os.environ["NUMEXPR_MAX_THREADS"] = str(num_threads)
+            os.environ["RBLN_NUM_THREADS"] = str(num_threads)
+
+            # Directly set PyTorch thread counts
+            torch.set_num_threads(num_threads)
+            torch.set_num_interop_threads(max(1, num_threads // 4))
+
+            set_omp_num_threads(self.rank, self.local_rank, num_threads)
         else:
             # Bare metal: use NUMA-aware binding
             set_cpu_affinity(self.rank, self.local_rank, self.parallel_config)
             allocated_cpus = len(os.sched_getaffinity(0))
             set_omp_num_threads(self.rank, self.local_rank, max(2, allocated_cpus))
 
+        # Sync numba and torch thread settings to avoid recompilation
+        # caused by global state mismatch between the two runtimes
         numba.set_num_threads(torch.get_num_threads())
         torch.set_num_threads(numba.get_num_threads())
-
         # Initialize the distributed environment.
         init_worker_distributed_environment(
             self.vllm_config, self.rank, self.distributed_init_method, self.local_rank

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -121,7 +121,6 @@ class RBLNOptimumWorker(WorkerBase):
 
             # Directly set PyTorch thread counts
             torch.set_num_threads(num_threads)
-            torch.set_num_interop_threads(max(1, num_threads // 4))
 
             set_omp_num_threads(self.rank, self.local_rank, num_threads)
         else:

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -99,20 +99,22 @@ class RBLNOptimumWorker(WorkerBase):
             self.profiler = None
 
     def init_device(self) -> None:
-        set_cpu_affinity(
-            self.rank,
-            self.local_rank,
-            self.parallel_config,
-        )
-
-        # set_cpu_affinity already selects physical cores only (no HT)
-        # so use the full affinity count
         allocated_cpus = len(os.sched_getaffinity(0))
-        set_omp_num_threads(
-            self.rank,
-            self.local_rank,
-            max(2, allocated_cpus),
-        )
+        reported_cpus = os.cpu_count() or allocated_cpus
+
+        if allocated_cpus < reported_cpus:
+            # Container: K8s cpuset already configured, don't override
+            logger.info(
+                "Container cpuset detected (%d/%d CPUs). "
+                "Skipping set_cpu_affinity, setting threads to %d.",
+                allocated_cpus, reported_cpus, allocated_cpus,
+            )
+            set_omp_num_threads(self.rank, self.local_rank, allocated_cpus)
+        else:
+            # Bare metal: use NUMA-aware binding
+            set_cpu_affinity(self.rank, self.local_rank, self.parallel_config)
+            allocated_cpus = len(os.sched_getaffinity(0))
+            set_omp_num_threads(self.rank, self.local_rank, max(2, allocated_cpus))
 
         numba.set_num_threads(torch.get_num_threads())
         torch.set_num_threads(numba.get_num_threads())

--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -101,7 +101,10 @@ class RBLNOptimumWorker(WorkerBase):
     def init_device(self) -> None:
         allocated_cpus = len(os.sched_getaffinity(0))
         reported_cpus = os.cpu_count() or allocated_cpus
-
+        logger.info(
+            "DEBUG: allocated_cpus=%d, reported_cpus=%d",
+            allocated_cpus, reported_cpus,
+        )
         if allocated_cpus < reported_cpus:
             # Container: K8s cpuset already configured, don't override
             logger.info(


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves # `Jira Issue: SR-98`

---

## Problem

In container environments, `os.cpu_count()` reports all host CPUs (e.g., 96) while the pod is restricted to a cpuset subset (e.g., 32). Libraries like OpenMP, MKL, and NumPy use `os.cpu_count()` to spawn threads, causing massive thread contention on the limited cpuset — resulting in 30-60x slower host ops compared to bare metal on the same server.

Additionally, `set_cpu_affinity()` further narrows the K8s-assigned cpuset
(e.g., 32 → 16) by applying NUMA-aware physical-core-only selection on top
of an already-configured cpuset, which is unnecessary and harmful in
container environments.

## Solution

Detect container environments by comparing `os.sched_getaffinity(0)` with
`os.cpu_count()`. When a mismatch is detected:

- **Skip `set_cpu_affinity()`**: trust the K8s cpuset configuration
- **Set thread count to `allocated_cpus // 2`**: use physical cores only, excluding HT siblings
- **Set all thread pool env vars**: `OMP_NUM_THREADS`, `MKL_NUM_THREADS`,
  `OPENBLAS_NUM_THREADS`, `NUMEXPR_MAX_THREADS`, `RBLN_NUM_THREADS`

On bare metal, set NUMA-aware binding similar to rbln_worker.py (type2).


### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
