### PR TITLE
fix(core): account for draft model memory in speculative decoding

### DIFF
--- a/examples/experimental/run_specdec_eagle_test.py
+++ b/examples/experimental/run_specdec_eagle_test.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+os.environ["RBLN_USE_CUSTOM_KERNEL"] = "1"
 os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
 os.environ["VLLM_RBLN_COMPILE_STRICT_MODE"] = "1"
 os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"

--- a/examples/experimental/run_specdec_eagle_test.py
+++ b/examples/experimental/run_specdec_eagle_test.py
@@ -18,14 +18,10 @@ import re
 from pathlib import Path
 from typing import Any
 
-os.environ["RBLN_USE_CUSTOM_KERNEL"] = "1"
 os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
 os.environ["VLLM_RBLN_COMPILE_STRICT_MODE"] = "1"
 os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
 os.environ["VLLM_RBLN_ENABLE_WARM_UP"] = "1"
-os.environ["VLLM_RBLN_SAMPLER"] = "0"
-# vLLM(v0.10.2) bug: speculative decoding works only in multi-processing.
-# os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -230,7 +226,6 @@ def main():
         },
         disable_log_stats=False,
         tensor_parallel_size=args.tensor_parallel_size,
-        gpu_memory_utilization=0.5,
     )
 
     sampling_params = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=128)

--- a/examples/experimental/run_specdec_medusa_test.py
+++ b/examples/experimental/run_specdec_medusa_test.py
@@ -23,7 +23,6 @@ os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
 os.environ["VLLM_RBLN_COMPILE_STRICT_MODE"] = "1"
 os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
 os.environ["VLLM_RBLN_ENABLE_WARM_UP"] = "1"
-os.environ["VLLM_RBLN_SAMPLER"] = "0"
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -234,7 +233,6 @@ def main() -> None:
         },
         disable_log_stats=False,
         tensor_parallel_size=args.tensor_parallel_size,
-        gpu_memory_utilization=0.8,
     )
 
     sampling_params = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=128)

--- a/tests/torch_compile/e2e/v1/spec_decode/conftest.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/conftest.py
@@ -17,7 +17,7 @@ import pytest
 
 @pytest.fixture(scope="module", autouse=True)
 def common_specdec_env(monkeypatch_module):
-    monkeypatch_module.setenv("VLLM_RBLN_USE_CUSTOM_KERNEL", "1")
+    monkeypatch_module.setenv("RBLN_USE_CUSTOM_KERNEL", "1")
     monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
     monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
     monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")

--- a/tests/torch_compile/e2e/v1/spec_decode/conftest.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/conftest.py
@@ -17,6 +17,8 @@ import pytest
 
 @pytest.fixture(scope="module", autouse=True)
 def common_specdec_env(monkeypatch_module):
+    monkeypatch_module.setenv("VLLM_RBLN_USE_CUSTOM_KERNEL", "1")
     monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
     monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
     monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")
+    monkeypatch_module.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")

--- a/tests/torch_compile/e2e/v1/spec_decode/conftest.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/conftest.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def common_specdec_env(monkeypatch_module):
+    monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
+    monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")

--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_basic.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_basic.py
@@ -31,15 +31,6 @@ PROMPTS = [
 NUM_SPECULATIVE_TOKENS = 3
 
 
-@pytest.fixture(scope="module")
-def llm_env(monkeypatch_module):
-    monkeypatch_module.setenv("VLLM_RBLN_USE_VLLM_MODEL", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
-    monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_SAMPLER", "0")
-
-
 def _build_llm(method: str) -> LLM:
     base_model_id, draft_model_id = get_default_eagle_test_model_ids(method)
     draft_model_id = ensure_vllm_compatible_eagle_draft_model(
@@ -60,12 +51,11 @@ def _build_llm(method: str) -> LLM:
         },
         disable_log_stats=False,
         tensor_parallel_size=1,
-        gpu_memory_utilization=0.5,
     )
 
 
 @pytest.mark.parametrize("method", ["eagle", "eagle3"])
-def test_basic_eagle_generation(llm_env, method: str) -> None:
+def test_basic_eagle_generation(method: str) -> None:
     sampling_params = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=128)
 
     llm = _build_llm(method)

--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
@@ -69,9 +69,17 @@ def _build_eagle_llm(method: str) -> LLM:
     )
 
 
-@pytest.mark.parametrize("method", ["eagle", "eagle3"])
-def test_eagle_matches_base_generation(method: str) -> None:
-    sampling_params = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+@pytest.mark.parametrize(
+    ("method", "max_tokens"),
+    [("eagle", 8), ("eagle3", 32)],
+)
+def test_eagle_matches_base_generation(method: str, max_tokens: int) -> None:
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=max_tokens,
+        ignore_eos=True,
+    )
 
     base_llm = _build_base_llm(method)
     base_outputs = base_llm.generate(PROMPTS, sampling_params=sampling_params)

--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
@@ -32,15 +32,6 @@ PROMPTS = [
 NUM_SPECULATIVE_TOKENS = 3
 
 
-@pytest.fixture(scope="module")
-def llm_env(monkeypatch_module):
-    monkeypatch_module.setenv("VLLM_RBLN_USE_VLLM_MODEL", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
-    monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_SAMPLER", "0")
-
-
 def _build_base_llm(method: str) -> LLM:
     base_model_id, _ = get_default_eagle_test_model_ids(method)
     return LLM(
@@ -52,7 +43,6 @@ def _build_base_llm(method: str) -> LLM:
         max_num_seqs=1,
         disable_log_stats=False,
         tensor_parallel_size=1,
-        gpu_memory_utilization=0.5,
     )
 
 
@@ -76,12 +66,11 @@ def _build_eagle_llm(method: str) -> LLM:
         },
         disable_log_stats=False,
         tensor_parallel_size=1,
-        gpu_memory_utilization=0.5,
     )
 
 
 @pytest.mark.parametrize("method", ["eagle", "eagle3"])
-def test_eagle_matches_base_generation(llm_env, method: str) -> None:
+def test_eagle_matches_base_generation(method: str) -> None:
     sampling_params = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
 
     base_llm = _build_base_llm(method)

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_basic.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_basic.py
@@ -69,5 +69,3 @@ def test_basic_medusa_generation() -> None:
     assert "vllm:spec_decode_num_drafts" in metric_names
     assert "vllm:spec_decode_num_draft_tokens" in metric_names
     assert "vllm:spec_decode_num_accepted_tokens" in metric_names
-
-

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_basic.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_basic.py
@@ -16,29 +16,19 @@
 
 from __future__ import annotations
 
-import pytest
 from vllm import LLM, SamplingParams
 
 from .utils import (
     DEFAULT_MEDUSA_MODEL_ID,
     DEFAULT_MODEL_ID,
     ensure_converted_medusa_adapter,
+    run_in_spawned_process,
 )
 
 PROMPTS = [
     "A robot may not injure a human being",
     "The capital of France is",
 ]
