### PR TITLE
fix(kv_connector): prevent double finalizing kv connector when using spec decoding 

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner_kv_cache.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner_kv_cache.py
@@ -16,7 +16,7 @@
 
 Tests _add_dummy_requests, _make_dummy_scheduler_outputs,
 select_common_block_size, _prepare_kernel_block_sizes,
-and _allocate_kv_cache_tensors.
+_allocate_kv_cache_tensors, and _propagate_runtime_holder.
 """
 
 from unittest.mock import MagicMock, patch
@@ -425,3 +425,96 @@ class TestAllocateKvCacheTensors:
         assert result["layer_0"].shape == (1024,)
         assert result["layer_1"].shape == (2048,)
         assert result["layer_0"] is not result["layer_1"]
+
+
+# ============================================================
+# _propagate_runtime_holder Tests
+# ============================================================
+
+
+class _ConnectorWithHolder:
+    """Stub for an RBLN-aware connector exposing set_runtime_holder."""
+
+    def __init__(self) -> None:
+        self.holder: list | None = None
+
+    def set_runtime_holder(self, runtime_holder: list) -> None:
+        self.holder = runtime_holder
+
+
+class _PlainConnector:
+    """Stub for a connector without set_runtime_holder (e.g. NIXL)."""
+
+
+class _MultiConnectorStub:
+    """Stub mimicking vLLM MultiConnector: has _connectors, no set_runtime_holder."""
+
+    def __init__(self, children: list[object]) -> None:
+        self._connectors = children
+
+
+class TestPropagateRuntimeHolder:
+    """Test _propagate_runtime_holder: walks MultiConnector children."""
+
+    def test_direct_connector_with_set_runtime_holder(self):
+        """Top-level connector that exposes the method receives the holder."""
+        connector = _ConnectorWithHolder()
+        holder = [object()]
+
+        RBLNModelRunner._propagate_runtime_holder(connector, holder)
+
+        assert connector.holder is holder
+
+    def test_direct_connector_without_set_runtime_holder(self):
+        """Top-level connector without the method is silently skipped."""
+        connector = _PlainConnector()
+        holder = [object()]
+
+        # Must not raise
+        RBLNModelRunner._propagate_runtime_holder(connector, holder)
+
+    def test_multi_connector_walks_children(self):
+        """MultiConnector itself lacks the method; children that have it get it."""
+        rbln_child = _ConnectorWithHolder()
+        nixl_child = _PlainConnector()
+        multi = _MultiConnectorStub([nixl_child, rbln_child])
+        holder = [object()]
+
+        RBLNModelRunner._propagate_runtime_holder(multi, holder)
+
+        assert rbln_child.holder is holder
+
+    def test_multi_connector_propagates_to_all_rbln_children(self):
+        """Every child with set_runtime_holder receives the same holder."""
+        child_a = _ConnectorWithHolder()
+        child_b = _ConnectorWithHolder()
+        multi = _MultiConnectorStub([child_a, child_b])
+        holder = [object()]
+
+        RBLNModelRunner._propagate_runtime_holder(multi, holder)
+
+        assert child_a.holder is holder
+        assert child_b.holder is holder
+
+    def test_nested_multi_connector(self):
+        """Nested MultiConnectors are walked recursively."""
+        inner_child = _ConnectorWithHolder()
+        inner = _MultiConnectorStub([inner_child])
+        outer = _MultiConnectorStub([inner])
+        holder = [object()]
+
+        RBLNModelRunner._propagate_runtime_holder(outer, holder)
+
+        assert inner_child.holder is holder
+
+    def test_holder_reference_is_shared_not_copied(self):
+        """The list itself is passed (lazy runtime population relies on this)."""
+        connector = _ConnectorWithHolder()
+        holder: list = []
+
+        RBLNModelRunner._propagate_runtime_holder(connector, holder)
+
+        # Mutating the original list must be visible via the connector.
+        holder.append("rt")
+        assert connector.holder is holder
+        assert connector.holder[0] == "rt"

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2683,16 +2683,24 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 runtime._copy_kv_cache(op.src_block_id, op.dst_block_id, op.num_tokens)
 
     @staticmethod
+    def _is_kv_connector_warm_up_phase(scheduler_output: "SchedulerOutput") -> bool:
+        # Warmup runs `_execute_dummy_requests` with synthetic SchedulerOutput
+        # whose `kv_connector_metadata` is None. The connector lifecycle
+        # (bind/wait/clear) must skip this phase, otherwise stateful
+        # connectors (e.g. LMCache) assert on missing bound metadata.
+        return scheduler_output.kv_connector_metadata is None
+
+    @staticmethod
     def maybe_get_kv_connector_output(
         scheduler_output: "SchedulerOutput",
         defer_finalize: bool = False,
     ) -> AbstractContextManager[KVConnectorOutput | None]:
-        warm_up_phase = scheduler_output.kv_connector_metadata is None
+        skip = RBLNModelRunner._is_kv_connector_warm_up_phase(scheduler_output)
         return (
             KVConnectorModelRunnerMixin._get_kv_connector_output(
                 scheduler_output, defer_finalize=defer_finalize
             )
-            if has_kv_transfer_group() and not warm_up_phase
+            if has_kv_transfer_group() and not skip
             else nullcontext()
         )
 
@@ -3193,8 +3201,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Finalize KV connector (wait_for_save + clear metadata) after
         # draft model runs. Deferred from target model forward to allow
-        # draft model to also save its KV cache.
-        if spec_config is not None:
+        # draft model to also save its KV cache. Skip during warmup —
+        # the connector context was bypassed in maybe_get_kv_connector_output,
+        # so no metadata was bound.
+        if spec_config is not None and not self._is_kv_connector_warm_up_phase(
+            scheduler_output
+        ):
             self.finalize_kv_connector()
 
         # FIXME(jiwoo.park) EPLB is not supported in RBLN

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -4428,6 +4428,20 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 else:
                     break
 
+    @staticmethod
+    def _propagate_runtime_holder(group: object, runtime_holder: list) -> None:
+        """Pass runtime_holder to every connector exposing set_runtime_holder.
+
+        Walks into ``MultiConnector._connectors`` recursively because
+        MultiConnector does not implement this RBLN-specific method, so a
+        plain hasattr check on the top-level group would silently skip the
+        nested LMCache/RBLN connector that actually needs the holder.
+        """
+        if hasattr(group, "set_runtime_holder"):
+            group.set_runtime_holder(runtime_holder)
+        for child in getattr(group, "_connectors", ()) or ():
+            RBLNModelRunner._propagate_runtime_holder(child, runtime_holder)
+
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """
         Initialize KV cache based on `kv_cache_config`.
