### PR TITLE
feature(sub-block): emit sub-block-granular KV cache events

### DIFF
--- a/docs/sub_block_prefix_caching.md
+++ b/docs/sub_block_prefix_caching.md
@@ -36,6 +36,11 @@ if the KV cache tensor has a token dimension that can be sliced for partial copy
 The `sub_block_size` is automatically set to prefill chunk size (`max_num_batched_tokens`)
 so that each prefill does not span multiple blocks.
 
+For cross-engine prefix-aware routing (e.g., llm-d):
+enable KV events via `--kv-events-config` in vLLM and
+set the router's token processing block size to vLLM `--max-num-batched-tokens`
+(**not** `--block-size`; see [Using with llm-d](#using-with-llm-d)).
+
 ## Key components
 
 ```
@@ -207,6 +212,133 @@ kv_cache[:, dst_block_id, :, :, :num_tokens, :] = \
   `SubBlockIndex.pop()` whenever the upstream evicts a cached block.
 - **Reset**: `reset_prefix_cache()` clears all sub-block indices and pending
   indexing queue.
+
+## KV cache events
+
+Sub-block caching so far is an intra-engine optimisation:
+one instance serving multiple requests that share a prefix reuses KV locally.
+Prefix-cache-aware routers (e.g. llm-d) extend that reuse *across* engines by
+subscribing to KV events and routing each request to an engine that already
+caches its prefix.
+
+Upstream vLLM emits those events at block granularity.
+For RBLN's 1k–4k token big blocks, that means a partial big block never gets advertised.
+So routers cannot utilize the sub-block prefix information.
+Therefore, we adapt the KV cache manager to emit events at sub-block granularity.
+
+### Contract
+
+When sub-block caching is active, `RBLNKVCacheManager` replaces upstream's
+block events with sub-block-granular ones:
+
+- `BlockStored(parent, [h_0, ..., h_n])`: a chained run of sub-block hashes
+  (each `h_i = hash(h_{i-1}, tokens_i, extras_i)`, with `h_{-1} = parent`)
+  became *newly* cached on this engine.
+- `BlockRemoved([h_0, ..., h_n])`: the *last* big block holding each hash
+  was evicted.
+- `AllBlocksCleared`: all sub-block state cleared.
+
+This is stricter than upstream.
+Upstream emits per-physical-block, so two blocks that happen to hold the same
+hash produce duplicate Store and premature Remove.
+Our Store/Remove fire only on 0↔1 transitions in the per-hash refcount
+(`SubBlockIndex._hash_to_blocks` bucket size), so the stream is a clean
+set-membership view.
+
+#### Why dedup matters here
+
+llm-d's `kvblock.Index` as of 2026-04 treats events as **set-membership**, not
+multiplicity: duplicate Store collapses to one entry, Remove for a missing key
+is a no-op.
+So a single Remove can cause the router to drop a hash the pod still caches in
+another block, and re-route away from a still-warm pod.
+Upstream GPU deployments see this rarely because block-level hash collisions are rare.
+
+Sub-block caching makes the collision path the *common* one.
+Partial matches are serviced by an intra-engine sub-block copy:
+the source big block and the freshly-allocated destination big block both carry
+the same prefix sub-block hashes from the moment of the copy.
+Every partial match mints a handful of duplicates.
+Without dedup, the first eviction of either block would incorrectly signal
+"gone" to llm-d.
+
+Dedup'ing at the hash-refcount level in the engine gives routers exactly the
+set-membership stream they already model, and sidesteps the multiplicity
+mismatch entirely.
+
+#### Dedup is chain-safe
+
+We say that a `BlockStored` event is *chain-safe* if it carries a contiguous,
+reconstructible hash chain:
+using the event's `parent_block_hash` as the seed, re-hashing `token_ids`
+sub-block by sub-block reproduces `block_hashes` entry-by-entry.
+A consumer that re-hashes the prompt to key its index depends on this.
+
+We need dedup to preserve chain-safety.
+If dedup dropped `h_1` out of `[h_0, h_1, h_2]` and emitted `[h_0, h_2]`,
+the consumer would compute `hash(h_0, tokens_h_2)` and miss `h_2`'s real value
+(whose parent is `h_1`, not `h_0`).
+
+Here, dedup never creates such gaps.
+Within one `SubBlockIndex.update` call,
+the "already indexed elsewhere" hashes form a contiguous prefix of the argument list,
+and the fresh hashes form a contiguous suffix.
+This is a consequence of position-chained hashing: if some other block holds
+`h_k`, that block also holds `h_0..h_{k-1}`.
+So we emit one event covering the fresh suffix.
+
+### Single-group only (for now)
+
+Events are gated to single-group configs, matching upstream's current
+restriction (`need_disable_hybrid_kv_cache_manager` in `vllm/config/vllm.py`
+trips when events are enabled).  Our per-group dedup would otherwise emit
+the same bare hash from each group and consumers couldn't disambiguate.
+
+Upstream vLLM is lifting this: `vllm-project/vllm@cc07dad789` (#37688) drops
+the gate and adds `group_idx` to `BlockStored` / `BlockRemoved`.  Once that
+feature is released, we can lift our assert and pass `group_idx` in our
+emissions.
+
+### No in-process consumer
+
+`Scheduler.take_events` feeds events directly to the external
+`KVEventPublisher` (ZMQ); nothing in-engine reads them, and KV connectors
+publish their own events rather than subscribing to the manager's.
+This allows us to change emission granularity unilaterally.
+
+### Using with llm-d
+
+llm-d's `precise-prefix-cache-scorer` chunks incoming prompts at its
+configured block size, looks those keys up in the index it builds from our
+events, and scores pods by how many consecutive blocks match.  Routing
+works iff the scorer's `blockSize` equals the engine's emitted
+`block_size` — our sub-block size, which is the prefill chunk size
+(`--max-num-batched-tokens`).
+
+> **Not** vLLM's `--block-size`.  For stock vLLM those two happen to be
+> the same knob, so generic guides tell you to align `--block-size` with
+> `blockSize`.  Here, `--block-size` is the big-block size (used for
+> attention-kernel layout) while the scorer sees sub-block events.  Align
+> `blockSize` with `--max-num-batched-tokens`, not `--block-size`.
+
+For example, with prefill chunk size 128:
+
+- vllm-rbln:
+  ```
+  vllm serve ... \
+      --enable-prefix-caching \
+      --max-num-batched-tokens=128 \
+      --kv-events-config='{"enable_kv_cache_events": true, "publisher": "zmq", ...}'
+  ```
+- EPP `prefix-cache-scorer` plugin:
+  ```
+  tokenProcessorConfig:
+    blockSize: 128
+  ```
+
+llm-d doesn't need to know anything about the big-block layout.
+Other event fields (`token_ids`, `parent_block_hash`, `extra_keys`,
+`lora_name`) are forwarded as-is from upstream vLLM.
 
 ## Interaction with KV Connectors
 

--- a/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py
@@ -16,6 +16,11 @@
 
 import pytest
 import torch
+from vllm.distributed.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+)
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
@@ -26,8 +31,11 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
+    generate_block_hash_extra_keys,
     get_request_block_hasher,
+    hash_block_tokens,
     init_none_hash,
+    maybe_convert_block_hash,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -63,46 +71,46 @@ class TestSubBlockHasher:
         self.hasher = SubBlockHasher(sha256, sub_block_size=4)
 
     def test_hash_empty_tokens(self):
-        hashes, _ = self.hasher.hash_tokens([])
+        hashes, _, _ = self.hasher.hash_tokens([])
         assert hashes == []
 
     def test_hash_fewer_than_sub_block(self):
-        hashes, _ = self.hasher.hash_tokens([1, 2, 3])
+        hashes, _, _ = self.hasher.hash_tokens([1, 2, 3])
         assert hashes == []
 
     def test_hash_exact_sub_block(self):
-        hashes, _ = self.hasher.hash_tokens([1, 2, 3, 4])
+        hashes, _, _ = self.hasher.hash_tokens([1, 2, 3, 4])
         assert len(hashes) == 1
         assert isinstance(hashes[0], bytes)
 
     def test_hash_multiple_sub_blocks(self):
-        hashes, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes, _, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
         assert len(hashes) == 2
 
     def test_hash_partial_last_sub_block(self):
-        hashes, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6])
+        hashes, _, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6])
         assert len(hashes) == 1  # Only the first full sub-block.
 
     def test_hashes_are_chained(self):
         # Hashing [1,2,3,4,5,6,7,8] should produce different h1 than
         # hashing [5,6,7,8] alone (because the parent hash differs).
-        hashes_full, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
-        hashes_second_only, _ = self.hasher.hash_tokens([5, 6, 7, 8])
+        hashes_full, _, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes_second_only, _, _ = self.hasher.hash_tokens([5, 6, 7, 8])
         assert hashes_full[1] != hashes_second_only[0]
 
     def test_incremental_hashing(self):
         # Hash in one go.
-        hashes_all, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
+        hashes_all, _, _ = self.hasher.hash_tokens([1, 2, 3, 4, 5, 6, 7, 8])
 
         # Hash in two steps.
         # Step 1: first sub-block only (only 4 tokens available).
-        h1, _ = self.hasher.hash_tokens(
+        h1, _, _ = self.hasher.hash_tokens(
             [1, 2, 3, 4],
             parent_hash=None,
             num_hashed_tokens=0,
         )
         # Step 2: all 8 tokens available, start from offset 4.
-        h2, _ = self.hasher.hash_tokens(
+        h2, _, _ = self.hasher.hash_tokens(
             [1, 2, 3, 4, 5, 6, 7, 8],
             parent_hash=h1[0],
             num_hashed_tokens=4,
@@ -156,7 +164,7 @@ class TestSubBlockHasher:
         )
 
         # One-shot: hash all 5 sub-blocks at once.
-        hashes_all, _ = self.hasher.hash_tokens(tokens, request=req)
+        hashes_all, _, _ = self.hasher.hash_tokens(tokens, request=req)
         assert len(hashes_all) == 5
 
         # Incremental: one sub-block at a time.
@@ -167,7 +175,7 @@ class TestSubBlockHasher:
         mm_idx = 0
         for i in range(5):
             off = i * 4
-            h, mm_idx = self.hasher.hash_tokens(
+            h, _, mm_idx = self.hasher.hash_tokens(
                 tokens[: off + 4],
                 parent_hash=parent,
                 num_hashed_tokens=off,
@@ -181,13 +189,13 @@ class TestSubBlockHasher:
 
     def test_deterministic(self):
         tokens = list(range(100, 112))
-        h1, _ = self.hasher.hash_tokens(tokens)
-        h2, _ = self.hasher.hash_tokens(tokens)
+        h1, _, _ = self.hasher.hash_tokens(tokens)
+        h2, _, _ = self.hasher.hash_tokens(tokens)
         assert h1 == h2
 
     def test_different_tokens_different_hashes(self):
-        h1, _ = self.hasher.hash_tokens([1, 2, 3, 4])
-        h2, _ = self.hasher.hash_tokens([5, 6, 7, 8])
+        h1, _, _ = self.hasher.hash_tokens([1, 2, 3, 4])
+        h2, _, _ = self.hasher.hash_tokens([5, 6, 7, 8])
         assert h1 != h2
 
 
@@ -202,7 +210,7 @@ class TestSubBlockIndex:
         sub-block token lists."""
         hasher = SubBlockHasher(sha256, sub_block_size=len(tokens_per_sub_block[0]))
         flat = [t for sub in tokens_per_sub_block for t in sub]
-        hashes, _ = hasher.hash_tokens(flat)
+        hashes, _, _ = hasher.hash_tokens(flat)
         return hashes
 
     def test_empty_no_match(self):
@@ -324,6 +332,7 @@ def _make_manager(
     sub_block_size: int,
     num_blocks: int,
     max_model_len: int = 8192,
+    enable_kv_cache_events: bool = False,
 ) -> RBLNKVCacheManager:
     manager = RBLNKVCacheManager(
         kv_cache_config=_make_kv_cache_config(block_size, num_blocks),
@@ -331,6 +340,7 @@ def _make_manager(
         hash_block_size=block_size,
         sub_block_size=sub_block_size,
         hash_fn=sha256,
+        enable_kv_cache_events=enable_kv_cache_events,
     )
     return manager
 
@@ -2092,3 +2102,471 @@ class TestSubBlockWithKVConnector:
         # The connector should have seen block-aligned count (0, not 4).
         # recorded_computed may have entries from req0 too; check the last.
         assert recorded_computed[-1] == 0  # Block-aligned, no sub-block inflation.
+
+
+# ---------------------------------------------------------------------------
+# KV cache events
+# ---------------------------------------------------------------------------
+
+
+class TestKVCacheEvents:
+    """Sub-block-granular KV cache event emission."""
+
+    BLOCK_SIZE = 8
+    SUB_BLOCK_SIZE = 4
+
+    def test_disabled_yields_no_events(self):
+        manager = _make_manager(self.BLOCK_SIZE, self.SUB_BLOCK_SIZE, num_blocks=10)
+        req = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+        assert manager.take_events() == []
+
+    def test_store_at_sub_block_granularity(self):
+        """A cached full big block emits one BlockStored per indexed run
+        at ``block_size = sub_block_size``, covering all R sub-blocks."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+
+        events = manager.take_events()
+        stored = [e for e in events if isinstance(e, BlockStored)]
+        assert stored, "expected at least one BlockStored"
+        # All stored events are at sub-block granularity.
+        assert all(e.block_size == self.SUB_BLOCK_SIZE for e in stored)
+        # Total sub-block hashes reported covers exactly the R sub-blocks
+        # of the full block.
+        R = self.BLOCK_SIZE // self.SUB_BLOCK_SIZE
+        total_hashes = sum(len(e.block_hashes) for e in stored)
+        assert total_hashes == R
+
+    def test_store_hash_chain_reconstructible(self):
+        """The parent-chained hashes in emitted events match what a
+        consumer would reconstruct by re-hashing the prompt."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(2 * self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+
+        events = manager.take_events()
+        stored = [e for e in events if isinstance(e, BlockStored)]
+
+        # Reconstruct the expected chain by re-hashing the prompt.
+        hasher = SubBlockHasher(sha256, self.SUB_BLOCK_SIZE)
+        expected_hashes, _, _ = hasher.hash_tokens(tokens)
+        expected = [maybe_convert_block_hash(h) for h in expected_hashes]
+
+        # Flatten emitted events in emission order with their chain parents.
+        flat_chain: list = []
+        for e in stored:
+            if not flat_chain:
+                assert e.parent_block_hash is None
+            else:
+                assert e.parent_block_hash == flat_chain[-1]
+            flat_chain.extend(e.block_hashes)
+
+        # The emitted chain should be a prefix of the expected chain.
+        assert flat_chain == expected[: len(flat_chain)]
+
+    def test_store_token_ids_and_size_match_sub_block(self):
+        """Emitted ``token_ids`` are exactly the prompt tokens the
+        sub-block hashes were computed from, sliced at sub-block size."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+
+        events = manager.take_events()
+        stored = [e for e in events if isinstance(e, BlockStored)]
+        flat_tokens: list[int] = []
+        for e in stored:
+            # len(token_ids) / block_size == len(block_hashes).
+            assert len(e.token_ids) == len(e.block_hashes) * e.block_size
+            flat_tokens.extend(e.token_ids)
+        assert flat_tokens == tokens
+
+    def test_dedup_on_multi_turn_same_prefix(self):
+        """Two requests caching identical prefix bytes: the second's
+        BlockStored skips the already-indexed hashes (dedup at hash
+        refcount level)."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(self.BLOCK_SIZE))
+
+        req0 = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        events0 = manager.take_events()
+        stored0 = [e for e in events0 if isinstance(e, BlockStored)]
+        total0 = sum(len(e.block_hashes) for e in stored0)
+        assert total0 > 0
+
+        # Free req0 but keep it cached (mark_cached=True makes it LRU-kept).
+        manager.free(req0)
+
+        # Same prompt, different request id.  The upstream full-block
+        # match hits; no fresh sub-block allocation → no sub-block Store.
+        req1 = _make_request("1", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req1)
+        events1 = manager.take_events()
+        stored1 = [e for e in events1 if isinstance(e, BlockStored)]
+        # All hashes in the second turn were already indexed by req0 →
+        # nothing fresh to emit.
+        assert stored1 == []
+
+    def test_remove_only_fires_on_last_holder(self):
+        """Two blocks hold the same prefix hashes (multi-block collision);
+        evicting the first holder fires no BlockRemoved; evicting the
+        second finally fires it."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        R = self.BLOCK_SIZE // self.SUB_BLOCK_SIZE
+        index = _sub_block_index(manager)
+
+        # Build the sub-block hash chain for a prompt of R sub-blocks.
+        tokens = list(range(self.BLOCK_SIZE))
+        hasher = SubBlockHasher(sha256, self.SUB_BLOCK_SIZE)
+        hashes, _, _ = hasher.hash_tokens(tokens)
+        assert len(hashes) == R
+
+        # Two distinct block IDs hold the identical prefix.
+        index.update(5, hashes)
+        index.update(6, hashes)
+        manager.take_events()  # drain any unrelated state
+
+        # Evict the first holder → no BlockRemoved (refcount still 1).
+        manager._on_block_evicted(5)
+        events_first = manager.take_events()
+        assert not any(isinstance(e, BlockRemoved) for e in events_first)
+
+        # Evict the second holder → BlockRemoved carrying all R hashes
+        # (refcount went 1→0 for every sub-block).
+        manager._on_block_evicted(6)
+        events_second = manager.take_events()
+        removed = [e for e in events_second if isinstance(e, BlockRemoved)]
+        assert len(removed) == 1
+        expected = [maybe_convert_block_hash(h) for h in hashes]
+        assert set(removed[0].block_hashes) == set(expected)
+
+    def test_partial_then_full_emits_suffix_only(self):
+        """A partial block indexed with N<R sub-blocks, later promoted to
+        full, emits a fresh Store for the trailing R-N hashes (chained to
+        the already-stored prefix)."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        # First request: 1 sub-block only (partial).  Upstream full-block
+        # match misses; sub-block indexing caches the partial sub-block
+        # via `_index_partial_block` during do_pending_indexing.
+        partial_tokens = list(range(self.SUB_BLOCK_SIZE))
+        req0 = _make_request(
+            "0", partial_tokens, self.BLOCK_SIZE, max_tokens=self.SUB_BLOCK_SIZE
+        )
+        _prefill_request(manager, req0)
+        # mark_cached=True in free() installs synthetic hash, keeping the
+        # indexed hashes around.
+        manager.free(req0)
+
+        events0 = manager.take_events()
+        stored0 = [e for e in events0 if isinstance(e, BlockStored)]
+        total0 = sum(len(e.block_hashes) for e in stored0)
+        # One sub-block was fresh.
+        assert total0 == 1
+
+        # Second request: full block (R sub-blocks) whose first sub-block
+        # shares the partial.  The first sub-block is dedup'd (already
+        # indexed in req0's partial block), only the trailing R-1 are fresh.
+        R = self.BLOCK_SIZE // self.SUB_BLOCK_SIZE
+        full_tokens = list(range(self.BLOCK_SIZE))
+        req1 = _make_request("1", full_tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req1)
+        events1 = manager.take_events()
+        stored1 = [e for e in events1 if isinstance(e, BlockStored)]
+        total1 = sum(len(e.block_hashes) for e in stored1)
+        assert total1 == R - 1
+        # The fresh suffix's parent must be the already-stored first hash.
+        hasher = SubBlockHasher(sha256, self.SUB_BLOCK_SIZE)
+        expected_hashes, _, _ = hasher.hash_tokens(full_tokens)
+        expected_parent = maybe_convert_block_hash(expected_hashes[0])
+        # First event of the second turn should chain from that.
+        assert stored1[0].parent_block_hash == expected_parent
+
+    def test_reset_emits_cleared(self):
+        """``reset_prefix_cache`` emits ``AllBlocksCleared``."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+        manager.free(req)
+        manager.take_events()  # drain Store events
+        assert _sub_block_index(manager).all_hashes()
+
+        assert manager.reset_prefix_cache() is True
+        events = manager.take_events()
+        assert [type(e) for e in events] == [AllBlocksCleared]
+
+    def test_take_events_drains(self):
+        """``take_events`` returns the buffered events and clears them."""
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request("0", tokens, self.BLOCK_SIZE)
+        _prefill_request(manager, req)
+        first = manager.take_events()
+        assert first
+        assert manager.take_events() == []
+
+    def test_extra_keys_round_trip_multimodal(self):
+        """End-to-end: emitted ``token_ids`` + ``extra_keys`` +
+        ``parent_block_hash`` re-hashed via upstream's ``hash_block_tokens``
+        reproduce the emitted ``block_hashes``.  Uses multimodal so
+        ``mm_idx`` advances mid-chain — the path that would silently break
+        if the extra_keys plumbing regressed."""
+        # Layout (sub_block_size=4, block_size=8):
+        #   tokens:     0..3   4..7   8..11  12..15  16..19
+        #   sub-blocks: sb0    sb1    sb2    sb3     sb4
+        #   image A:    [0, 4)
+        #   image B:                  [8,      14)
+        #   image C:                                 [16, 20)
+        mm_features = [
+            MultiModalFeatureSpec(
+                data=MultiModalKwargsItem.dummy(),
+                modality="image",
+                identifier="hash_img_a",
+                mm_position=PlaceholderRange(offset=0, length=4),
+            ),
+            MultiModalFeatureSpec(
+                data=MultiModalKwargsItem.dummy(),
+                modality="image",
+                identifier="hash_img_b",
+                mm_position=PlaceholderRange(offset=8, length=6),
+            ),
+            MultiModalFeatureSpec(
+                data=MultiModalKwargsItem.dummy(),
+                modality="image",
+                identifier="hash_img_c",
+                mm_position=PlaceholderRange(offset=16, length=4),
+            ),
+        ]
+        tokens = list(range(20))
+
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        req = Request(
+            request_id="mm",
+            prompt_token_ids=tokens,
+            mm_features=mm_features,
+            sampling_params=SamplingParams(max_tokens=5),
+            pooling_params=None,
+            cache_salt="sprinkle",
+            block_hasher=get_request_block_hasher(self.BLOCK_SIZE, sha256),
+        )
+        _prefill_request(manager, req)
+
+        events = manager.take_events()
+        stored = [e for e in events if isinstance(e, BlockStored)]
+        assert stored, "expected BlockStored events"
+
+        # Reconstruct: walk the emitted events in order, rehash each
+        # (token, extra_keys) triple, and check each emitted hash matches.
+        prev_bare_hash: BlockHash | None = None
+        for e in stored:
+            # parent_block_hash wiring must reflect the chain.
+            expected_parent_external = (
+                maybe_convert_block_hash(prev_bare_hash)
+                if prev_bare_hash is not None
+                else None
+            )
+            assert e.parent_block_hash == expected_parent_external
+            # Extra keys must be present (this prompt has MM + cache_salt).
+            assert e.extra_keys is not None
+            assert len(e.extra_keys) == len(e.block_hashes)
+            # Token_ids must align to sub_block_size per hash.
+            assert len(e.token_ids) == len(e.block_hashes) * e.block_size
+
+            # Re-hash each sub-block.
+            parent = prev_bare_hash
+            for i, emitted_hash in enumerate(e.block_hashes):
+                sub_tokens = e.token_ids[i * e.block_size : (i + 1) * e.block_size]
+                extras = e.extra_keys[i]
+                bare = hash_block_tokens(sha256, parent, sub_tokens, extras)
+                assert maybe_convert_block_hash(bare) == emitted_hash
+                parent = bare
+            prev_bare_hash = parent
+
+        # The reconstructed chain must match what
+        # ``generate_block_hash_extra_keys`` produces for the same prompt,
+        # proving the mm_idx threading is faithful through event boundaries.
+        mm_idx = 0
+        parent = None
+        sbs = self.SUB_BLOCK_SIZE
+        expected_chain: list = []
+        for i in range(len(tokens) // sbs):
+            extras, mm_idx = generate_block_hash_extra_keys(
+                req, i * sbs, (i + 1) * sbs, mm_idx
+            )
+            parent = hash_block_tokens(
+                sha256, parent, tokens[i * sbs : (i + 1) * sbs], extras
+            )
+            expected_chain.append(maybe_convert_block_hash(parent))
+
+        flat_emitted: list = []
+        for e in stored:
+            flat_emitted.extend(e.block_hashes)
+        assert flat_emitted == expected_chain[: len(flat_emitted)]
+
+    def test_extra_keys_round_trip_lora(self):
+        """LoRA + cache_salt round-trip: the emitted extras reproduce the
+        emitted hash via upstream's ``hash_block_tokens``, and the
+        ``lora_name``/``lora_id`` fields surface on the event itself."""
+        lora = LoRARequest(
+            lora_name="sales_bot", lora_int_id=42, lora_path="/tmp/ignored"
+        )
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=10,
+            enable_kv_cache_events=True,
+        )
+        tokens = list(range(self.BLOCK_SIZE))
+        req = _make_request(
+            "0",
+            tokens,
+            self.BLOCK_SIZE,
+            cache_salt="pepper",
+            lora_request=lora,
+        )
+        _prefill_request(manager, req)
+
+        stored = [e for e in manager.take_events() if isinstance(e, BlockStored)]
+        assert stored
+
+        for e in stored:
+            assert e.lora_id == 42
+            assert e.lora_name == "sales_bot"
+            assert e.extra_keys is not None
+
+        # Round-trip.
+        parent: BlockHash | None = None
+        for e in stored:
+            for i, emitted_hash in enumerate(e.block_hashes):
+                sub_tokens = e.token_ids[i * e.block_size : (i + 1) * e.block_size]
+                extras = e.extra_keys[i]
+                bare = hash_block_tokens(sha256, parent, sub_tokens, extras)
+                assert maybe_convert_block_hash(bare) == emitted_hash
+                parent = bare
+
+    def test_multi_group_with_events_raises(self):
+        """Fail loudly when events are enabled on a multi-group config.
+
+        Upstream already disables the hybrid KV cache manager when KV
+        events are enabled; this guard catches the case where that gate
+        ever loosens (per-group dedup would otherwise let the same hash
+        emit twice, breaking the set-membership contract).
+        """
+        with pytest.raises(ValueError, match="multi-group"):
+            RBLNKVCacheManager(
+                kv_cache_config=_make_hybrid_kv_cache_config(
+                    self.BLOCK_SIZE, num_blocks=10, sliding_window=16
+                ),
+                max_model_len=8192,
+                hash_block_size=self.BLOCK_SIZE,
+                sub_block_size=self.SUB_BLOCK_SIZE,
+                hash_fn=sha256,
+                enable_kv_cache_events=True,
+            )
+
+    def test_eviction_via_real_pool_path_emits_remove(self):
+        """Forces a real ``BlockPool._maybe_evict_cached_block`` by
+        saturating the pool — covers the monkey-patch wiring and its
+        contract with upstream (the symbol, the return-True-on-eviction
+        signal, and the reset of ``block_hash`` that would otherwise
+        leave the sub-block index stale).
+        """
+        # Small pool so eviction kicks in after a few requests.
+        # One slot is reserved for null_block; leaves 3 allocatable.
+        manager = _make_manager(
+            self.BLOCK_SIZE,
+            self.SUB_BLOCK_SIZE,
+            num_blocks=4,
+            enable_kv_cache_events=True,
+        )
+
+        # Request 0: allocate + cache + free (goes to upstream LRU).
+        req0 = _make_request("0", list(range(self.BLOCK_SIZE)), self.BLOCK_SIZE)
+        _prefill_request(manager, req0)
+        manager.free(req0)
+
+        # Sanity: req0's hashes are indexed and have been Store-announced.
+        assert _sub_block_index(manager).all_hashes()
+        manager.take_events()  # drain setup events
+
+        # Requests 1..N exhaust remaining slots until the pool must evict
+        # req0's (sole) cached block to satisfy a new allocation.
+        removed_events: list[BlockRemoved] = []
+        for i in range(1, 6):
+            req = _make_request(
+                str(i),
+                list(range(i * 1000, i * 1000 + self.BLOCK_SIZE)),
+                self.BLOCK_SIZE,
+            )
+            _prefill_request(manager, req)
+            manager.free(req)
+            for e in manager.take_events():
+                if isinstance(e, BlockRemoved):
+                    removed_events.append(e)
+
+        assert removed_events, (
+            "expected BlockRemoved via the upstream eviction path; the "
+            "monkey-patched _maybe_evict_cached_block hook is the only "
+            "wire-up for that"
+        )
+        # The evicted hashes must be req0's sub-block hashes.
+        hasher = SubBlockHasher(sha256, self.SUB_BLOCK_SIZE)
+        expected_hashes, _, _ = hasher.hash_tokens(list(range(self.BLOCK_SIZE)))
+        expected = {maybe_convert_block_hash(h) for h in expected_hashes}
+        seen: set = set()
+        for ev in removed_events:
+            seen.update(ev.block_hashes)
+        assert expected & seen, (
+            f"expected at least one of req0's hashes in remove events; "
+            f"got {seen}, expected {expected}"
+        )

--- a/vllm_rbln/v1/core/rbln_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/rbln_kv_cache_manager.py
@@ -21,15 +21,23 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
+from vllm.distributed.kv_events import (
+    MEDIUM_GPU,
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    KVCacheEvent,
+)
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     generate_block_hash_extra_keys,
     hash_block_tokens,
     make_block_hash_with_group_id,
+    maybe_convert_block_hash,
     need_extra_keys,
 )
 from vllm.v1.kv_cache_interface import (
@@ -96,7 +104,7 @@ class SubBlockHasher:
         num_hashed_tokens: int = 0,
         request: Request | None = None,
         start_mm_idx: int = 0,
-    ) -> tuple[list[BlockHash], int]:
+    ) -> tuple[list[BlockHash], list[tuple[Any, ...] | None], int]:
         """Return sub-block hashes for *full* sub-blocks in ``token_ids``.
 
         Args:
@@ -112,13 +120,17 @@ class SubBlockHasher:
                 incremental hashing with multimodal requests.
 
         Returns:
-            ``(hashes, mm_idx)`` — list of ``BlockHash`` values (one
-            per full sub-block) and the updated multimodal index.
+            ``(hashes, extra_keys, mm_idx)``.  ``extra_keys`` is a list
+            (aligned with ``hashes``) of the per-sub-block extra-keys
+            tuples actually mixed into the hash, or ``None`` for
+            sub-blocks that had no extra keys — returned so callers can
+            reproduce the hash when emitting KV events.
         """
         # Based on upstream request_block_hasher() in get_request_block_hasher().
 
         sbs = self.sub_block_size
         hashes: list[BlockHash] = []
+        extra_keys_list: list[tuple[Any, ...] | None] = []
         use_extra = request is not None and need_extra_keys(request)
         # NOTE: We can't simply use `mm_idx=-1`,
         # because it means the last mm input in the entire prompt,
@@ -126,7 +138,7 @@ class SubBlockHasher:
         mm_idx = start_mm_idx
         start = num_hashed_tokens
         for i in range(start, len(token_ids) - sbs + 1, sbs):
-            extra_keys = None
+            extra_keys: tuple[Any, ...] | None = None
             if use_extra:
                 extra_keys, mm_idx = generate_block_hash_extra_keys(
                     request, i, i + sbs, mm_idx
@@ -138,7 +150,8 @@ class SubBlockHasher:
                 extra_keys,
             )
             hashes.append(parent_hash)
-        return hashes, mm_idx
+            extra_keys_list.append(extra_keys)
+        return hashes, extra_keys_list, mm_idx
 
 
 class SubBlockIndex:
@@ -151,29 +164,48 @@ class SubBlockIndex:
         # Reverse index: block_id → list of sub-block hashes (for removal).
         self._block_hashes: dict[int, list[BlockHash]] = {}
 
-    def update(self, block_id: int, sub_block_hashes: list[BlockHash]) -> None:
+    def update(self, block_id: int, sub_block_hashes: list[BlockHash]) -> int:
         """Index or extend a block's sub-block hashes (idempotent).
 
-        If the block is not yet indexed, inserts all hashes.
-        If already indexed, appends any new hashes beyond what is recorded.
+        Returns ``first_fresh_idx``: the index in ``sub_block_hashes`` at
+        which the first globally-fresh (previously absent from the whole
+        index) hash was added by this call.
+        ``first_fresh_idx == len(sub_block_hashes)`` means nothing was fresh.
         """
         existing = self._block_hashes.setdefault(block_id, [])
+        first_fresh_idx = len(sub_block_hashes)
         for i in range(len(existing), len(sub_block_hashes)):
             h = sub_block_hashes[i]
+            bucket = self._hash_to_blocks.setdefault(h, set())
+            if not bucket and i < first_fresh_idx:
+                first_fresh_idx = i
             existing.append(h)
-            self._hash_to_blocks.setdefault(h, set()).add(block_id)
+            bucket.add(block_id)
+        return first_fresh_idx
 
-    def pop(self, block_id: int) -> None:
-        """Remove a block from the index (called on eviction)."""
+    def pop(self, block_id: int) -> list[BlockHash]:
+        """Remove a block from the index (called on eviction).
+
+        Returns the list of hashes whose bucket became empty as a result.
+        An empty list means nothing was removed or every removed hash is still
+        held by another block.
+        """
         hashes = self._block_hashes.pop(block_id, None)
         if hashes is None:
-            return
+            return []
+        fully_removed: list[BlockHash] = []
         for h in hashes:
             s = self._hash_to_blocks.get(h)
             if s is not None:
                 s.discard(block_id)
                 if not s:
                     del self._hash_to_blocks[h]
+                    fully_removed.append(h)
+        return fully_removed
+
+    def all_hashes(self) -> list[BlockHash]:
+        """All currently-indexed hashes (order unspecified)."""
+        return list(self._hash_to_blocks.keys())
 
     def contains(self, block_id: int) -> bool:
         """Return True if the block is indexed."""
@@ -207,9 +239,15 @@ class SubBlockIndex:
 
 @dataclass(slots=True)
 class _SubHashState:
-    """Per-request cached sub-block hashes and multimodal index."""
+    """Per-request cached sub-block hashes and multimodal index.
+
+    ``extra_keys`` is aligned 1:1 with ``hashes`` and records the
+    extra-keys tuple mixed into each sub-block's hash (or ``None`` when
+    the sub-block had no extras).
+    """
 
     hashes: list[BlockHash]
+    extra_keys: list[tuple[Any, ...] | None] = field(default_factory=list)
     mm_idx: int = 0
 
 
@@ -327,6 +365,22 @@ class RBLNKVCacheManager(KVCacheManager):
         # taken before allocate_slots, used to narrow the scan range.
         self._pending_indexing: dict[str, tuple[Request, tuple[int, ...]]] = {}
 
+        # Sub-block-granular KV event queue. We intercept the upstream pool's
+        # big-block event emission and publish sub-block events instead.
+        self.enable_kv_cache_events = self.block_pool.enable_kv_cache_events
+        self.block_pool.enable_kv_cache_events = False
+        self._sub_block_event_queue: list[KVCacheEvent] = []
+
+        # Upstream gates hybrid (multi-group) KV cache manager off when
+        # KV events are enabled (see vllm/config/vllm.py
+        # ``need_disable_hybrid_kv_cache_manager``).
+        if self.enable_kv_cache_events and len(self._group_infos) > 1:
+            raise ValueError(
+                "KV cache events are not supported with multi-group (hybrid) "
+                "sub-block caching. Upstream disables the hybrid KV cache "
+                "manager when KV events are enabled."
+            )
+
         self._install_eviction_hook()
 
     def get_computed_blocks_sub_block(
@@ -347,7 +401,7 @@ class RBLNKVCacheManager(KVCacheManager):
         if request.skip_reading_prefix_cache:
             return None
 
-        sub_hashes = self._get_or_compute_sub_hashes(request)
+        sub_hashes = self._get_or_compute_sub_hashes(request).hashes
 
         min_matched: int | None = None
         group_matches: list[_GroupPartialMatch] = []
@@ -551,16 +605,30 @@ class RBLNKVCacheManager(KVCacheManager):
         """Reset prefix cache including all per-group sub-block indices."""
         result = super().reset_prefix_cache()
         if result:
+            if self.enable_kv_cache_events:
+                self._sub_block_event_queue.append(AllBlocksCleared())
             for gi in self._group_infos:
                 gi.sub_block_index = SubBlockIndex()
             self._pending_indexing.clear()
         return result
 
+    def take_events(self) -> list[KVCacheEvent]:
+        """Return and clear the sub-block KV event queue.
+
+        Overrides upstream to return sub-block-granular events (big-block
+        emission from the underlying pool is suppressed in ``__init__``).
+        """
+        if not self.enable_kv_cache_events:
+            return []
+        events = self._sub_block_event_queue
+        self._sub_block_event_queue = []
+        return events
+
     # -- sub-block hash helpers ---------------------------------------------
 
-    def _get_or_compute_sub_hashes(self, request: Request) -> list[BlockHash]:
-        """Return the sub-block hashes for the request, computing new ones if
-        the request has grown since the last call.  Group-independent."""
+    def _get_or_compute_sub_hashes(self, request: Request) -> _SubHashState:
+        """Return the sub-block hash state for the request, computing new ones if
+        the request has grown since the last call. Group-independent."""
         state = self._req_sub_hashes.get(request.request_id)
         if state is None:
             state = _SubHashState(hashes=[])
@@ -569,7 +637,7 @@ class RBLNKVCacheManager(KVCacheManager):
         num_hashed_tokens = len(state.hashes) * self.sub_block_size
         parent_hash = state.hashes[-1] if state.hashes else None
 
-        new_hashes, new_mm_idx = self.sub_block_hasher.hash_tokens(
+        new_hashes, new_extra_keys, new_mm_idx = self.sub_block_hasher.hash_tokens(
             request.all_token_ids,
             parent_hash=parent_hash,
             num_hashed_tokens=num_hashed_tokens,
@@ -578,8 +646,9 @@ class RBLNKVCacheManager(KVCacheManager):
         )
         if new_hashes:
             state.hashes.extend(new_hashes)
+            state.extra_keys.extend(new_extra_keys)
             state.mm_idx = new_mm_idx
-        return state.hashes
+        return state
 
     # -- sub-block index maintenance ----------------------------------------
 
@@ -610,14 +679,15 @@ class RBLNKVCacheManager(KVCacheManager):
         gi: _GroupInfo,
     ) -> None:
         """Index a newly cached full block's sub-blocks."""
-        sub_hashes = self._get_or_compute_sub_hashes(request)
+        state = self._get_or_compute_sub_hashes(request)
         sbpb = gi.sub_blocks_per_block
         sub_start = blk_idx * sbpb
-        sub_end = min(sub_start + sbpb, len(sub_hashes))
+        sub_end = min(sub_start + sbpb, len(state.hashes))
         if sub_end <= sub_start:
             return
-        blk_sub_hashes = sub_hashes[sub_start:sub_end]
-        gi.sub_block_index.update(blk.block_id, blk_sub_hashes)
+        blk_sub_hashes = state.hashes[sub_start:sub_end]
+        first_fresh_idx = gi.sub_block_index.update(blk.block_id, blk_sub_hashes)
+        self._emit_block_stored(request, state, sub_start, sub_end, first_fresh_idx)
 
     def _index_partial_block(self, request: Request, mark_cached: bool) -> None:
         """Index sub-blocks of the last partial block per group.
@@ -627,7 +697,7 @@ class RBLNKVCacheManager(KVCacheManager):
                 upstream LRU preserves the block.
         """
         num_computed_tokens = request.num_computed_tokens
-        sub_hashes = self._get_or_compute_sub_hashes(request)
+        state = self._get_or_compute_sub_hashes(request)
         blocks = self.coordinator.get_blocks(request.request_id)
 
         for gid, gi in enumerate(self._group_infos):
@@ -647,13 +717,16 @@ class RBLNKVCacheManager(KVCacheManager):
 
             sbpb = gi.sub_blocks_per_block
             sub_start = last_blk_idx * sbpb
-            sub_end = min(sub_start + num_sub_blocks, len(sub_hashes))
+            sub_end = min(sub_start + num_sub_blocks, len(state.hashes))
             if sub_end <= sub_start:
                 continue
-            partial_sub_hashes = sub_hashes[sub_start:sub_end]
+            partial_sub_hashes = state.hashes[sub_start:sub_end]
 
             # Index in the group's sub-block index.
-            gi.sub_block_index.update(blk.block_id, partial_sub_hashes)
+            first_fresh_idx = gi.sub_block_index.update(
+                blk.block_id, partial_sub_hashes
+            )
+            self._emit_block_stored(request, state, sub_start, sub_end, first_fresh_idx)
 
             if mark_cached:
                 # Give the block a synthetic block_hash so the upstream block pool
@@ -674,9 +747,11 @@ class RBLNKVCacheManager(KVCacheManager):
                 self.block_pool.cached_block_hash_to_block.insert(synthetic_hash, blk)
 
     def _on_block_evicted(self, block_id: int) -> None:
-        """Called when a block is evicted — remove from index."""
+        """Called when a block is evicted — remove from index and emit
+        ``BlockRemoved`` for hashes whose last holder was this block."""
         for gi in self._group_infos:
-            gi.sub_block_index.pop(block_id)
+            fully_removed = gi.sub_block_index.pop(block_id)
+            self._emit_block_removed(fully_removed)
 
     def _install_eviction_hook(self) -> None:
         # Monkey-patch the block pool's eviction method to also clean up the
@@ -692,3 +767,62 @@ class RBLNKVCacheManager(KVCacheManager):
             return result
 
         self.block_pool._maybe_evict_cached_block = evict_with_index_cleanup
+
+    # -- event emission ------------------------------------------------------
+
+    def _emit_block_stored(
+        self,
+        request: Request,
+        state: _SubHashState,
+        sub_start: int,
+        sub_end: int,
+        first_fresh_idx: int,
+    ) -> None:
+        """Emit a single ``BlockStored`` for the fresh suffix of one update.
+
+        The caller has just indexed ``state.hashes[sub_start:sub_end]`` via
+        ``SubBlockIndex.update``, which returned ``first_fresh_idx``.
+        The fresh suffix we emit is
+        ``state.hashes[sub_start + first_fresh_idx : sub_end]``.
+        """
+        if not self.enable_kv_cache_events:
+            return
+        slice_len = sub_end - sub_start
+        if first_fresh_idx >= slice_len:
+            return
+        fresh_start = sub_start + first_fresh_idx
+        fresh_hashes = state.hashes[fresh_start:sub_end]
+        parent_hash = state.hashes[fresh_start - 1] if fresh_start > 0 else None
+        tok_start = fresh_start * self.sub_block_size
+        tok_end = sub_end * self.sub_block_size
+        token_ids = request.all_token_ids[tok_start:tok_end]
+        extras = state.extra_keys[fresh_start:sub_end]
+        self._sub_block_event_queue.append(
+            BlockStored(
+                block_hashes=[maybe_convert_block_hash(h) for h in fresh_hashes],
+                parent_block_hash=(
+                    maybe_convert_block_hash(parent_hash)
+                    if parent_hash is not None
+                    else None
+                ),
+                token_ids=list(token_ids),
+                block_size=self.sub_block_size,
+                lora_id=(
+                    request.lora_request.adapter_id if request.lora_request else None
+                ),
+                medium=MEDIUM_GPU,
+                lora_name=(request.lora_request.name if request.lora_request else None),
+                extra_keys=extras if any(e is not None for e in extras) else None,
+            )
+        )
+
+    def _emit_block_removed(self, fully_removed: list[BlockHash]) -> None:
+        """Emit a single ``BlockRemoved`` for hashes whose last holder is gone."""
+        if not self.enable_kv_cache_events or not fully_removed:
+            return
+        self._sub_block_event_queue.append(
+            BlockRemoved(
+                block_hashes=[maybe_convert_block_hash(h) for h in fully_removed],
+                medium=MEDIUM_GPU,
+            )
+        )

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -97,6 +97,13 @@ class RBLNScheduler(Scheduler):
                 self.block_size,
                 sub_block_size,
             )
+            if self.enable_kv_cache_events:
+                logger.info(
+                    "NOTE that KV cache events emit at sub_block_size granularity. "
+                    "Cache-aware routers must set token processing block size to "
+                    "sub_block_size=%d.",
+                    sub_block_size,
+                )
 
     def schedule(self) -> RBLNSchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/v1/core/sched/scheduler.py#L338-L927


### PR DESCRIPTION
### 🚀 Summary of Changes

Problem:
Prefix-cache-aware routers (e.g. llm-d) rely on KV cache events to route requests to engines that already cache their prefix.  Upstream vLLM emits events at its native block granularity (1k–4k tokens on RBLN), so partial big blocks never get advertised and the sub-block prefix information the engine actually has is invisible to routers.

Solution:
Suppress upstream BlockPool big-block events and let RBLNKVCacheManager publish sub-block-granular events.

See the updated design doc for details. 

## NOTE
**For llm-d's precise prefix cache scorer, set `tokenProcessorConfig.blockSize` to vllm `--max-num-batched-tokens`**, (not `--block-size`).


---

### 📌 Related Issues / Tickets
https://github.com/rebellions-sw/vllm-rbln-internal/issues/43

### 🧪 How to Test

* Run `pytest tests/torch_compile/unit/v1/core/test_sub_block_prefix_caching.py`
* integration test with llm-d (done)
