### PR TITLE
fix(pooling): align with vllm 0.18 PoolingMetadata + LLM API

### DIFF
--- a/tests/torch_compile/e2e/models/test_pooling_model_embed.py
+++ b/tests/torch_compile/e2e/models/test_pooling_model_embed.py
@@ -51,7 +51,7 @@ def run_vllm_score(llm_kwargs: dict) -> None:
     input_prompts = queries + documents
 
     try:
-        llm = LLM(task="embed", **llm_kwargs)
+        llm = LLM(runner="pooling", **llm_kwargs)
 
         outputs = llm.embed(input_prompts)
         embeddings = torch.tensor([o.outputs.embedding for o in outputs])

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1722,11 +1722,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         hidden_states = hidden_states[:num_scheduled_tokens]
+        seq_lens_cpu = self.seq_lens.cpu[: self.input_batch.num_reqs]
         pooling_metadata = self.input_batch.get_pooling_metadata()
         pooling_metadata.build_pooling_cursor(
-            num_scheduled_tokens_np.tolist(), device=hidden_states.device
+            num_scheduled_tokens_np,
+            seq_lens_cpu,
+            device=hidden_states.device,
         )
-        seq_lens_cpu = self.seq_lens.cpu[: self.input_batch.num_reqs]
 
         # Pooling models D2H & synchronize occurs in pooler.py:build_output
         raw_pooler_output = self.model.pooler(


### PR DESCRIPTION
### 🚀 Summary of Changes

Two breakages exposed by `pytest -s -v tests/torch_compile/e2e/models` against vllm 0.18:

- **`PoolingMetadata.build_pooling_cursor` signature drift.** vllm 0.18 added a required \`seq_lens_cpu\` positional argument and now expects an `np.ndarray` for the first arg (it does `torch.from_numpy(...)` internally). `RBLNModelRunner._pool` was still calling the old signature with `num_scheduled_tokens_np.tolist()` and no `seq_lens_cpu`, which raised `TypeError` during engine warm-up. Pass the ndarray directly and forward \`seq_lens_cpu\` (computed from `self.seq_lens.cpu`). `optimum_model_runner` already does this; this brings `rbln_model_runner` in line.
- **\`LLM(task=\"embed\", ...)\` removed.** vllm 0.18 dropped the \`task=\` constructor kwarg in favor of \`runner=\` (\`'auto' | 'generate' | 'pooling' | 'draft'\`) plus an optional \`convert=\` (\`'auto' | 'none' | 'embed' | 'classify'\`). The embed pooling test now uses \`runner=\"pooling\"\`, matching the sibling score test.

### 📌 Related Issues / Tickets

* Resolves #
* Related to #

---

### ✅ Type of Change

* [ ] 🚀 Release (\`release\`)
* [ ] ✨ Feature (\`feature\`)
* [ ] 🧠 Model support (\`model\`)
* [ ] 🧬 Core engine changes (\`core\`)
* [x] 🛠 Bug fix (\`fix\`)
* [ ] ⚙️ Performance improvement (\`perf\`)
* [ ] 🔁 Refactor or code cleanup (\`refactor\`)
* [ ] 📄 Documentation (\`docs\`)
* [ ] ❓ Other (\`other\`)

---

### 🧪 How to Test

```bash
pytest -s -v tests/torch_compile/e2e/models
```

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes
🤖 Generated with [Claude Code](https://claude.com/claude-code)