### PR TITLE
fix(core): deduplicate KV cache inputs for torch.export compatibility

### DIFF
--- a/vllm_rbln/forward_context.py
+++ b/vllm_rbln/forward_context.py
@@ -171,11 +171,9 @@ def _set_forward_context(
         ubatch_slices,
     )
     if additional_kwargs:
-        existing_additional_kwargs = getattr(
-            forward_context, "additional_kwargs", None
-        )
+        existing_additional_kwargs = getattr(forward_context, "additional_kwargs", None)
         if existing_additional_kwargs is None:
-            setattr(forward_context, "additional_kwargs", dict(additional_kwargs))
+            forward_context.additional_kwargs = dict(additional_kwargs)
         else:
             existing_additional_kwargs.update(additional_kwargs)
 

--- a/vllm_rbln/forward_context.py
+++ b/vllm_rbln/forward_context.py
@@ -138,6 +138,7 @@ def _set_forward_context(
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
     num_padded_tokens: int | None = None,
+    additional_kwargs: dict[str, Any] | None = None,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -169,6 +170,14 @@ def _set_forward_context(
         batch_descriptor,
         ubatch_slices,
     )
+    if additional_kwargs:
+        existing_additional_kwargs = getattr(
+            forward_context, "additional_kwargs", None
+        )
+        if existing_additional_kwargs is None:
+            setattr(forward_context, "additional_kwargs", dict(additional_kwargs))
+        else:
+            existing_additional_kwargs.update(additional_kwargs)
 
     try:
         with override_forward_context(forward_context):

--- a/vllm_rbln/model_executor/layers/attention/attention.py
+++ b/vllm_rbln/model_executor/layers/attention/attention.py
@@ -15,6 +15,7 @@
 import torch
 import vllm.model_executor.layers.attention.attention as vllm_attn
 from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention.attention import (
     Attention,
     get_attention_context,
@@ -26,6 +27,7 @@ from vllm.model_executor.models.utils import extract_layer_index
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
+from vllm_rbln.v1.attention.kv_cache_bindings import materialize_kv_cache_view
 from vllm_rbln.v1.kv_cache import RBLNSlidingWindowSpec
 
 # ---------------------------------------------------------------------------
@@ -51,6 +53,24 @@ def _rbln_attention_init(self, *args, **kwargs) -> None:
         self.layer_index -= start
 
 
+def _resolve_kv_cache(attn_metadata, layer_index: int) -> torch.Tensor:
+    """Resolve the KV cache for a given layer, either from deduplicated
+    base tensors (for torch.export compatibility) or from the direct list."""
+    kv_cache_view_infos = getattr(attn_metadata, "kv_cache_view_infos", None)
+    forward_context = get_forward_context()
+    additional_kwargs = getattr(forward_context, "additional_kwargs", {}) or {}
+    kv_cache_bases = additional_kwargs.get("kv_cache_bases")
+    if kv_cache_bases and kv_cache_view_infos:
+        assert layer_index < len(kv_cache_view_infos)
+        return materialize_kv_cache_view(
+            kv_cache_bases, kv_cache_view_infos[layer_index]
+        )
+
+    assert attn_metadata.kv_caches is not None
+    assert layer_index < len(attn_metadata.kv_caches)
+    return attn_metadata.kv_caches[layer_index]
+
+
 def _rbln_unified_attention(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -64,9 +84,7 @@ def _rbln_unified_attention(
     # kv cache (self.kv_cache); use attention metadata's kv cache.
     # attention metadata's kv cache must equal the attention layer's
     # embedded kv cache.
-    assert attn_metadata.kv_caches is not None
-    assert self.layer_index < len(attn_metadata.kv_caches)
-    kv_cache = attn_metadata.kv_caches[self.layer_index]
+    kv_cache = _resolve_kv_cache(attn_metadata, self.layer_index)
 
     output = self.impl.forward(self, query, key, value, kv_cache, attn_metadata)
     return output
@@ -93,9 +111,7 @@ def _rbln_unified_attention_with_output(
     # kv cache (self.kv_cache); use attention metadata's kv cache.
     # attention metadata's kv cache must equal the attention layer's
     # embedded kv cache.
-    assert attn_metadata.kv_caches is not None
-    assert self.layer_index < len(attn_metadata.kv_caches)
-    kv_cache = attn_metadata.kv_caches[self.layer_index]
+    kv_cache = _resolve_kv_cache(attn_metadata, self.layer_index)
     self.impl.forward(
         self,
         query,

--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 import vllm_rbln.rbln_envs as envs
 import vllm_rbln.utils as rbln_utils
 from vllm_rbln.logger import init_logger
+from vllm_rbln.v1.attention.kv_cache_bindings import KVCacheViewInfo
 
 logger = init_logger(__name__)
 
@@ -1018,6 +1019,7 @@ class RBLNFlashAttentionMetadata:
     # For RBLN Attention
     attn_masks: torch.Tensor | None = None
     kv_caches: list[torch.Tensor] | None = None
+    kv_cache_view_infos: list[KVCacheViewInfo] | None = None
     # for sliding window attention
     cache_seq_lens: torch.Tensor | None = None
     cache_offsets: torch.Tensor | None = None

--- a/vllm_rbln/v1/attention/kv_cache_bindings.py
+++ b/vllm_rbln/v1/attention/kv_cache_bindings.py
@@ -1,0 +1,143 @@
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from typing import Any
+
+import torch
+from vllm.model_executor.models.utils import extract_layer_index
+
+
+@dataclass(frozen=True)
+class KVCacheViewInfo:
+    base_index: int = -1
+    view_dtype: torch.dtype | None = None
+    view_shape: tuple[int, ...] | None = None
+    permute_order: tuple[int, ...] | None = None
+    select_index: int | None = None
+
+
+def build_kv_cache_base_bindings(
+    kv_cache_bases_by_layer: dict[str, torch.Tensor],
+    kv_cache_view_infos_by_layer: dict[str, KVCacheViewInfo],
+    num_attn_module: int = 1,
+) -> tuple[list[torch.Tensor], list[KVCacheViewInfo]]:
+    """Deduplicate KV cache inputs by storage and capture per-layer view info."""
+    base_tensors: list[torch.Tensor] = []
+    view_infos: list[KVCacheViewInfo] = []
+    base_index_by_storage: dict[tuple[int, int], int] = {}
+
+    layer_names = _get_ordered_layer_names(
+        kv_cache_view_infos_by_layer, num_attn_module
+    )
+    for layer_name in layer_names:
+        base_tensor = kv_cache_bases_by_layer[layer_name]
+        storage = base_tensor.untyped_storage()
+        storage_key = (storage.data_ptr(), storage.nbytes())
+        base_index = base_index_by_storage.get(storage_key)
+        if base_index is None:
+            base_index = len(base_tensors)
+            base_index_by_storage[storage_key] = base_index
+            base_tensors.append(base_tensor)
+
+        view_infos.append(
+            replace(
+                kv_cache_view_infos_by_layer[layer_name],
+                base_index=base_index,
+            )
+        )
+
+    return base_tensors, view_infos
+
+
+def materialize_kv_cache_view(
+    base_tensors: list[torch.Tensor], view_info: KVCacheViewInfo
+) -> torch.Tensor:
+    """Rebuild a layer-local KV cache view from a deduplicated base tensor."""
+    tensor = base_tensors[view_info.base_index]
+    if view_info.view_dtype is not None:
+        tensor = tensor.view(view_info.view_dtype)
+    if view_info.view_shape is not None:
+        tensor = tensor.view(view_info.view_shape)
+    if view_info.permute_order is not None:
+        tensor = tensor.permute(*view_info.permute_order)
+    if view_info.select_index is not None:
+        tensor = tensor.select(0, view_info.select_index)
+    return tensor
+
+
+def attach_kv_cache_bindings(
+    attn_metadata: Any,
+    kv_caches: list[torch.Tensor] | None,
+    kv_cache_bases: list[torch.Tensor] | None,
+    kv_cache_view_infos: list[KVCacheViewInfo] | None,
+) -> None:
+    """Attach either per-layer KV views or deduplicated bases to metadata."""
+    if kv_cache_bases and kv_cache_view_infos:
+        attn_metadata.kv_caches = None
+        attn_metadata.kv_cache_view_infos = kv_cache_view_infos
+        return
+
+    attn_metadata.kv_caches = kv_caches
+    attn_metadata.kv_cache_view_infos = None
+
+
+def build_kv_cache_forward_context_kwargs(
+    kv_cache_bases: list[torch.Tensor] | None,
+) -> dict[str, tuple[torch.Tensor, ...]]:
+    if not kv_cache_bases:
+        return {}
+    return {"kv_cache_bases": tuple(kv_cache_bases)}
+
+
+def validate_shared_attention_kv_cache_contiguity(
+    kv_caches: dict[str, torch.Tensor],
+    kv_cache_bases_by_layer: dict[str, torch.Tensor],
+    kv_cache_view_infos_by_layer: dict[str, KVCacheViewInfo],
+) -> None:
+    layers_by_storage: dict[tuple[int, int], list[str]] = defaultdict(list)
+
+    for layer_name in kv_cache_view_infos_by_layer:
+        base_tensor = kv_cache_bases_by_layer.get(layer_name)
+        kv_cache = kv_caches.get(layer_name)
+        if base_tensor is None or kv_cache is None:
+            continue
+        storage = base_tensor.untyped_storage()
+        storage_key = (storage.data_ptr(), storage.nbytes())
+        layers_by_storage[storage_key].append(layer_name)
+
+    for layer_names in layers_by_storage.values():
+        if len(layer_names) <= 1:
+            continue
+
+        non_contiguous = [
+            layer_name
+            for layer_name in layer_names
+            if not kv_caches[layer_name].is_contiguous()
+        ]
+        if not non_contiguous:
+            continue
+
+        layer_summaries = ", ".join(
+            (
+                f"{layer_name}(shape={tuple(kv_caches[layer_name].shape)}, "
+                f"stride={tuple(kv_caches[layer_name].stride())})"
+            )
+            for layer_name in non_contiguous
+        )
+        raise ValueError(
+            "Shared attention KV cache tensors must be contiguous. "
+            f"Non-contiguous layers: {layer_summaries}"
+        )
+
+
+def _get_ordered_layer_names(
+    kv_caches: dict[str, torch.Tensor], num_attn_module: int
+) -> list[str]:
+    index_to_names: dict[int, list[str]] = defaultdict(list)
+    for layer_name in kv_caches:
+        layer_index = extract_layer_index(layer_name, num_attn_module)
+        index_to_names[layer_index].append(layer_name)
+
+    ordered_layer_names: list[str] = []
+    for layer_index in sorted(index_to_names):
+        ordered_layer_names.extend(index_to_names[layer_index])
+    return ordered_layer_names

--- a/vllm_rbln/v1/attention/kv_cache_bindings.py
+++ b/vllm_rbln/v1/attention/kv_cache_bindings.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from typing import Any

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -30,6 +30,10 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 import vllm_rbln.rbln_envs as envs
 import vllm_rbln.utils as rbln_utils
 from vllm_rbln.logger import init_logger
+from vllm_rbln.v1.attention.kv_cache_bindings import (
+    attach_kv_cache_bindings,
+    build_kv_cache_forward_context_kwargs,
+)
 from vllm_rbln.v1.spec_decode.utils import (
     eagle_prepare_inputs_padded,
     eagle_prepare_next_token_padded,
@@ -153,9 +157,9 @@ class RBLNEagleProposer(EagleProposer):
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
             num_padded_tokens=num_padded_tokens,
-            # slot_mapping=self._get_slot_mapping(
-            #     num_input_tokens, common_attn_metadata.slot_mapping
-            # ),
+            additional_kwargs=build_kv_cache_forward_context_kwargs(
+                getattr(self.runner, "kv_cache_bases", None)
+            ),
         ):
             hidden_states, logits = self.model_executable(
                 input_ids=input_ids,
@@ -275,7 +279,12 @@ class RBLNEagleProposer(EagleProposer):
                     fast_build=True,
                     **extra_attn_metadata_args,
                 )
-                attn_metadata.kv_caches = self.runner.kv_caches
+                attach_kv_cache_bindings(
+                    attn_metadata,
+                    self.runner.kv_caches,
+                    getattr(self.runner, "kv_cache_bases", None),
+                    getattr(self.runner, "kv_cache_view_infos", None),
+                )
                 for layer_name in attn_group.layer_names:
                     per_layer_attn_metadata[layer_name] = attn_metadata
 
@@ -308,7 +317,9 @@ class RBLNEagleProposer(EagleProposer):
                 num_tokens=batch_size,
                 num_tokens_across_dp=None,
                 num_padded_tokens=None,
-                # slot_mapping=self._get_slot_mapping(batch_size),
+                additional_kwargs=build_kv_cache_forward_context_kwargs(
+                    getattr(self.runner, "kv_cache_bases", None)
+                ),
             ):
                 hidden_states, logits = self.model_executable(
                     input_ids=input_ids,

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -110,7 +110,12 @@ class RBLNEagleProposer(EagleProposer):
                 fast_build=True,
                 **extra_attn_metadata_args,
             )
-            attn_metadata.kv_caches = self.runner.kv_caches
+            attach_kv_cache_bindings(
+                attn_metadata,
+                self.runner.kv_caches,
+                getattr(self.runner, "kv_cache_bases", None),
+                getattr(self.runner, "kv_cache_view_infos", None),
+            )
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -125,6 +125,13 @@ from vllm_rbln.forward_context import RBLNDPMetadata
 from vllm_rbln.logger import init_logger
 from vllm_rbln.lora.inputs import LoRAInputs
 from vllm_rbln.lora.mask import LoRAMask
+from vllm_rbln.v1.attention.kv_cache_bindings import (
+    KVCacheViewInfo,
+    attach_kv_cache_bindings,
+    build_kv_cache_base_bindings,
+    build_kv_cache_forward_context_kwargs,
+    validate_shared_attention_kv_cache_contiguity,
+)
 from vllm_rbln.v1.attention.backends.flash_attention import (
     RBLNFlashAttentionMetadataBuilder,
 )
@@ -321,6 +328,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # self.model: nn.Module  # Set after load_model
         # Initialize in initialize_kv_cache
         self.kv_caches: list[torch.Tensor] = []
+        self.kv_cache_bases: list[torch.Tensor] = []
+        self.kv_cache_view_infos: list[KVCacheViewInfo] = []
         # indexes: [kv_cache_group_id][attn_group]
         self.attn_groups: list[list[AttentionGroup]] = []
         # self.kv_cache_config: KVCacheConfig
@@ -2280,8 +2289,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     for layer_name in attn_group.layer_names:
                         attn_metadata[layer_name] = attn_metadata_i
 
-            for attn_metadatum in attn_metadata.values():
-                attn_metadatum.kv_caches = self.kv_caches
+            self._attach_kv_cache_bindings(attn_metadata)
             num_input_tokens = total_num_scheduled_tokens
             input_ids = input_ids[:num_input_tokens]
             positions = positions[:num_input_tokens]
@@ -2442,7 +2450,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
             num_padded_tokens=num_padded_tokens,
+            additional_kwargs=self._get_kv_cache_forward_context_kwargs(),
         ):
+            self._attach_kv_cache_bindings(bucket_attn_metadata)
             token_indices = None
             inputs_embeds = None
             model_kwargs = dict[str, Any]({})
@@ -2804,13 +2814,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 num_padded_tokens=num_padded_tokens,
+                additional_kwargs=self._get_kv_cache_forward_context_kwargs(),
             ),
             record_function_or_nullcontext("Forward"),
             self.maybe_get_kv_connector_output(scheduler_output) as kv_connector_output,
         ):
-            if attn_metadata is not None:
-                for attn_metadatum in attn_metadata.values():
-                    attn_metadatum.kv_caches = self.kv_caches
+            self._attach_kv_cache_bindings(attn_metadata)
 
             # FIXME(jiwoo.park) This is a temporary workaround;
             # we must resolve the batch dimension.
@@ -4076,7 +4085,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         kv_cache_config: KVCacheConfig,
         kv_cache_raw_tensors: dict[str, torch.Tensor],
         kernel_block_sizes: list[int],
-    ) -> dict[str, torch.Tensor]:
+    ) -> tuple[
+        dict[str, torch.Tensor],
+        dict[str, torch.Tensor],
+        dict[str, KVCacheViewInfo],
+    ]:
         """
         Reshape the KV cache tensors to the desired shape and dtype.
 
@@ -4086,10 +4099,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 correct size but uninitialized shape.
             kernel_block_sizes: The kernel block sizes for each KV cache group.
         Returns:
-            Dict[str, torch.Tensor]: A map between layer names to their
-            corresponding memory buffer for KV cache.
+            Tuple of (kv_caches, kv_cache_base_tensors, kv_cache_view_infos):
+            - kv_caches: layer name -> reshaped+permuted KV cache tensor
+            - kv_cache_base_tensors: layer name -> typed base tensor (pre-permute)
+            - kv_cache_view_infos: layer name -> view transformation metadata
         """
         kv_caches: dict[str, torch.Tensor] = {}
