### PR TITLE
fix(eager): use CPU metadata mirrors in RBLN flash attention eager path

### DIFF
--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -1087,19 +1087,33 @@ class RBLNFlashAttentionMetadataBuilder(
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len
         query_max_seq_len = common_attn_metadata.max_seq_len
+        # Keep the device-resident query_start_loc for the returned
+        # ``RBLNFlashAttentionMetadata`` (downstream RBLN attention kernels
+        # expect it on the runtime device), but drive all internal CPU-side
+        # metadata math (numpy conversion at ``is_prefills``, attention-mask
+        # construction with python-int indexing, ``enumerate(seq_lens)``,
+        # ``positions[...]`` indexing where ``positions`` is the CPU buffer)
+        # off CPU mirrors. In graph mode device==cpu so both mirrors point at
+        # the same tensor and behavior is unchanged; in eager mode device==rbln
+        # and this avoids mixed-device errors like
+        # ``RuntimeError: indices should be either on cpu or on the same
+        # device as the indexed tensor (cpu)`` and
+        # ``TypeError: can't convert rbln:0 device type tensor to numpy``.
         query_start_loc = common_attn_metadata.query_start_loc
+        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         seq_lens = common_attn_metadata.seq_lens
+        seq_lens_cpu = seq_lens if seq_lens.device.type == "cpu" else seq_lens.cpu()
         block_tables_tensor = common_attn_metadata.block_table_tensor
         slot_mapping = common_attn_metadata.slot_mapping
-        query_seq_lens = query_start_loc[1:] - query_start_loc[:-1]
-        num_computed_tokens = seq_lens - query_seq_lens
+        query_seq_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+        num_computed_tokens = seq_lens_cpu - query_seq_lens
 
         cu_prefix_query_lens = None
         prefix_kv_lens = None
         suffix_kv_lens = None
         prefix_scheduler_metadata = None
 
-        seq_idx = positions[query_start_loc[:num_reqs]].view(-1, 1)
+        seq_idx = positions[query_start_loc_cpu[:num_reqs]].view(-1, 1)
 
         # The length of the partition equals the block size.
         partition_len = self.block_size
@@ -1158,7 +1172,7 @@ class RBLNFlashAttentionMetadataBuilder(
                     max_seq_len,
                     dtype=torch.float16 if self.enforce_eager else torch.float32,
                 )
-                for batch_index, batch_step in enumerate(seq_lens):
+                for batch_index, batch_step in enumerate(seq_lens_cpu):
                     decode_attention_mask[batch_index, :, :, :, : batch_step + 1] = 1
                 attn_masks = decode_attention_mask
                 attn_masks = attn_masks.to(self.device)
@@ -1171,7 +1185,7 @@ class RBLNFlashAttentionMetadataBuilder(
             num_computed_tokens = (
                 num_computed_tokens[:num_reqs].view(-1, 1).to(torch.int16)
             )
-            seq_lens = seq_lens[:num_reqs].view(-1, 1).to(torch.int16)
+            seq_lens = seq_lens_cpu[:num_reqs].view(-1, 1).to(torch.int16)
             query_lens = seq_lens - num_computed_tokens
             cache_seq_lens = torch.clamp(num_computed_tokens, max=sliding_window)
             cache_offsets = cache_seq_lens + query_lens


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

- Use CPU mirrors (query_start_loc_cpu, seq_lens_cpu) for metadata-side indexing/math in RBLNFlashAttentionMetadataBuilder.
- Keep runtime metadata tensors on the target device for downstream RBLN attention kernels.
- Prevent eager-mode mixed-device failures during numpy conversion and CPU-buffer indexing.

because In eager mode, some metadata tensors are device-resident while internal metadata processing expects CPU tensors. This could trigger mixed-device and numpy conversion errors.

---

### 📌 Related Issues / Tickets

* Related to https://github.com/RBLN-SW/torch-rbln/pull/29

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

- python -m py_compile vllm-rbln/vllm_rbln/v1/attention/backends/flash_attention.py
- Smoke test eager decode path (single model).
- Smoke test one sliding-window model decode path.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
