### PR TITLE
fix(whisper): use vLLM block_tables as decoder batch position

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/whisper.py
+++ b/vllm_rbln/model_executor/models/optimum/whisper.py
@@ -27,13 +27,6 @@ from vllm.utils.jsontree import json_map_leaves
 
 from .base import ModelInputForRBLN
 from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
-from .optimum_attention import (
-    AttentionManager,
-    InnerAttentionEntry,
-    InnerAttentionStrategy,
-    InnerR1,
-    InnerR2,
-)
 
 logger = init_logger(__name__)
 
@@ -82,11 +75,6 @@ class RBLNOptimumWhisperForConditionalGeneration(
         self.dec_max_seq_len = self.model_config.max_model_len
         self.dec_lengths = [0] * self.batch_size
 
-        self.strategy = InnerAttentionStrategy()
-        self.attention_manager: AttentionManager[
-            InnerAttentionStrategy, InnerAttentionEntry, InnerR1, InnerR2
-        ] = AttentionManager(self.strategy)
-
     def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
         input_ids = model_input.input_tokens
         block_tables = model_input.block_tables
@@ -97,13 +85,7 @@ class RBLNOptimumWhisperForConditionalGeneration(
 
         is_prompt = model_input.is_prompt
 
-        table_ids = self.attention_manager.get(
-            is_prompt,
-            self.decoder_batch_size,
-            running_requests_ids,
-            finished_requests_ids,
-        )
-        valid_block_ids = torch.tensor(table_ids)
+        valid_block_ids = block_tables.flatten().to(torch.int16)
 
         if is_prompt:
             if model_input.multi_modal_kwargs:
@@ -138,11 +120,7 @@ class RBLNOptimumWhisperForConditionalGeneration(
             # Set the probability of INVALID_TOKEN (the last token in
             # the logits tensor) to 1.0.
             lm_logits[0][0][-1] = 1
-            self.attention_manager.add(
-                running_requests_ids[0],
-                table_ids[0],
-            )
-            self.dec_lengths[table_ids[0]] = 0
+            self.dec_lengths[valid_block_ids[0].item()] = 0
 
         else:
             input_ids[

--- a/vllm_rbln/model_executor/models/optimum/whisper.py
+++ b/vllm_rbln/model_executor/models/optimum/whisper.py
@@ -83,7 +83,7 @@ class RBLNOptimumWhisperForConditionalGeneration(
 
         is_prompt = model_input.is_prompt
 
-        valid_block_ids = block_tables.flatten().to(torch.int16)
+        valid_block_ids = block_tables.flatten().to(torch.int64)
 
         if is_prompt:
             if model_input.multi_modal_kwargs:

--- a/vllm_rbln/model_executor/models/optimum/whisper.py
+++ b/vllm_rbln/model_executor/models/optimum/whisper.py
@@ -83,7 +83,7 @@ class RBLNOptimumWhisperForConditionalGeneration(
 
         is_prompt = model_input.is_prompt
 
-        valid_block_ids = block_tables.flatten().to(torch.int64)
+        valid_block_ids = block_tables.flatten().to(torch.int32)
 
         if is_prompt:
             if model_input.multi_modal_kwargs:

--- a/vllm_rbln/model_executor/models/optimum/whisper.py
+++ b/vllm_rbln/model_executor/models/optimum/whisper.py
@@ -79,8 +79,6 @@ class RBLNOptimumWhisperForConditionalGeneration(
         input_ids = model_input.input_tokens
         block_tables = model_input.block_tables
 
-        finished_requests_ids = model_input.finished_requests_ids
-        running_requests_ids = model_input.running_requests_ids
         request_nums = input_ids.shape[0]
 
         is_prompt = model_input.is_prompt


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

The Whisper integration reused AttentionManager from sliding-window models for `input_block_ids`, which allocated a local slot via `min(available_ids)`. In sequential mode `attention_manager.pop` emptied the table after each request, so `min` always returned 0 and every new request was placed at decoder batch position 0. 

Meanwhile vLLM's LRU BlockPool kept advancing its block id (0, 1, 2, ...), so the encoder wrote cross-KV to a different slot than the one the decoder batch was going to read from. The decoder then cross-attended to stale KV from sample 0 for every subsequent sequential request.

Drop AttentionManager in Whisper and derive the batch position directly from `block_tables`. This keeps vLLM block id, decoder batch position, and cross-KV slot consistent across sequential, batched, and batches that exceed `batch_size`.

**Fix**
- In `whisper.py`, drop the `AttentionManager` / `InnerAttentionStrategy` import, the init in `__init__`, the `add(...)` call, and the `table_ids` variable.
- Replace them with `valid_block_ids = block_tables.flatten().to(torch.int16)` so that vLLM block id, decoder batch position, and cross-KV slot all share the same numbering.

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