-
-
-@pytest.fixture(scope="module")
-def llm_env(monkeypatch_module):
-    monkeypatch_module.setenv("RBLN_USE_CUSTOM_KERNEL", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_USE_VLLM_MODEL", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
-    monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_SAMPLER", "0")
 
 
 def _build_llm() -> LLM:
@@ -60,11 +50,10 @@ def _build_llm() -> LLM:
         },
         disable_log_stats=False,
         tensor_parallel_size=1,
-        gpu_memory_utilization=0.8,
     )
 
 
-def test_basic_medusa_generation(llm_env) -> None:
+def _run_basic_medusa_generation() -> None:
     sampling_params = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=32)
 
     llm = _build_llm()
@@ -81,3 +70,13 @@ def test_basic_medusa_generation(llm_env) -> None:
     assert "vllm:spec_decode_num_drafts" in metric_names
     assert "vllm:spec_decode_num_draft_tokens" in metric_names
     assert "vllm:spec_decode_num_accepted_tokens" in metric_names
+
+
+def test_basic_medusa_generation():
+    run_in_spawned_process(
+        module_name=__name__,
+        func_name="_run_basic_medusa_generation",
+        env={
+            "RBLN_USE_CUSTOM_KERNEL": "1",
+        },
+    )

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_basic.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_basic.py
@@ -22,7 +22,6 @@ from .utils import (
     DEFAULT_MEDUSA_MODEL_ID,
     DEFAULT_MODEL_ID,
     ensure_converted_medusa_adapter,
-    run_in_spawned_process,
 )
 
 PROMPTS = [
@@ -53,7 +52,7 @@ def _build_llm() -> LLM:
     )
 
 
-def _run_basic_medusa_generation() -> None:
+def test_basic_medusa_generation() -> None:
     sampling_params = SamplingParams(temperature=0.1, top_p=0.9, max_tokens=32)
 
     llm = _build_llm()
@@ -72,11 +71,3 @@ def _run_basic_medusa_generation() -> None:
     assert "vllm:spec_decode_num_accepted_tokens" in metric_names
 
 
-def test_basic_medusa_generation():
-    run_in_spawned_process(
-        module_name=__name__,
-        func_name="_run_basic_medusa_generation",
-        env={
-            "RBLN_USE_CUSTOM_KERNEL": "1",
-        },
-    )

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -24,7 +24,6 @@ from .utils import (
     DEFAULT_MEDUSA_MODEL_ID,
     DEFAULT_MODEL_ID,
     ensure_converted_medusa_adapter,
-    run_in_spawned_process,
 )
 
 PROMPTS = [
@@ -67,7 +66,7 @@ def _build_medusa_llm() -> LLM:
     )
 
 
-def _run_medusa_matches_base_generation() -> None:
+def test_medusa_matches_base_generation() -> None:
     sampling_params = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
 
     base_llm = _build_base_llm()
@@ -92,11 +91,3 @@ def _run_medusa_matches_base_generation() -> None:
         assert base_output.outputs[0].token_ids == medusa_output.outputs[0].token_ids
 
 
-def test_medusa_matches_base_generation():
-    run_in_spawned_process(
-        module_name=__name__,
-        func_name="_run_medusa_matches_base_generation",
-        env={
-            "RBLN_USE_CUSTOM_KERNEL": "1",
-        },
-    )

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -67,7 +67,12 @@ def _build_medusa_llm() -> LLM:
 
 
 def test_medusa_matches_base_generation() -> None:
-    sampling_params = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=8,
+        ignore_eos=True,
+    )
 
     base_llm = _build_base_llm()
     base_outputs = base_llm.generate(PROMPTS, sampling_params=sampling_params)

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -89,5 +89,3 @@ def test_medusa_matches_base_generation() -> None:
         )
         assert base_output.outputs[0].text == medusa_output.outputs[0].text
         assert base_output.outputs[0].token_ids == medusa_output.outputs[0].token_ids
-
-

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -18,28 +18,18 @@ from __future__ import annotations
 
 import gc
 
-import pytest
 from vllm import LLM, SamplingParams
 
 from .utils import (
     DEFAULT_MEDUSA_MODEL_ID,
     DEFAULT_MODEL_ID,
     ensure_converted_medusa_adapter,
+    run_in_spawned_process,
 )
 
 PROMPTS = [
     "The capital of France is",
 ]
-
-
-@pytest.fixture(scope="module")
-def llm_env(monkeypatch_module):
-    monkeypatch_module.setenv("RBLN_USE_CUSTOM_KERNEL", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_USE_VLLM_MODEL", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_COMPILE_STRICT_MODE", "1")
-    monkeypatch_module.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_ENABLE_WARM_UP", "1")
-    monkeypatch_module.setenv("VLLM_RBLN_SAMPLER", "0")
 
 
 def _build_base_llm() -> LLM:
@@ -52,7 +42,6 @@ def _build_base_llm() -> LLM:
         max_num_seqs=1,
         disable_log_stats=False,
         tensor_parallel_size=1,
-        gpu_memory_utilization=0.8,
     )
 
 
@@ -75,11 +64,10 @@ def _build_medusa_llm() -> LLM:
         },
         disable_log_stats=False,
         tensor_parallel_size=1,
-        gpu_memory_utilization=0.8,
     )
 
 
-def test_medusa_matches_base_generation(llm_env) -> None:
+def _run_medusa_matches_base_generation() -> None:
     sampling_params = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
 
     base_llm = _build_base_llm()
@@ -102,3 +90,13 @@ def test_medusa_matches_base_generation(llm_env) -> None:
         )
         assert base_output.outputs[0].text == medusa_output.outputs[0].text
         assert base_output.outputs[0].token_ids == medusa_output.outputs[0].token_ids
+
+
+def test_medusa_matches_base_generation():
+    run_in_spawned_process(
+        module_name=__name__,
+        func_name="_run_medusa_matches_base_generation",
+        env={
+            "RBLN_USE_CUSTOM_KERNEL": "1",
+        },
+    )

--- a/tests/torch_compile/e2e/v1/spec_decode/utils.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/utils.py
@@ -16,12 +16,8 @@
 
 from __future__ import annotations
 
-import importlib
 import json
-import multiprocessing
-import os
 import re
-import traceback
 from pathlib import Path
 from typing import Any
 
