### PR TITLE
fix(gemma3): use non-negative sentinel for IMG_PAD_TOKEN_ID

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -33,7 +33,12 @@ from .optimum_attention import HybridAttentionImageManager, HybridAttentionImage
 
 logger = init_logger(__name__)
 
-IMG_PAD_TOKEN_ID = -1
+# Sentinel token ID for image boundary padding. Must be a non-negative value
+# that fits within u32 range, since vllm's FastIncrementalDetokenizer passes
+# prompt_token_ids to tokenizers.DecodeStream which expects u32 values.
+# Using a value beyond the vocab size (262208) so it won't collide with real tokens.
+# This is replaced with PAD_TOKEN_ID before model execution.
+IMG_PAD_TOKEN_ID = 2**30
 PAD_TOKEN_ID = 0
 
 

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -33,12 +33,6 @@ from .optimum_attention import HybridAttentionImageManager, HybridAttentionImage
 
 logger = init_logger(__name__)
 
-# Sentinel token ID for image boundary padding. Must be a non-negative value
-# that fits within u32 range, since vllm's FastIncrementalDetokenizer passes
-# prompt_token_ids to tokenizers.DecodeStream which expects u32 values.
-# Using a value beyond the vocab size (262208) so it won't collide with real tokens.
-# This is replaced with PAD_TOKEN_ID before model execution.
-IMG_PAD_TOKEN_ID = 2**30
 PAD_TOKEN_ID = 0
 
 
@@ -62,10 +56,8 @@ class RBLNGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
                 - (image_start + padded_seq_len) % image_prefill_chunk_size
             )
             padded_seq_len += pad_needed
-        # To pad the image token
-        # not using pad_token_id
-        # NOTE: Left padding for Gemma3
-        prompt_ids = [IMG_PAD_TOKEN_ID] * padded_seq_len + prompt_ids
+        # Left padding for Gemma3 image boundary alignment
+        prompt_ids = [PAD_TOKEN_ID] * padded_seq_len + prompt_ids
         return prompt_ids
 
     def apply(self, *args, **kwargs):
@@ -108,7 +100,7 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             decoder_batch_sizes=self.model.rbln_config.language_model.decoder_batch_sizes,
             num_blocks=self.kv_block_adapter._estimated_num_blocks(),
         )
-        self.strategy = HybridAttentionImageStrategy(IMG_PAD_TOKEN_ID)
+        self.strategy = HybridAttentionImageStrategy(PAD_TOKEN_ID)
         self.attention_manager: HybridAttentionImageManager = (
             HybridAttentionImageManager(self.strategy)
         )
@@ -134,21 +126,6 @@ class RBLNOptimumGemma3ForConditionalGeneration(
                 input_ids=input_ids,
             )
         )
-        # When processing input_ids, we initially pad them with IMG_PAD_TOKEN_ID
-        # instead of PAD_TOKEN_ID.
-        #
-        # IMG_PAD_TOKEN_ID does not have an embedding. It is used only to mark
-        # image boundaries and to prevent multiple images from being placed
-        # within the same attention window. It is used in generating
-        # attention mask during the prefill phase.
-        #
-        # PAD_TOKEN_ID, on the other hand, has a valid embedding and is used for
-        # standard padding.
-        #
-        # After the attention mask is generated, IMG_PAD_TOKEN_ID is replaced
-        # with PAD_TOKEN_ID.
-        input_ids = self.postprocess_input_ids(input_ids)
-
         kwargs = self.preprocess_for_decoder(
             is_prompt, block_tables, input_ids, position_ids
         )
@@ -270,8 +247,3 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             num_patches=num_patches,
             resolve_bindings={"h": image_size, "w": image_size},
         )
-
-    def postprocess_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        is_image_pad_token = input_ids == IMG_PAD_TOKEN_ID
-        input_ids[is_image_pad_token] = PAD_TOKEN_ID
-        return input_ids

--- a/vllm_rbln/utils/optimum/configuration.py
+++ b/vllm_rbln/utils/optimum/configuration.py
@@ -112,7 +112,7 @@ def prepare_vllm_for_compile(vllm_config: VllmConfig) -> None:
     # 1. block_size
     # Get proper block_size if not set by user
     hf_config = vllm_config.model_config.hf_config
-    if vllm_config.cache_config.block_size is None:
+    if not vllm_config.cache_config.user_specified_block_size:
         # Set block_size to 4096 for fast compilation
         if is_multi_modal(hf_config) or is_generation_arch(hf_config):
             vllm_config.cache_config.block_size = 4096


### PR DESCRIPTION
## Summary

Fixes `OverflowError` during Gemma3 multimodal inference caused by `IMG_PAD_TOKEN_ID = -1` being passed to vllm's `FastIncrementalDetokenizer`, which expects u32 values.

### Root Cause

`IMG_PAD_TOKEN_ID` was set to `-1` and inserted into `prompt_token_ids` for image boundary padding. When vllm's `FastIncrementalDetokenizer` passes these IDs to the tokenizer's Rust `DecodeStream`, it expects unsigned 32-bit integers, causing an overflow.

### Solution

Use `PAD_TOKEN_ID` (0) directly instead of a separate sentinel:

- **Non-negative** — fits within u32 range (no `OverflowError`)
- **Within vocab range** — passes vllm's `InputProcessor._validate_prompt` (no `ValueError`)
- **Safe as a sentinel** — the HF tokenizer does not produce token 0 (`<pad>`) in single-sequence encoding, so `(input_ids != PAD_TOKEN_ID)` correctly masks only the image padding positions in the attention mask
- **Removes `postprocess_input_ids()`** — replacing the sentinel with `PAD_TOKEN_ID` is now a no-op

Also fixes a bug in `prepare_vllm_for_compile` where `block_size is None` was dead code (pydantic's validator converts `None` → `16` before the check runs). Changed to use `user_specified_block_size` so the auto-default to 4096 for compilation actually works.

### Testing

- Gemma3 multimodal (image + text) inference: no OverflowError or ValueError
- Text-only inference: no regression
- Compile-on-the-fly with HuggingFace model ID: works without explicit `--block-size`