### PR TITLE
fix(test): load vllm plugin before test collection

### DIFF
--- a/tests/torch_compile/conftest.py
+++ b/tests/torch_compile/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 from vllm.config import (
     CacheConfig,
@@ -23,13 +25,12 @@ from vllm.config import (
 from vllm.plugins import load_general_plugins
 
 
-@pytest.fixture(scope="session", autouse=True)
-def initialize_environment():
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setenv("VLLM_RBLN_USE_VLLM_MODEL", "1")
-    monkeypatch.setenv("VLLM_USE_V1", "1")
+def pytest_configure(config):
+    # Must run before test collection so that monkey patches applied by
+    # `register_ops()` are in place before any test module does
+    # `from vllm.xxx import yyy` at import time and captures the original symbol.
+    os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
     load_general_plugins()
-    return
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION



### 🚀 Summary of Changes
Problem:
`load_general_plugins()` ran in a session autouse fixture, i.e. after collection. Test modules whose top-level `from vllm.xxx import yyy` resolved a monkey-patched symbol captured the original before the patch was applied.

For example, when running `pytest tests/torch_compile/{e2e,unit}/v1/lora/` on https://github.com/RBLN-SW/vllm-rbln/pull/504/,  tests/torch_compile/e2e/v1/lora/test_basic_lora.py fails with `TypeError: set_forward_context() got an unexpected keyword argument 'num_padded_tokens'`.


Solution:
Move env var setup and `load_general_plugins()` into [`pytest_configure`](https://docs.pytest.org/en/stable/reference/reference.html#std-hook-pytest_configure) so patches are in place before any test module is imported.


While at it, remove the removed env var `VLLM_USE_V1`.