@@ -279,57 +275,6 @@ def ensure_vllm_compatible_eagle_draft_model(
     return str(out_dir)
 
 
-def _spawn_entry(
-    module_name: str,
-    func_name: str,
-    env: dict[str, str],
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    error_queue,
-) -> None:
-    for key, value in env.items():
-        os.environ[key] = value
-
-    try:
-        module = importlib.import_module(module_name)
-        func = getattr(module, func_name)
-        func(*args, **kwargs)
-    except BaseException:
-        error_queue.put(traceback.format_exc())
-        raise
-
-
-def run_in_spawned_process(
-    *,
-    module_name: str,
-    func_name: str,
-    env: dict[str, str] | None = None,
-    args: tuple[Any, ...] = (),
-    kwargs: dict[str, Any] | None = None,
-) -> None:
-    ctx = multiprocessing.get_context("spawn")
-    error_queue = ctx.Queue()
-    proc = ctx.Process(
-        target=_spawn_entry,
-        args=(
-            module_name,
-            func_name,
-            env or {},
-            args,
-            kwargs or {},
-            error_queue,
-        ),
-    )
-    proc.start()
-    proc.join()
-
-    if proc.exitcode != 0:
-        tb = ""
-        if not error_queue.empty():
-            tb = error_queue.get()
-        raise AssertionError(f"Spawned process exited with code {proc.exitcode}\n{tb}")
-
-
 __all__ = [
     "DEFAULT_EAGLE_TEST_MODEL_IDS",
     "DEFAULT_MEDUSA_MODEL_ID",
@@ -337,5 +282,4 @@ __all__ = [
     "ensure_converted_medusa_adapter",
     "ensure_vllm_compatible_eagle_draft_model",
     "get_default_eagle_test_model_ids",
-    "run_in_spawned_process",
 ]

--- a/tests/torch_compile/e2e/v1/spec_decode/utils.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/utils.py
@@ -16,8 +16,12 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+import multiprocessing
+import os
 import re
+import traceback
 from pathlib import Path
 from typing import Any
 
@@ -275,6 +279,57 @@ def ensure_vllm_compatible_eagle_draft_model(
     return str(out_dir)
 
 
+def _spawn_entry(
+    module_name: str,
+    func_name: str,
+    env: dict[str, str],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    error_queue,
+) -> None:
+    for key, value in env.items():
+        os.environ[key] = value
+
+    try:
+        module = importlib.import_module(module_name)
+        func = getattr(module, func_name)
+        func(*args, **kwargs)
+    except BaseException:
+        error_queue.put(traceback.format_exc())
+        raise
+
+
+def run_in_spawned_process(
+    *,
+    module_name: str,
+    func_name: str,
+    env: dict[str, str] | None = None,
+    args: tuple[Any, ...] = (),
+    kwargs: dict[str, Any] | None = None,
+) -> None:
+    ctx = multiprocessing.get_context("spawn")
+    error_queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_spawn_entry,
+        args=(
+            module_name,
+            func_name,
+            env or {},
+            args,
+            kwargs or {},
+            error_queue,
+        ),
+    )
+    proc.start()
+    proc.join()
+
+    if proc.exitcode != 0:
+        tb = ""
+        if not error_queue.empty():
+            tb = error_queue.get()
+        raise AssertionError(f"Spawned process exited with code {proc.exitcode}\n{tb}")
+
+
 __all__ = [
     "DEFAULT_EAGLE_TEST_MODEL_IDS",
     "DEFAULT_MEDUSA_MODEL_ID",
@@ -282,4 +337,5 @@ __all__ = [
     "ensure_converted_medusa_adapter",
     "ensure_vllm_compatible_eagle_draft_model",
     "get_default_eagle_test_model_ids",
+    "run_in_spawned_process",
 ]

--- a/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
+++ b/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
@@ -80,8 +80,8 @@ class FakeRunner:
         self.kv_caches = [torch.tensor([11], dtype=torch.int32)]
         self._is_prefill = is_prefill
 
-    def is_prefills(self):
-        return [self._is_prefill]
+    def is_prefill_phase(self):
+        return self._is_prefill
 
 
 def make_common_attn_metadata(

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -794,8 +794,8 @@ class TestDetermineAvailableMemory:
     def test_draft_model_kernel_size_is_added(self):
         worker = self._setup()
         draft_model = MagicMock()
-        draft_model.named_parameters.return_value = [
-            ("draft.weight", torch.zeros(40, dtype=torch.bfloat16)),
+        draft_model.parameters.return_value = [
+            torch.zeros(40, dtype=torch.bfloat16),
         ]
         worker.model_runner.drafter = SimpleNamespace(model=draft_model)
         worker.speculative_config = SimpleNamespace(
@@ -818,15 +818,18 @@ class TestDetermineAvailableMemory:
             worker.determine_available_memory()
 
         assert kernel_est.call_count == 2
+        assert kernel_est.call_args_list[0].kwargs["n_model_bytes"] == 300
+        assert kernel_est.call_args_list[1].kwargs["n_model_bytes"] == 80
         assert est.call_args.kwargs["kernel_size"] == 520
-        assert "n_model_params" not in est.call_args.kwargs
+        assert est.call_args.kwargs["num_runtimes"] == 4
+        assert "n_model_bytes" not in est.call_args.kwargs
 
     def test_draft_model_fp8_params_are_reflected_in_kernel_estimation(self):
         worker = self._setup()
         draft_model = MagicMock()
-        draft_model.named_parameters.return_value = [
-            ("draft.attn.weight", torch.zeros(100, dtype=torch.bfloat16)),
-            ("draft.mlp.weight", torch.zeros(50, dtype=torch.uint8)),
+        draft_model.parameters.return_value = [
+            torch.zeros(100, dtype=torch.bfloat16),
+            torch.zeros(50, dtype=torch.uint8),
         ]
         worker.model_runner.drafter = SimpleNamespace(model=draft_model)
         worker.speculative_config = SimpleNamespace(
@@ -850,8 +853,7 @@ class TestDetermineAvailableMemory:
 
         draft_call = kernel_est.call_args_list[1].kwargs
         assert draft_call["parallel_config"] is worker.parallel_config
-        assert draft_call["nbits_per_param"] == 8
-        assert draft_call["n_model_params"] == 150
+        assert draft_call["n_model_bytes"] == 250
 
 
 # ===========================================================================

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -824,7 +824,8 @@ class TestDetermineAvailableMemory:
         assert est.call_args.kwargs["num_runtimes"] == 4
         assert "n_model_bytes" not in est.call_args.kwargs
 
-    def test_draft_model_fp8_params_are_reflected_in_kernel_estimation(self):
+    @pytest.mark.parametrize("quantization", ["fp8", "mxfp4", "compressed-tensors"])
+    def test_draft_model_quantization_is_rejected(self, quantization):
         worker = self._setup()
         draft_model = MagicMock()
         draft_model.parameters.return_value = [
@@ -833,78 +834,7 @@ class TestDetermineAvailableMemory:
         ]
         worker.model_runner.drafter = SimpleNamespace(model=draft_model)
         worker.speculative_config = SimpleNamespace(
-            draft_model_config=SimpleNamespace(quantization="fp8"),
-            draft_parallel_config=None,
-        )
-
-        with (
-            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
-            patch(
-                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
-                side_effect=[400, 120],
-            ) as kernel_est,
-            patch(
-                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
-                return_value=10**9,
-            ),
-        ):
-            plat.get_device_name.return_value = "RBLN-CA25"
-            worker.determine_available_memory()
-
-        draft_call = kernel_est.call_args_list[1].kwargs
-        assert draft_call["parallel_config"] is worker.parallel_config
-        assert draft_call["n_model_bytes"] == 250
-
-    def test_draft_model_compressed_tensors_without_num_bits_assumes_fp8(self):
-        worker = self._setup()
-        draft_model = MagicMock()
-        draft_model.parameters.return_value = [
-            torch.zeros(100, dtype=torch.bfloat16),
-            torch.zeros(50, dtype=torch.uint8),
-        ]
-        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
-        worker.speculative_config = SimpleNamespace(
-            draft_model_config=SimpleNamespace(
-                quantization="compressed-tensors",
-                hf_config=SimpleNamespace(
-                    quantization_config={"config_groups": {"g0": {"weights": {}}}}
-                ),
-            ),
-            draft_parallel_config=None,
-        )
-
-        with (
-            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
-            patch(
-                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
-                side_effect=[400, 120],
-            ) as kernel_est,
-            patch(
-                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
-                return_value=10**9,
-            ),
-            patch("vllm_rbln.v1.worker.rbln_worker.logger.warning") as warn,
-        ):
-            plat.get_device_name.return_value = "RBLN-CA25"
-            worker.determine_available_memory()
-
-        assert "assuming fp8" in warn.call_args.args[0]
-        assert kernel_est.call_args_list[1].kwargs["n_model_bytes"] == 250
-
-    def test_draft_model_compressed_tensors_rejects_unsupported_bit_width(self):
-        worker = self._setup()
-        draft_model = MagicMock()
-        draft_model.parameters.return_value = [torch.zeros(40, dtype=torch.uint8)]
-        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
-        worker.speculative_config = SimpleNamespace(
-            draft_model_config=SimpleNamespace(
-                quantization="compressed-tensors",
-                hf_config=SimpleNamespace(
-                    quantization_config={
-                        "config_groups": {"g0": {"weights": {"num_bits": 4}}}
-                    }
-                ),
-            ),
+            draft_model_config=SimpleNamespace(quantization=quantization),
             draft_parallel_config=None,
         )
 
@@ -916,48 +846,11 @@ class TestDetermineAvailableMemory:
             ),
         ):
             plat.get_device_name.return_value = "RBLN-CA25"
-            with pytest.raises(ValueError, match="unsupported bit-widths"):
+            with pytest.raises(
+                ValueError,
+                match="draft model quantization is not supported",
+            ):
                 worker.determine_available_memory()
-
-    @pytest.mark.parametrize(
-        ("device_name", "expected_bytes"),
-        [
-            ("RBLN-CA25", 440),
-            ("RBLN-CR100", 264),
-        ],
-    )
-    def test_draft_model_mxfp4_params_are_reflected_in_kernel_estimation(
-        self,
-        device_name,
-        expected_bytes,
-    ):
-        worker = self._setup()
-        draft_model = MagicMock()
-        draft_model.parameters.return_value = [
-            torch.zeros(100, dtype=torch.bfloat16),
-            torch.zeros(64, dtype=torch.uint8),
-        ]
-        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
-        worker.speculative_config = SimpleNamespace(
-            draft_model_config=SimpleNamespace(quantization="mxfp4"),
-            draft_parallel_config=None,
-        )
-
-        with (
-            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
-            patch(
-                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
-                side_effect=[400, 120],
-            ) as kernel_est,
-            patch(
-                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
-                return_value=10**9,
-            ),
-        ):
-            plat.get_device_name.return_value = device_name
-            worker.determine_available_memory()
-
-        assert kernel_est.call_args_list[1].kwargs["n_model_bytes"] == expected_bytes
 
 
 # ===========================================================================

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -855,6 +855,110 @@ class TestDetermineAvailableMemory:
         assert draft_call["parallel_config"] is worker.parallel_config
         assert draft_call["n_model_bytes"] == 250
 
+    def test_draft_model_compressed_tensors_without_num_bits_assumes_fp8(self):
+        worker = self._setup()
+        draft_model = MagicMock()
+        draft_model.parameters.return_value = [
+            torch.zeros(100, dtype=torch.bfloat16),
+            torch.zeros(50, dtype=torch.uint8),
+        ]
+        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
+        worker.speculative_config = SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                quantization="compressed-tensors",
+                hf_config=SimpleNamespace(
+                    quantization_config={"config_groups": {"g0": {"weights": {}}}}
+                ),
+            ),
+            draft_parallel_config=None,
+        )
+
+        with (
+            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
+                side_effect=[400, 120],
+            ) as kernel_est,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
+                return_value=10**9,
+            ),
+            patch("vllm_rbln.v1.worker.rbln_worker.logger.warning") as warn,
+        ):
+            plat.get_device_name.return_value = "RBLN-CA25"
+            worker.determine_available_memory()
+
+        assert "assuming fp8" in warn.call_args.args[0]
+        assert kernel_est.call_args_list[1].kwargs["n_model_bytes"] == 250
+
+    def test_draft_model_compressed_tensors_rejects_unsupported_bit_width(self):
+        worker = self._setup()
+        draft_model = MagicMock()
+        draft_model.parameters.return_value = [torch.zeros(40, dtype=torch.uint8)]
+        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
+        worker.speculative_config = SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                quantization="compressed-tensors",
+                hf_config=SimpleNamespace(
+                    quantization_config={
+                        "config_groups": {"g0": {"weights": {"num_bits": 4}}}
+                    }
+                ),
+            ),
+            draft_parallel_config=None,
+        )
+
+        with (
+            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
+                return_value=400,
+            ),
+        ):
+            plat.get_device_name.return_value = "RBLN-CA25"
+            with pytest.raises(ValueError, match="unsupported bit-widths"):
+                worker.determine_available_memory()
+
+    @pytest.mark.parametrize(
+        ("device_name", "expected_bytes"),
+        [
+            ("RBLN-CA25", 440),
+            ("RBLN-CR100", 264),
+        ],
+    )
+    def test_draft_model_mxfp4_params_are_reflected_in_kernel_estimation(
+        self,
+        device_name,
+        expected_bytes,
+    ):
+        worker = self._setup()
+        draft_model = MagicMock()
+        draft_model.parameters.return_value = [
+            torch.zeros(100, dtype=torch.bfloat16),
+            torch.zeros(64, dtype=torch.uint8),
+        ]
+        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
+        worker.speculative_config = SimpleNamespace(
+            draft_model_config=SimpleNamespace(quantization="mxfp4"),
+            draft_parallel_config=None,
+        )
+
+        with (
+            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
+                side_effect=[400, 120],
+            ) as kernel_est,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
+                return_value=10**9,
+            ),
+        ):
+            plat.get_device_name.return_value = device_name
+            worker.determine_available_memory()
+
+        assert kernel_est.call_args_list[1].kwargs["n_model_bytes"] == expected_bytes
+
 
 # ===========================================================================
 # Tests: compile_or_warm_up_model

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -791,6 +791,68 @@ class TestDetermineAvailableMemory:
         # bf16: 100*2 = 200; uint8 fp8: 50 * 1 * 1.0 * 8 // 8 = 50
         assert est.call_args.kwargs["n_model_bytes"] == 250
 
