### PR TITLE
fix(encoder): use RBLNClassifierPooler for classification models

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/encoder.py
+++ b/vllm_rbln/model_executor/models/optimum/encoder.py
@@ -72,14 +72,17 @@ class RBLNOptimumForEncoderModel(RBLNOptimumModelBase, VllmModelForPooling):
         # Therefore, we override the pooling type to CLS here.
         pooler_config.pooling_type = "CLS"
         assert pooler_config is not None
-        # https://github.com/vllm-project/vllm/blob/72506c98349d6bcd32b4e33eec7b5513453c1502/docs/models/pooling_models.md?plain=1#L312
-        # encode task is split into `token_embed` and `token_classify` tasks
-        self.pooler = DispatchPooler(
-            {
-                "token_embed": pooler_for_token_embed(pooler_config),
-                "embed": pooler_for_embed(pooler_config),
-            },
-        )
+        if self.is_classification_arch():
+            self.pooler = RBLNClassifierPooler()
+        else:
+            # https://github.com/vllm-project/vllm/blob/72506c98349d6bcd32b4e33eec7b5513453c1502/docs/models/pooling_models.md?plain=1#L312
+            # encode task is split into `token_embed` and `token_classify` tasks
+            self.pooler = DispatchPooler(
+                {
+                    "token_embed": pooler_for_token_embed(pooler_config),
+                    "embed": pooler_for_embed(pooler_config),
+                },
+            )
 
     def is_classification_arch(self):
         architectures = getattr(


### PR DESCRIPTION
## Summary
- Fix `ValueError: Unsupported task: 'score'` when calling `llm.score()` on classification models (e.g., `XLMRobertaForSequenceClassification`)
- `RBLNOptimumForEncoderModel.__init__` unconditionally created a `DispatchPooler` with only `embed`/`token_embed` tasks, so the `score` task was never registered
- The existing `RBLNClassifierPooler` (which supports `classify`/`score`) was defined but never used
- Now checks `is_classification_arch()` to dispatch to `RBLNClassifierPooler` for classification models, while non-classification models continue using `DispatchPooler`

## Root Cause
After vLLM refactored pooling in the v1 engine (splitting the old `encode` task into `token_embed`/`embed` with `DispatchPooler`), the RBLN encoder model was updated to use the new pattern but the classification/score code path was not wired up.

## Test plan
- [ ] Run `xlm_roberta_sequence_classify` CI script to verify `llm.score()` works
- [ ] Run embedding CI scripts to verify non-classification encoder models still work with `DispatchPooler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)