### PR TITLE
fix(config): ensure max_num_batched_tokens >= max_source_positions for enc-dec

### DIFF
--- a/vllm_rbln/utils/optimum/configuration.py
+++ b/vllm_rbln/utils/optimum/configuration.py
@@ -32,6 +32,7 @@ from vllm_rbln.utils.optimum.rbln_params import (
 )
 from vllm_rbln.utils.optimum.registry import (
     get_rbln_model_info,
+    is_enc_dec_arch,
     is_generation_arch,
     is_multi_modal,
 )
@@ -80,14 +81,31 @@ def sync_vllm_from_rbln_config(
         )
         vllm_config.scheduler_config.max_num_seqs = batch_size
 
-    if vllm_config.scheduler_config.max_num_batched_tokens != (max_model_len):
+    # For encoder-decoder multimodal models (e.g. Whisper), max_num_batched_tokens
+    # must be at least max_source_positions so that vllm's MultiModalBudget
+    # validation passes (it requires max_tokens_per_mm_item <= max_num_batched_tokens
+    # when chunked MM input is disabled).
+    target_max_num_batched_tokens = max_model_len
+    hf_config = vllm_config.model_config.hf_config
+    if is_enc_dec_arch(hf_config):
+        max_source_positions = getattr(hf_config, "max_source_positions", 0)
+        if max_source_positions > target_max_num_batched_tokens:
+            target_max_num_batched_tokens = max_source_positions
+            logger.info(
+                "Encoder-decoder model detected: setting max_num_batched_tokens "
+                "to %d (max_source_positions) instead of %d (max_model_len)",
+                max_source_positions,
+                max_model_len,
+            )
+
+    if vllm_config.scheduler_config.max_num_batched_tokens != target_max_num_batched_tokens:
         logger.info(
             "Updating scheduler_config.max_num_batched_tokens from %s to "
             "%d based on rbln_config.json",
             vllm_config.scheduler_config.max_num_batched_tokens,
-            max_model_len,
+            target_max_num_batched_tokens,
         )
-        vllm_config.scheduler_config.max_num_batched_tokens = max_model_len
+        vllm_config.scheduler_config.max_num_batched_tokens = target_max_num_batched_tokens
 
     if vllm_config.model_config.max_model_len != max_model_len:
         logger.info(

--- a/vllm_rbln/utils/optimum/configuration.py
+++ b/vllm_rbln/utils/optimum/configuration.py
@@ -98,14 +98,17 @@ def sync_vllm_from_rbln_config(
                 max_model_len,
             )
 
-    if vllm_config.scheduler_config.max_num_batched_tokens != target_max_num_batched_tokens:
+    cur = vllm_config.scheduler_config.max_num_batched_tokens
+    if cur != target_max_num_batched_tokens:
         logger.info(
-            "Updating scheduler_config.max_num_batched_tokens from %s to "
-            "%d based on rbln_config.json",
-            vllm_config.scheduler_config.max_num_batched_tokens,
+            "Updating scheduler_config.max_num_batched_tokens "
+            "from %s to %d based on rbln_config.json",
+            cur,
             target_max_num_batched_tokens,
         )
-        vllm_config.scheduler_config.max_num_batched_tokens = target_max_num_batched_tokens
+        vllm_config.scheduler_config.max_num_batched_tokens = (
+            target_max_num_batched_tokens
+        )
 
     if vllm_config.model_config.max_model_len != max_model_len:
         logger.info(


### PR DESCRIPTION
## Summary
- Fix `ValueError: Chunked MM input disabled but max_tokens_per_mm_item (1500) is larger than max_num_batched_tokens (448)` when initializing Whisper models
- `sync_vllm_from_rbln_config` was setting `max_num_batched_tokens = dec_max_seq_len` (448), but vllm's `MultiModalBudget` now validates that `max_num_batched_tokens >= max_tokens_per_mm_item` (1500 for whisper audio) when chunked MM input is disabled
- For encoder-decoder models, now uses `max(max_model_len, max_source_positions)` as `max_num_batched_tokens` to satisfy the encoder's token budget

## Root Cause
vllm added a `MultiModalBudget` validation in the v1 engine that checks encoder input size against `max_num_batched_tokens`. The RBLN config sync was overriding `max_num_batched_tokens` to the decoder length (448) without considering the encoder's larger input size (1500).

## Test plan
- [ ] Run Whisper CI script (`whisper-small`) to verify model initializes and transcribes correctly
- [ ] Run non-encoder-decoder models to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)