+    def test_draft_model_kernel_size_is_added(self):
+        worker = self._setup()
+        draft_model = MagicMock()
+        draft_model.named_parameters.return_value = [
+            ("draft.weight", torch.zeros(40, dtype=torch.bfloat16)),
+        ]
+        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
+        worker.speculative_config = SimpleNamespace(
+            draft_model_config=SimpleNamespace(quantization=None),
+            draft_parallel_config=SimpleNamespace(tensor_parallel_size=1),
+        )
+
+        with (
+            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
+                side_effect=[400, 120],
+            ) as kernel_est,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
+                return_value=10**9,
+            ) as est,
+        ):
+            plat.get_device_name.return_value = "RBLN-CA25"
+            worker.determine_available_memory()
+
+        assert kernel_est.call_count == 2
+        assert est.call_args.kwargs["kernel_size"] == 520
+        assert "n_model_params" not in est.call_args.kwargs
+
+    def test_draft_model_fp8_params_are_reflected_in_kernel_estimation(self):
+        worker = self._setup()
+        draft_model = MagicMock()
+        draft_model.named_parameters.return_value = [
+            ("draft.attn.weight", torch.zeros(100, dtype=torch.bfloat16)),
+            ("draft.mlp.weight", torch.zeros(50, dtype=torch.uint8)),
+        ]
+        worker.model_runner.drafter = SimpleNamespace(model=draft_model)
+        worker.speculative_config = SimpleNamespace(
+            draft_model_config=SimpleNamespace(quantization="fp8"),
+            draft_parallel_config=None,
+        )
+
+        with (
+            patch("vllm_rbln.v1.worker.rbln_worker.current_platform") as plat,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_model_kernel_size",
+                side_effect=[400, 120],
+            ) as kernel_est,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.estimate_available_memory",
+                return_value=10**9,
+            ),
+        ):
+            plat.get_device_name.return_value = "RBLN-CA25"
+            worker.determine_available_memory()
+
+        draft_call = kernel_est.call_args_list[1].kwargs
+        assert draft_call["parallel_config"] is worker.parallel_config
+        assert draft_call["nbits_per_param"] == 8
+        assert draft_call["n_model_params"] == 150
+
 
 # ===========================================================================
 # Tests: compile_or_warm_up_model