+        kv_cache_base_tensors: dict[str, torch.Tensor] = {}
+        kv_cache_view_infos: dict[str, KVCacheViewInfo] = {}
         has_attn, has_mamba = False, False
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
@@ -4137,11 +4154,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         kv_cache_stride_order.index(i)
                         for i in range(len(kv_cache_stride_order))
                     ]
-                    kv_caches[layer_name] = (
-                        kv_cache_raw_tensors[layer_name]
-                        .view(dtype)
-                        .view(kv_cache_shape)
-                        .permute(*inv_order)
+                    # Keep the deduped base in a backend-native multidimensional
+                    # shape so export/Relay never sees a giant flat dimension.
+                    typed_base = kv_cache_raw_tensors[layer_name].view(dtype).view(
+                        kv_cache_shape
+                    )
+                    kv_caches[layer_name] = typed_base.permute(*inv_order)
+                    kv_cache_base_tensors[layer_name] = typed_base
+                    kv_cache_view_infos[layer_name] = KVCacheViewInfo(
+                        view_shape=kv_cache_shape,
+                        permute_order=tuple(inv_order),
                     )
                 elif isinstance(kv_cache_spec, MambaSpec):
                     has_mamba = True
@@ -4173,7 +4195,78 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if has_attn and has_mamba:
             self._update_hybrid_attention_mamba_layout(kv_caches)
 
-        return kv_caches
+        return kv_caches, kv_cache_base_tensors, kv_cache_view_infos
+
+    def _build_uniform_kv_cache_view_infos(
+        self,
+        kv_cache_config: KVCacheConfig,
+        cross_layers_kv_cache: torch.Tensor,
+        attn_backend: "AttentionBackend",
+    ) -> dict[str, KVCacheViewInfo]:
+        try:
+            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
+                include_num_layers_dimension=True
+            )
+            assert len(kv_cache_stride_order) == cross_layers_kv_cache.ndim
+        except (AttributeError, NotImplementedError):
+            kv_cache_stride_order = tuple(range(cross_layers_kv_cache.ndim))
+
+        inv_order = tuple(
+            kv_cache_stride_order.index(i) for i in range(len(kv_cache_stride_order))
+        )
+
+        kv_cache_view_infos: dict[str, KVCacheViewInfo] = {}
+        for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
+            view_info = KVCacheViewInfo(
+                permute_order=inv_order,
+                select_index=i,
+            )
+            for layer_name in kv_cache_tensor.shared_by:
+                kv_cache_view_infos[layer_name] = view_info
+
+        return kv_cache_view_infos
+
+    def _update_kv_cache_base_bindings(
+        self,
+        kv_cache_bases_by_layer: dict[str, torch.Tensor],
+        kv_cache_view_infos_by_layer: dict[str, KVCacheViewInfo],
+        num_attn_module: int,
+    ) -> None:
+        if not kv_cache_view_infos_by_layer:
+            self.kv_cache_bases = []
+            self.kv_cache_view_infos = []
+            return
+        kv_cache_bases, kv_cache_view_infos = build_kv_cache_base_bindings(
+            kv_cache_bases_by_layer,
+            kv_cache_view_infos_by_layer,
+            num_attn_module=num_attn_module,
+        )
+        # If no deduplication occurred (each layer has its own unique base),
+        # the new system adds overhead without benefit — disable it.
+        if len(kv_cache_bases) == len(kv_cache_view_infos):
+            self.kv_cache_bases = []
+            self.kv_cache_view_infos = []
+            return
+        self.kv_cache_bases = kv_cache_bases
+        self.kv_cache_view_infos = kv_cache_view_infos
+
+    def _attach_kv_cache_bindings(
+        self, attn_metadata: dict[str, Any] | None
+    ) -> None:
+        if attn_metadata is None:
+            return
+        for attn_metadatum in attn_metadata.values():
+            attach_kv_cache_bindings(
+                attn_metadatum,
+                self.kv_caches,
+                self.kv_cache_bases,
+                self.kv_cache_view_infos,
+            )
+
+    def _get_kv_cache_forward_context_kwargs(
+        self,
+    ) -> dict[str, tuple[torch.Tensor, ...]]:
+        return build_kv_cache_forward_context_kwargs(self.kv_cache_bases)
 
     def initialize_kv_cache_tensors(
         self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
@@ -4192,6 +4285,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Try creating KV caches optimized for kv-connector transfers
         cache_dtype = self.cache_config.cache_dtype
+        kv_cache_bases_by_layer: dict[str, torch.Tensor]
+        kv_cache_view_infos: dict[str, KVCacheViewInfo]
         if self.use_uniform_kv_cache(self.attn_groups, cache_dtype):
             kv_caches, cross_layers_kv_cache, attn_backend = (
                 self.allocate_uniform_kv_caches(
@@ -4204,23 +4299,55 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             self.cross_layers_kv_cache = cross_layers_kv_cache
             self.cross_layers_attn_backend = attn_backend
+            kv_cache_bases_by_layer = {
+                layer_name: cross_layers_kv_cache for layer_name in kv_caches
+            }
+            kv_cache_view_infos = self._build_uniform_kv_cache_view_infos(
+                kv_cache_config,
+                cross_layers_kv_cache,
+                attn_backend,
+            )
         else:
             # Fallback to the general case
             # Initialize the memory buffer for KV cache
             kv_cache_raw_tensors = self._allocate_kv_cache_tensors(kv_cache_config)
 
             # Change the memory buffer to the desired shape
-            kv_caches = self._reshape_kv_cache_tensors(
-                kv_cache_config, kv_cache_raw_tensors, kernel_block_sizes
+            kv_caches, kv_cache_bases_by_layer, kv_cache_view_infos = (
+                self._reshape_kv_cache_tensors(
+                    kv_cache_config,
+                    kv_cache_raw_tensors,
+                    kernel_block_sizes,
+                )
             )
 
         # Set up cross-layer KV cache sharing
         for layer_name, target_layer_name in self.shared_kv_cache_layers.items():
             logger.debug("%s reuses KV cache of %s", layer_name, target_layer_name)
             kv_caches[layer_name] = kv_caches[target_layer_name]
+            kv_cache_bases_by_layer[layer_name] = kv_cache_bases_by_layer[
+                target_layer_name
+            ]
+            if target_layer_name in kv_cache_view_infos:
+                kv_cache_view_infos[layer_name] = kv_cache_view_infos[
+                    target_layer_name
+                ]
+
+        validate_shared_attention_kv_cache_contiguity(
+            kv_caches,
+            kv_cache_bases_by_layer,
+            kv_cache_view_infos,
+        )
 
         num_attn_module = (
             2 if self.model_config.hf_config.model_type == "longcat_flash" else 1
+        )
+        self.kv_cache_bases = []
+        self.kv_cache_view_infos = []
+        self._update_kv_cache_base_bindings(
+            kv_cache_bases_by_layer,
+            kv_cache_view_infos,
+            num_attn_module,
         )
         bind_kv_cache(
             kv_caches,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -125,15 +125,15 @@ from vllm_rbln.forward_context import RBLNDPMetadata
 from vllm_rbln.logger import init_logger
 from vllm_rbln.lora.inputs import LoRAInputs
 from vllm_rbln.lora.mask import LoRAMask
+from vllm_rbln.v1.attention.backends.flash_attention import (
+    RBLNFlashAttentionMetadataBuilder,
+)
 from vllm_rbln.v1.attention.kv_cache_bindings import (
     KVCacheViewInfo,
     attach_kv_cache_bindings,
     build_kv_cache_base_bindings,
     build_kv_cache_forward_context_kwargs,
     validate_shared_attention_kv_cache_contiguity,
-)
-from vllm_rbln.v1.attention.backends.flash_attention import (
-    RBLNFlashAttentionMetadataBuilder,
 )
 from vllm_rbln.v1.kv_cache import RBLNSlidingWindowSpec
 from vllm_rbln.v1.sample import RBLNSampler
@@ -4156,8 +4156,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     ]
                     # Keep the deduped base in a backend-native multidimensional
                     # shape so export/Relay never sees a giant flat dimension.
-                    typed_base = kv_cache_raw_tensors[layer_name].view(dtype).view(
-                        kv_cache_shape
+                    typed_base = (
+                        kv_cache_raw_tensors[layer_name]
+                        .view(dtype)
+                        .view(kv_cache_shape)
                     )
                     kv_caches[layer_name] = typed_base.permute(*inv_order)
                     kv_cache_base_tensors[layer_name] = typed_base
@@ -4250,9 +4252,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.kv_cache_bases = kv_cache_bases
         self.kv_cache_view_infos = kv_cache_view_infos
 
-    def _attach_kv_cache_bindings(
-        self, attn_metadata: dict[str, Any] | None
-    ) -> None:
+    def _attach_kv_cache_bindings(self, attn_metadata: dict[str, Any] | None) -> None:
         if attn_metadata is None:
             return
         for attn_metadatum in attn_metadata.values():
@@ -4329,9 +4329,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 target_layer_name
             ]
             if target_layer_name in kv_cache_view_infos:
-                kv_cache_view_infos[layer_name] = kv_cache_view_infos[
-                    target_layer_name
-                ]
+                kv_cache_view_infos[layer_name] = kv_cache_view_infos[target_layer_name]
 
         validate_shared_attention_kv_cache_contiguity(
             kv_caches,


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

When multiple attention layers share the same KV cache storage but require different shaped views (e.g., GPT-OSS), `torch.export` fails because it sees the same mutable tensor appearing as multiple input args with different shapes.

This PR introduces a `KVCacheViewInfo` system that:
- Passes **deduplicated base tensors** as single input args through `forward_context`
- Reconstructs per-layer views **inside the graph** via traceable operations (`view`, `permute`, `select`)
- Falls back to the existing direct `kv_caches` list when no deduplication is needed

Key changes:
- New module `vllm_rbln/v1/attention/kv_cache_bindings.py` with `KVCacheViewInfo` dataclass and build/materialize/attach helpers
- `_resolve_kv_cache` in attention layer dynamically selects between old (direct kv_caches list) and new (base + view_info materialization) systems
- `forward_context` extended with `additional_kwargs` to carry base tensors as graph inputs
- Model runner builds and propagates base bindings during KV cache initialization
- Eagle proposer integrated with the new binding system

---

### 📌 Related Issues / Tickets

* Related to: `device_tensor2` branch commits (`99ac8e0`, `cac8d22`, `9e47226`)

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)
* [x] 🧬 Core engine changes (`core`)

---

### 🧪 How to Test

1. Compile GPT-OSS model with `torch.export` — should no longer fail with mutable tensor shape mismatch
2. Run inference on models without shared KV cache (e.g., Qwen, LLaMA) — should behave identically (fallback path)
3. Run inference on models with shared KV cache (e.g., GPT-OSS) — should produce correct results via the new dedup path

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- This is an adaptation of 3 commits from the `device_tensor2` branch, adjusted for the current `dev` branch file structure (notably `vllm_rbln/attention/layer.py` → `vllm_rbln/model_executor/layers/attention/attention.py` reorganization from #509)
- Debug artifacts from the original branch (`torch.empty`, `print()` statements) were intentionally excluded
- The `kv_cache_bases` field on `RBLNFlashAttentionMetadata` was omitted since it was always `None` and unused — base tensors are passed through `forward_context.additional_kwargs` instead
- The dedup system automatically disables itself when no sharing is detected (`len(bases) == len(view_infos)`), so there is zero overhead for non-shared models

---