@@ -4518,17 +4532,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             kv_transfer_group.set_host_xfer_buffer_ops(rbln_copy_kv_blocks)
 
-            # Propagate runtime_holder to every connector that exposes
-            # set_runtime_holder, walking into MultiConnector children since
-            # MultiConnector itself does not implement this RBLN-specific
-            # method (it would otherwise be silently skipped by hasattr).
-            def _propagate_runtime_holder(group: object) -> None:
-                if hasattr(group, "set_runtime_holder"):
-                    group.set_runtime_holder(self.runtime_holder)
-                for child in getattr(group, "_connectors", ()) or ():
-                    _propagate_runtime_holder(child)
-
-            _propagate_runtime_holder(kv_transfer_group)
+            self._propagate_runtime_holder(kv_transfer_group, self.runtime_holder)
 
         if self.dcp_world_size > 1:
             layer_type = cast(type[Any], AttentionLayerBase)

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -4518,8 +4518,17 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             kv_transfer_group.set_host_xfer_buffer_ops(rbln_copy_kv_blocks)
 
-            if hasattr(kv_transfer_group, "set_runtime_holder"):
-                kv_transfer_group.set_runtime_holder(self.runtime_holder)
+            # Propagate runtime_holder to every connector that exposes
+            # set_runtime_holder, walking into MultiConnector children since
+            # MultiConnector itself does not implement this RBLN-specific
+            # method (it would otherwise be silently skipped by hasattr).
+            def _propagate_runtime_holder(group: object) -> None:
+                if hasattr(group, "set_runtime_holder"):
+                    group.set_runtime_holder(self.runtime_holder)
+                for child in getattr(group, "_connectors", ()) or ():
+                    _propagate_runtime_holder(child)
+
+            _propagate_runtime_holder(kv_transfer_group)
 
         if self.dcp_world_size > 1:
             layer_type = cast(type[Any], AttentionLayerBase)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

When speculative decoding is enabled together with a KV connector, the worker crashed during warmup because the deferred `finalize_kv_connector()` call ran on a connector whose per-step metadata was never bound. This first surfaced with `RBLNLMCacheConnectorV1`, but the close-side hooks of every KV connector in the codebase (`LMCacheConnectorV1Impl.wait_for_save`, `NixlConnector.wait_for_save`, …) carry the same "metadata must be bound" assertion, so the bug is connector-agnostic. See #585 for the full lifecycle walkthrough.

This PR:

1. **Skip `finalize_kv_connector()` during warmup (connector-agnostic).** Extract the warmup-detection check into a shared `_is_kv_connector_warm_up_phase(scheduler_output)` predicate (true iff `scheduler_output.kv_connector_metadata is None`), and apply it on **both** sides of the connector lifecycle so `bind` and `wait/clear` always come as a matching pair.
   - `maybe_get_kv_connector_output` already bypassed the open during warmup; it now calls the shared predicate instead of an inline `warm_up_phase = ...`.
   - The deferred-finalize block at the end of `execute_model` also checks the predicate before calling `finalize_kv_connector()`.
   - The guard sits in the model runner, before any connector-specific hook runs, so it covers LMCache, NIXL, and any future connector that participates in the same lifecycle.
2. **Propagate `runtime_holder` through `MultiConnector`.** A plain `hasattr(group, "set_runtime_holder")` silently skipped the call on `MultiConnector` (which does not implement that RBLN-specific method), so multi-connector setups (e.g. LMCache + NIXL) never received the runtime. Walk into `MultiConnector._connectors` recursively and invoke `set_runtime_holder` on every child that exposes it.
3. **Unit tests for `_propagate_runtime_holder`.** Refactor the closure into a `@staticmethod` and add coverage for: direct connector, connector without `set_runtime_holder`, `MultiConnector` with mixed children, multiple RBLN children, nested `MultiConnector`, and shared-list reference (lazy runtime population relies on the same list object reaching every child).

---

### 📌 Related Issues / Tickets

* Resolves #585

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Launch a model with `speculative_config` set (eagle / medusa / ngram / suffix) **and** any `kv_transfer_config` — both `RBLNLMCacheConnectorV1` and a NIXL-based connector exercise the same code path.
2. Verify the worker completes warmup without hitting the `_get_connector_metadata()` assertion in the connector's `wait_for_save()`.
3. Run a small set of real requests; confirm KV save/load still happens normally on non-warmup steps.
4. For multi-connector setups (e.g. LMCache + NIXL via `MultiConnector`), confirm the RBLN runtime reaches every child connector by checking the `"RBLN runtime_holder set on RBLNConnector (lazy)"` log line.
5. `pytest` for the new `_propagate_runtime_holder` unit tests.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)
