### PR TITLE
fix: skip NUMA cpu affinity on bare metal to prevent 32x latency regression

### DIFF
--- a/vllm_rbln/v1/worker/optimum_worker.py
+++ b/vllm_rbln/v1/worker/optimum_worker.py
@@ -40,7 +40,7 @@ from vllm_rbln.logger import init_logger
 from vllm_rbln.utils.optimum.cache_blocks import sync_num_blocks
 from vllm_rbln.utils.optimum.rbln_params import get_rbln_params
 from vllm_rbln.v1.worker.optimum_model_runner import RBLNOptimumModelRunner
-from vllm_rbln.v1.worker.utils import set_cpu_affinity, set_omp_num_threads
+from vllm_rbln.v1.worker.utils import set_omp_num_threads
 
 logger = init_logger(__name__)
 
@@ -126,10 +126,30 @@ class RBLNOptimumWorker(WorkerBase):
 
             set_omp_num_threads(self.rank, self.local_rank, num_threads)
         else:
-            # Bare metal: use NUMA-aware binding
-            set_cpu_affinity(self.rank, self.local_rank, self.parallel_config)
-            allocated_cpus = len(os.sched_getaffinity(0))
-            set_omp_num_threads(self.rank, self.local_rank, max(2, allocated_cpus))
+            # Bare metal: use physical cores only (exclude HT siblings).
+            # Skip set_cpu_affinity to avoid restricting the process to a
+            # single NUMA node, which causes severe latency regression on
+            # high-core-count servers (e.g. 128 core → 32x slower).
+            num_threads = max(2, allocated_cpus // 2)
+            logger.info(
+                "Bare metal detected (%d CPUs). "
+                "Skipping set_cpu_affinity, setting threads to %d "
+                "(physical cores only, excluding HT).",
+                allocated_cpus,
+                num_threads,
+            )
+
+            # Set all thread pool environment variables
+            os.environ["OMP_NUM_THREADS"] = str(num_threads)
+            os.environ["MKL_NUM_THREADS"] = str(num_threads)
+            os.environ["OPENBLAS_NUM_THREADS"] = str(num_threads)
+            os.environ["NUMEXPR_MAX_THREADS"] = str(num_threads)
+            os.environ["RBLN_NUM_THREADS"] = str(num_threads)
+
+            # Directly set PyTorch thread counts
+            torch.set_num_threads(num_threads)
+
+            set_omp_num_threads(self.rank, self.local_rank, num_threads)
 
         # Sync numba and torch thread settings to avoid recompilation
         # caused by global state mismatch between the two runtimes


### PR DESCRIPTION
## Summary
- **Removes `set_cpu_affinity` call from the bare metal path** in `optimum_worker.py`, which was restricting the process to a single NUMA node (~32 of 128 cores) and causing 32x latency regression (0.29s → 9.5s) with CPU util drop (387% → 54%)
- **Sets all thread pool env vars** (`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `NUMEXPR_MAX_THREADS`, `RBLN_NUM_THREADS`) consistently, matching the container path — the old bare metal path only set `RBLN_NUM_THREADS`
- **Uses `allocated_cpus // 2`** for thread count (physical cores only), consistent with `rbln_worker.py` and the container path — the old bare metal path used `allocated_cpus` (no halving)

## Context
Commit `25dd74f` (PR #512) fixed container pod performance but introduced a severe regression on bare metal (128-core) servers. The container path (4/32 core pods) works correctly; only the bare metal path (`allocated_cpus == reported_cpus`) is affected.

## Root Cause
Three issues in the bare metal `else` branch of `init_device`:
1. `set_cpu_affinity` binds the entire process (including asyncio, GC, IPC) to one NUMA node's physical cores
2. `OMP_NUM_THREADS` env var was not set → OpenMP initialized with 128 threads, then `torch.set_num_threads(32)` reduced active threads, creating thread pool mismatch
3. Thread count used `max(2, allocated_cpus)` instead of `max(2, allocated_cpus // 2)`, inconsistent with `rbln_worker.py`

## Test plan
- [ ] Verify 128-core bare metal: latency should return to ~0.29s baseline
- [ ] Verify 32-core container: no regression from the #512 improvement
- [ ] Verify 4-core container: no regression from the #512 improvement
- [ ] Check logs for `"Bare metal detected (N CPUs). Skipping set_cpu_affinity, setting threads to M"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)