### PR TITLE
fix(encoder): fix T5EncoderModel scoring mismatch after v0.18.1 bump

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/encoder.py
+++ b/vllm_rbln/model_executor/models/optimum/encoder.py
@@ -18,7 +18,12 @@ import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.pooler import DispatchPooler, Pooler
-from vllm.model_executor.layers.pooler.seqwise import pooler_for_embed
+from vllm.model_executor.layers.pooler.activations import PoolerNormalize
+from vllm.model_executor.layers.pooler.seqwise import (
+    EmbeddingPoolerHead,
+    SequencePooler,
+    get_seq_pooling_method,
+)
 from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_embed
 from vllm.model_executor.models import VllmModelForPooling
 from vllm.tasks import PoolingTask
@@ -71,16 +76,34 @@ class RBLNOptimumForEncoderModel(RBLNOptimumModelBase, VllmModelForPooling):
         # CLS token pooling is more appropriate.
         # Therefore, we override the pooling type to CLS here.
         pooler_config.pooling_type = "CLS"
+        # NOTE: Setting pooling_type after PoolerConfig init doesn't update
+        # seq_pooling_type (already set to model default, e.g. "MEAN" for T5).
+        # Set it directly to ensure CLS pooling is used.
+        pooler_config.seq_pooling_type = "CLS"
         assert pooler_config is not None
         if self.is_classification_arch():
             self.pooler = RBLNClassifierPooler()
         else:
             # https://github.com/vllm-project/vllm/blob/72506c98349d6bcd32b4e33eec7b5513453c1502/docs/models/pooling_models.md?plain=1#L312
             # encode task is split into `token_embed` and `token_classify` tasks
+            #
+            # Build the "embed" pooler without sentence-transformers projection.
+            # vllm's pooler_for_embed() loads the ST Dense layer via
+            # _load_st_projector, but RBLN encoder models produce raw hidden
+            # states — the projection is not part of the compiled model.
+            pooling = get_seq_pooling_method(pooler_config.get_seq_pooling_type())
+            embed_pooler = SequencePooler(
+                pooling=pooling,
+                head=EmbeddingPoolerHead(
+                    head_dtype=vllm_config.model_config.head_dtype,
+                    projector=None,
+                    activation=PoolerNormalize(),
+                ),
+            )
             self.pooler = DispatchPooler(
                 {
                     "token_embed": pooler_for_token_embed(pooler_config),
-                    "embed": pooler_for_embed(pooler_config),
+                    "embed": embed_pooler,
                 },
             )
 

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import os
 from typing import TYPE_CHECKING
 
@@ -253,6 +254,20 @@ class RblnPlatform(Platform):
             assert vllm_config.speculative_config is None, (
                 "Speculative decoding is not supported in optimum-rbln."
             )
+            # T5EncoderModel is encoder-only but inherits T5Config which has
+            # is_encoder_decoder=True. This causes vllm to route inputs
+            # through the enc-dec path, prepending decoder_start_token_id and
+            # breaking CLS pooling. Set it to False for pooling models.
+            # ModelConfig.is_encoder_decoder is a @cached_property that's
+            # already evaluated by this point, so invalidate the cache too.
+            hf_config = model_config.hf_config
+            if is_pooling_arch(hf_config) and getattr(
+                hf_config, "is_encoder_decoder", False
+            ):
+                hf_config.is_encoder_decoder = False
+                with contextlib.suppress(KeyError):
+                    del model_config.__dict__["is_encoder_decoder"]
+
             cls.disable_unsupported_prefix_caching(vllm_config)
             sync_with_rbln_config(vllm_config)
 


### PR DESCRIPTION
## Summary

Fixes T5EncoderModel scoring mismatch introduced by the vllm v0.18.1 bump (#493). Score went from ~0.136 (correct) to ~0.585.

Two root causes:

- **`decoder_start_token_id` prepending**: T5Config has `is_encoder_decoder=True`, causing vllm's renderer to route inputs through the enc-dec path and prepend `decoder_start_token_id` (0) to prompts. This shifted the CLS token position. Fixed by setting `hf_config.is_encoder_decoder=False` for pooling models, with `ModelConfig.is_encoder_decoder` `@cached_property` invalidation.

- **MEAN pooling instead of CLS**: Setting `pooler_config.pooling_type="CLS"` after `PoolerConfig.__post_init__` doesn't update `seq_pooling_type` (already set to model default "MEAN" by `ModelConfig`). Fixed by setting `seq_pooling_type="CLS"` directly. Also builds the embed pooler without ST Dense projection since RBLN encoder models produce raw hidden states.

## Test plan

- [x] T5EncoderModel scoring: `llm.score()` with `sentence-transformers/sentence-t5-base`
- [x] Verify score matches golden (HF T5EncoderModel CLS + normalize): ~0.136
- [x] BERT/RoBERTa classification models: regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)