--- a/tests/torch_compile/unit/v1/worker/test_utils.py
+++ b/tests/torch_compile/unit/v1/worker/test_utils.py
@@ -22,6 +22,7 @@ from vllm.platforms.cpu import LogicalCPUInfo
 
 from vllm_rbln.v1.worker.utils import (
     estimate_available_memory,
+    estimate_model_kernel_size,
     get_autobind_cpu_ids,
     set_cpu_affinity,
     set_omp_num_threads,
@@ -69,6 +70,47 @@ def _make_cpu(cpu_id, physical_core, numa_node):
 # ---------------------------------------------------------------------------
 # estimate_available_memory
 # ---------------------------------------------------------------------------
+class TestEstimateModelKernelSize:
+    @patch("vllm_rbln.v1.worker.utils.current_platform")
+    def test_bytes_path_estimates_kernel_size(self, mock_platform):
+        mock_platform.get_device_name.return_value = "RBLN-CA12"
+
+        model_cfg = _make_model_config(num_layers=2, vocab_size=64, hidden_size=32)
+        parallel_cfg = _make_parallel_config(tp_size=1)
+
+        result = estimate_model_kernel_size(
+            model_cfg,
+            parallel_cfg,
+            n_model_bytes=12_288,
+        )
+
+        assert result == 6_291_456
+
+    @patch("vllm_rbln.v1.worker.utils.current_platform")
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({}, "Either `n_model_params` or `n_model_bytes`"),
+            (
+                {"n_model_params": 1_000_000, "n_model_bytes": 2_000_000},
+                "Only one of `n_model_params` or `n_model_bytes`",
+            ),
+            (
+                {"n_model_params": 1_000_000},
+                "`nbits_per_param` should be specified",
+            ),
+        ],
+    )
+    def test_validates_input_combinations(self, mock_platform, kwargs, match):
+        mock_platform.get_device_name.return_value = "RBLN-CA12"
+
+        model_cfg = _make_model_config()
+        parallel_cfg = _make_parallel_config()
+
+        with pytest.raises(ValueError, match=match):
+            estimate_model_kernel_size(model_cfg, parallel_cfg, **kwargs)
+
+
 class TestEstimateAvailableMemory:
     """Test DRAM estimation for ATOM and REBEL devices."""
 
@@ -159,6 +201,22 @@ class TestEstimateAvailableMemory:
 
     @patch("vllm_rbln.v1.worker.utils.current_platform")
     @patch("vllm_rbln.v1.worker.utils.envs")
+    def test_estimated_kernel_size_from_bytes(self, mock_envs, mock_platform):
+        mock_platform.get_device_name.return_value = "RBLN-CA12"
+        mock_envs.VLLM_RBLN_TP_SIZE = 1
+
+        model_cfg = _make_model_config(num_layers=2, vocab_size=64, hidden_size=32)
+        parallel_cfg = _make_parallel_config(tp_size=1)
+
+        result = estimate_available_memory(
+            model_cfg,
+            parallel_cfg,
+            n_model_bytes=12_288,
+        )
+        assert result > 0
+
+    @patch("vllm_rbln.v1.worker.utils.current_platform")
+    @patch("vllm_rbln.v1.worker.utils.envs")
     def test_no_params_no_kernel_raises(self, mock_envs, mock_platform):
         """If neither kernel_size nor n_model_params given, should raise."""
         mock_platform.get_device_name.return_value = "RBLN-CA12"
@@ -169,6 +227,22 @@ class TestEstimateAvailableMemory:
 
         with pytest.raises(ValueError, match="n_model_params.*should be specified"):
             estimate_available_memory(model_cfg, parallel_cfg)
+
+    @patch("vllm_rbln.v1.worker.utils.current_platform")
+    @patch("vllm_rbln.v1.worker.utils.envs")
+    def test_n_model_params_requires_nbits(self, mock_envs, mock_platform):
+        mock_platform.get_device_name.return_value = "RBLN-CA12"
+        mock_envs.VLLM_RBLN_TP_SIZE = 1
+
+        model_cfg = _make_model_config()
+        parallel_cfg = _make_parallel_config()
+
+        with pytest.raises(ValueError, match="`nbits_per_param` should be specified"):
+            estimate_available_memory(
+                model_cfg,
+                parallel_cfg,
+                n_model_params=1_000_000,
+            )
 
     @patch("vllm_rbln.v1.worker.utils.current_platform")
     @patch("vllm_rbln.v1.worker.utils.envs")

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -66,6 +66,7 @@ class RBLNEagleProposer(EagleProposer):
         | None = None,
     ) -> torch.Tensor:
         batch_size = next_token_ids.shape[0]
+        is_prefill = self.runner.is_prefill_phase()
 
         if self.method == "eagle3":
             # assert isinstance(
@@ -97,11 +98,9 @@ class RBLNEagleProposer(EagleProposer):
         num_padded_tokens = None
         num_tokens_across_dp = None
         extra_attn_metadata_args = {}
-        extra_attn_metadata_args["num_tokens"] = (
-            self.runner.input_batch.num_tokens_no_spec
-        )
         extra_attn_metadata_args["positions"] = target_positions.cpu()
         extra_attn_metadata_args["batch_pad"] = batch_bucket_size
+        extra_attn_metadata_args["is_prefill"] = is_prefill
         per_layer_attn_metadata: dict[str, object] = {}
         for attn_group in self.draft_attn_groups:
             attn_metadata = attn_group.get_metadata_builder().build(
@@ -133,7 +132,6 @@ class RBLNEagleProposer(EagleProposer):
             inputs_embeds = self.inputs_embeds[:num_input_tokens]
         else:
             # NOTE(RBLN): reshape tensors in the same way as the RBLN model runner.
-            is_prefill = self.runner.is_prefills()[0]
             if is_prefill:
                 input_ids = self.input_ids.view(batch_size, -1)
                 positions = rbln_utils.pad(
@@ -272,11 +270,9 @@ class RBLNEagleProposer(EagleProposer):
 
             # Rebuild attention metadata
             extra_attn_metadata_args = {}
-            extra_attn_metadata_args["num_tokens"] = (
-                common_attn_metadata.seq_lens.cpu().numpy()
-            )
             extra_attn_metadata_args["positions"] = positions.cpu()
             extra_attn_metadata_args["batch_pad"] = batch_bucket_size
+            extra_attn_metadata_args["is_prefill"] = False
             for attn_group in self.draft_attn_groups:
                 attn_metadata = attn_group.get_metadata_builder().build(
                     common_prefix_len=0,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -315,6 +315,12 @@ class RBLNWorker(WorkerBase):
             if draft_parallel_config is None:
                 draft_parallel_config = self.parallel_config
 
+            draft_quantization = getattr(draft_model_config, "quantization", None)
+            if draft_quantization is not None:
+                raise ValueError(
+                    f"draft model quantization is not supported: {draft_quantization}"
+                )
+
             model_kernel_size = estimate_model_kernel_size(
                 model_config=self.model_config,
                 parallel_config=self.parallel_config,
@@ -323,76 +329,9 @@ class RBLNWorker(WorkerBase):
 
             num_draft_runtimes = 1 + decode_batch_buckets_count
             draft_n_model_bytes = 0
-            draft_ratio: float = 1.0
-            if getattr(draft_model_config, "quantization", None) is not None:
-                logger.info(
-                    "draft model quantization scheme = %s",
-                    draft_model_config.quantization,
-                )
-                quantization = draft_model_config.quantization
-                assert quantization in ("mxfp4", "fp8", "compressed-tensors")
-
-                if quantization == "compressed-tensors":
-                    qcfg = (
-                        getattr(
-                            getattr(draft_model_config, "hf_config", None),
-                            "quantization_config",
-                            {},
-                        )
-                        or {}
-                    )
-                    groups = qcfg.get("config_groups", {})
-                    num_bits_set = set()
-                    for group_cfg in groups.values():
-                        nb = group_cfg.get("weights", {}).get("num_bits")
-                        if nb is not None:
-                            num_bits_set.add(nb)
-                    if not num_bits_set:
-                        logger.warning(
-                            "compressed-tensors quantization_config has no num_bits; "
-                            "assuming fp8."
-                        )
-                    elif num_bits_set != {8}:
-                        raise ValueError(
-                            f"compressed-tensors config has unsupported bit-widths "
-                            f"{num_bits_set}; only 8-bit (fp8) is supported."
-                        )
-                    quantization = "fp8"
-
-                if quantization == "fp8":
-                    draft_nbits_per_param = 8
-                    draft_packed_num_elems = 1
-                elif quantization == "mxfp4":
-                    if "ca" in device_name:
-                        draft_nbits_per_param = 16
-                        draft_ratio = 16 / 17
-                    elif "cr" in device_name:
-                        draft_nbits_per_param = 4
-                    else:
-                        raise ValueError(
-                            "invalid RBLN architecture, "
-                            "candidates = [ATOM(ca), REBEL(cr)]"
-                        )
-                    draft_packed_num_elems = 8 // 4
-                else:
-                    raise ValueError(
-                        "invalid quantization scheme, candidates = [fp8, mxfp4]"
-                    )
-            else:
-                draft_nbits_per_param = 16
-                draft_packed_num_elems = 1
 
             for value in draft_model.parameters():
-                if value.is_floating_point():
-                    draft_n_model_bytes += value.numel() * value.element_size()
-                else:
-                    draft_n_model_bytes += int(
-                        value.numel()
-                        * draft_packed_num_elems
-                        * draft_ratio
-                        * draft_nbits_per_param
-                        // 8
-                    )
+                draft_n_model_bytes += value.numel() * value.element_size()
 
             draft_kernel_size = estimate_model_kernel_size(
                 model_config=draft_model_config,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -342,7 +342,7 @@ class RBLNWorker(WorkerBase):
                         or {}
                     )
                     groups = qcfg.get("config_groups", {})
-                    num_bits_set: set[int] = set()
+                    num_bits_set = set()
                     for group_cfg in groups.values():
                         nb = group_cfg.get("weights", {}).get("num_bits")
                         if nb is not None:

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -65,6 +65,7 @@ from vllm_rbln.logger import init_logger
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.v1.worker.utils import (
     estimate_available_memory,
+    estimate_model_kernel_size,
     get_rbln_planned_affinity_cpu_count,
     set_cpu_affinity,
     set_omp_num_threads,
@@ -283,7 +284,7 @@ class RBLNWorker(WorkerBase):
             packed_num_elems = 1
 
         n_model_bytes = 0
-        for key, value in params_dict.items():
+        for value in params_dict.values():
             if value.is_floating_point():
                 n_model_bytes += value.numel() * value.element_size()
             else:
@@ -293,13 +294,122 @@ class RBLNWorker(WorkerBase):
 
         logger.info("n_model_bytes = %.2f GB", n_model_bytes / 1024**3)
 
-        available_memory_estimate = estimate_available_memory(
+        estimate_kwargs = dict(
             model_config=self.model_config,
             parallel_config=self.parallel_config,
-            n_model_bytes=n_model_bytes,
             num_runtimes=num_runtimes,
             gpu_memory_utilization=self.cache_config.gpu_memory_utilization,
         )
+
+        speculative_config = getattr(self, "speculative_config", None)
+        drafter = getattr(self.model_runner, "drafter", None)
+        draft_model = getattr(drafter, "model", None)
+        draft_model_config = getattr(speculative_config, "draft_model_config", None)
+        draft_parallel_config = getattr(
+            speculative_config,
+            "draft_parallel_config",
+            None,
+        )
+
+        if draft_model is not None and draft_model_config is not None:
+            if draft_parallel_config is None:
+                draft_parallel_config = self.parallel_config
+
+            model_kernel_size = estimate_model_kernel_size(
+                model_config=self.model_config,
+                parallel_config=self.parallel_config,
+                n_model_bytes=n_model_bytes,
+            )
+
+            num_draft_runtimes = 1 + decode_batch_buckets_count
+            draft_n_model_bytes = 0
+            draft_ratio: float = 1.0
+            if getattr(draft_model_config, "quantization", None) is not None:
+                logger.info(
+                    "draft model quantization scheme = %s",
+                    draft_model_config.quantization,
+                )
+                quantization = draft_model_config.quantization
+                assert quantization in ("mxfp4", "fp8", "compressed-tensors")
+
+                if quantization == "compressed-tensors":
+                    qcfg = (
+                        getattr(
+                            getattr(draft_model_config, "hf_config", None),
+                            "quantization_config",
+                            {},
+                        )
+                        or {}
+                    )
+                    groups = qcfg.get("config_groups", {})
+                    num_bits_set: set[int] = set()
+                    for group_cfg in groups.values():
+                        nb = group_cfg.get("weights", {}).get("num_bits")
+                        if nb is not None:
+                            num_bits_set.add(nb)
+                    if not num_bits_set:
+                        logger.warning(
+                            "compressed-tensors quantization_config has no num_bits; "
+                            "assuming fp8."
+                        )
+                    elif num_bits_set != {8}:
+                        raise ValueError(
+                            f"compressed-tensors config has unsupported bit-widths "
+                            f"{num_bits_set}; only 8-bit (fp8) is supported."
+                        )
+                    quantization = "fp8"
+
+                if quantization == "fp8":
+                    draft_nbits_per_param = 8
+                    draft_packed_num_elems = 1
+                elif quantization == "mxfp4":
+                    if "ca" in device_name:
+                        draft_nbits_per_param = 16
+                        draft_ratio = 16 / 17
+                    elif "cr" in device_name:
+                        draft_nbits_per_param = 4
+                    else:
+                        raise ValueError(
+                            "invalid RBLN architecture, "
+                            "candidates = [ATOM(ca), REBEL(cr)]"
+                        )
+                    draft_packed_num_elems = 8 // 4
+                else:
+                    raise ValueError(
+                        "invalid quantization scheme, candidates = [fp8, mxfp4]"
+                    )
+            else:
+                draft_nbits_per_param = 16
+                draft_packed_num_elems = 1
+
+            for value in draft_model.parameters():
+                if value.is_floating_point():
+                    draft_n_model_bytes += value.numel() * value.element_size()
+                else:
+                    draft_n_model_bytes += int(
+                        value.numel()
+                        * draft_packed_num_elems
+                        * draft_ratio
+                        * draft_nbits_per_param
+                        // 8
+                    )
+
+            draft_kernel_size = estimate_model_kernel_size(
+                model_config=draft_model_config,
+                parallel_config=draft_parallel_config,
+                n_model_bytes=draft_n_model_bytes,
+            )
+            estimate_kwargs["num_runtimes"] = num_runtimes + num_draft_runtimes
+            estimate_kwargs["kernel_size"] = model_kernel_size + draft_kernel_size
+            logger.info("draft_n_model_bytes = %.2f GB", draft_n_model_bytes / 1024**3)
+            logger.info(
+                "draft_model_kernel_size = %.2f GB",
+                draft_kernel_size / 1024**3,
+            )
+        else:
+            estimate_kwargs["n_model_bytes"] = n_model_bytes
+
+        available_memory_estimate = estimate_available_memory(**estimate_kwargs)
 
         logger.info(
             "available_memory_estimate = %.2f GiB", available_memory_estimate / 1024**3

--- a/vllm_rbln/v1/worker/utils.py
+++ b/vllm_rbln/v1/worker/utils.py
@@ -75,7 +75,6 @@ def estimate_model_kernel_size(
     lm_heads_nbytes = (
         align_2MB(lm_heads_params * default_bits_per_param // 8 / tp_size) * tp_size
     )
-
     if n_model_bytes is not None:
         lm_heads_bytes = lm_heads_params * default_bits_per_param // 8
         word_embedding_bytes = lm_heads_bytes
@@ -89,9 +88,11 @@ def estimate_model_kernel_size(
             )
         word_embedding_params = lm_heads_params
         params = n_model_params - lm_heads_params - word_embedding_params
-        layer_nbytes = align_2MB(params * nbits_per_param // 8 / num_layers) * num_layers
+        layer_nbytes = (
+            align_2MB(params * nbits_per_param // 8 / num_layers) * num_layers
+        )
 
-    return int(layer_nbytes + lm_heads_nbytes)
+    return layer_nbytes + lm_heads_nbytes
 
 
 # NOTE: This function comes from optimum-rbln. Keep in sync.

--- a/vllm_rbln/v1/worker/utils.py
+++ b/vllm_rbln/v1/worker/utils.py
@@ -31,6 +31,69 @@ from vllm_rbln.logger import init_logger
 logger = init_logger(__name__)
 
 
+def estimate_model_kernel_size(
+    model_config: ModelConfig,
+    parallel_config: ParallelConfig,
+    *,
+    nbits_per_param: int | None = None,
+    n_model_params: int | float | None = None,
+    n_model_bytes: int | float | None = None,
+    default_bits_per_param: int | None = None,
+) -> int:
+    def align(x: int | float, nbytes: int) -> int:
+        return int(math.ceil(x / nbytes) * nbytes)
+
+    def align_2MB(x: int | float) -> int:
+        return align(x, 2**21)
+
+    num_layers = model_config.get_num_layers(parallel_config)
+    vocab_size = model_config.get_vocab_size()
+    hidden_size = model_config.get_hidden_size()
+    tp_size = parallel_config.tensor_parallel_size
+
+    if default_bits_per_param is None:
+        device_name = current_platform.get_device_name().lower()
+        assert "rbln" in device_name
+        if "ca" in device_name or "cr" in device_name:
+            default_bits_per_param = 16
+        else:
+            raise ValueError(
+                "invalid RBLN architecture, candidates = [ATOM(ca), REBEL(cr)]"
+            )
+
+    if n_model_params is None and n_model_bytes is None:
+        raise ValueError(
+            "Either `n_model_params` or `n_model_bytes` should be specified "
+            "to estimate the kernel memory."
+        )
+    if n_model_params is not None and n_model_bytes is not None:
+        raise ValueError(
+            "Only one of `n_model_params` or `n_model_bytes` may be specified."
+        )
+
+    lm_heads_params = align(vocab_size, 64) * hidden_size
+    lm_heads_nbytes = (
+        align_2MB(lm_heads_params * default_bits_per_param // 8 / tp_size) * tp_size
+    )
+
+    if n_model_bytes is not None:
+        lm_heads_bytes = lm_heads_params * default_bits_per_param // 8
+        word_embedding_bytes = lm_heads_bytes
+        layer_bytes = n_model_bytes - lm_heads_bytes - word_embedding_bytes
+        layer_nbytes = align_2MB(layer_bytes / num_layers) * num_layers
+    else:
+        if nbits_per_param is None:
+            raise ValueError(
+                "`nbits_per_param` should be specified when using `n_model_params` "
+                "to estimate the kernel memory."
+            )
+        word_embedding_params = lm_heads_params
+        params = n_model_params - lm_heads_params - word_embedding_params
+        layer_nbytes = align_2MB(params * nbits_per_param // 8 / num_layers) * num_layers
+
+    return int(layer_nbytes + lm_heads_nbytes)
+
+
 # NOTE: This function comes from optimum-rbln. Keep in sync.
 def estimate_available_memory(
     model_config: ModelConfig,
@@ -73,17 +136,7 @@ def estimate_available_memory(
     # After that, we can derive the following equation:
     # x = floor(2**21 / b * floor((k - 1) / 2**21))
 
-    def align(x: int, nbytes: int) -> int:
-        return int(math.ceil(x / nbytes) * nbytes)
-
-    def align_2MB(x: int) -> int:
-        return align(x, 2**21)
-
-    num_layers = model_config.get_num_layers(parallel_config)
-    vocab_size = model_config.get_vocab_size()
-    hidden_size = model_config.get_hidden_size()
     num_key_value_heads = model_config.get_num_kv_heads(parallel_config)
-    tp_size = parallel_config.tensor_parallel_size
 
     device_name = current_platform.get_device_name().lower()
     assert "rbln" in device_name
@@ -135,34 +188,23 @@ def estimate_available_memory(
             raise ValueError(
                 "Only one of `n_model_params` or `n_model_bytes` may be specified."
             )
-        # Get estimated kernel size (approximated)
-        # kernel_size
-        # - QKV params    - model parallel (tp) sharded
-        # - MLP or expert - model parallel (ep) sharded
-        # - word embedding- non sharded,  not included into device,
-        #                   hidden_size * vocab_size
-        # - lm head       - model parallel (tp) sharded,
-        #                   hidden_size * vocab_size
-        lm_heads_params = align(vocab_size, 64) * hidden_size
-        lm_heads_nbytes = (
-            align_2MB(lm_heads_params * default_bits_per_param // 8 / tp_size) * tp_size
-        )
-        if n_model_bytes is not None:
-            lm_heads_bytes = lm_heads_params * default_bits_per_param // 8
-            word_embedding_bytes = lm_heads_params * default_bits_per_param // 8
-            layer_bytes = n_model_bytes - lm_heads_bytes - word_embedding_bytes
-            layer_nbytes = align_2MB(layer_bytes / num_layers) * num_layers
-        else:
-            word_embedding_params = lm_heads_params
-            params = n_model_params - lm_heads_params - word_embedding_params
-            layer_nbytes = (
-                align_2MB(params * nbits_per_param // 8 / num_layers) * num_layers
+        if n_model_params is not None and nbits_per_param is None:
+            raise ValueError(
+                "`nbits_per_param` should be specified when using `n_model_params` "
+                "to estimate the kernel memory."
             )
-        kernel_size = layer_nbytes + lm_heads_nbytes
+        kernel_size = estimate_model_kernel_size(
+            model_config=model_config,
+            parallel_config=parallel_config,
+            nbits_per_param=nbits_per_param,
+            n_model_params=n_model_params,
+            n_model_bytes=n_model_bytes,
+            default_bits_per_param=default_bits_per_param,
+        )
     elif n_model_params is not None or n_model_bytes is not None:
         raise ValueError(
-            "`n_model_params`/`n_model_bytes` and `kernel_size`"
-            " cannot both be specified."
+            "`n_model_params`/`n_model_bytes` and `kernel_size` cannot both be "
+            "specified."
         )
 
     available_dram_bytes -= kernel_size


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

This PR improves speculative decoding stability and memory estimation by accounting for draft model memory in available memory estimation, aligning spec decode paths with the updated attention build interface, and cleaning up the related test/runtime setup.

- Update available memory estimation to account for draft model memory usage, including draft model weights and related runtime/kernel memory, and add coverage for the updated logic.
- Remove outdated example-side `gpu_memory_utilization` constraints and clean up unnecessary environment variable usage that became redundant after the memory estimation fix.
- Fix the EAGLE failure introduced by the attention build interface change.
- Consolidate `spec_decode` test environment setup and fix the Medusa test issue where `RBLN_USE_CUSTOM_KERNEL` was not applied to the actual test process by isolating Medusa e2e execution in a spawned subprocess.
- Adjust related unit/e2e tests to match the updated execution path and interfaces.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [x] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run the updated speculative decoding test suite.

- `pytest tests/torch_compile/unit/v1/spec_decode/test_eagle.py`
- `pytest tests/torch_compile?e2e/v1/spec_decode`

2. Verify that EAGLE and Medusa engines initialize successfully and that the Medusa e2e tests no longer fail due to `RBLN_USE_CUSTOM_KERNEL` not being applied in the test process.
3. Verify that draft-model-aware available memory estimation is used and that the worker logs reflect draft model kernel size / adjusted available memory during initialization.

As part of validation, the updated paths were confirmed to work correctly under the default `gpu_memory_utilization=0.9` setting.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

This PR combines closely related spec decode fixes that were validated together: draft-aware memory estimation, EAGLE compatibility after the attention interface update, and test process isolation for Medusa custom-kernel execution.

EAGLE3 test results could not be verified in this environment because the compiler version currently in use does not support compiling EAGLE3.

Known limitation
- The shared kernel-size estimator still assumes a separate embedding term, so Medusa draft memory is underestimated by roughly one head-size matrix.
- `num_runtimes` is still estimated from the target-model path only, so Medusa/EAGLE-specific draft runtime overhead is not yet modeled precisely.

---
