### PR TITLE
ci: switch fsw-integration triggers to dispatch+await for visible CI outcome

### DIFF
--- a/.github/workflows/rbln_trigger_fsw_merge_ci.yaml
+++ b/.github/workflows/rbln_trigger_fsw_merge_ci.yaml
@@ -19,20 +19,36 @@ jobs:
         vllm_version:
           - "0.18.0+cpu"
     steps:
-      - name: Dispatch to fsw-integration (vllm ${{ matrix.vllm_version }})
-        uses: Wandalen/wretry.action@v3
+      - name: Compute distinct id
+        id: distinct
+        shell: bash
+        run: |
+          echo "id=merge-ci-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.vllm_version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch fsw-integration merge CI and capture run id
+        id: dispatch
+        uses: Codex-/return-dispatch@v2
         with:
-          action: peter-evans/repository-dispatch@v4
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            token: ${{ secrets.GIT_PAT }}
-            repository: rebellions-sw/fsw-integration
-            event-type: vllm-rbln-merge-event
-            client-payload: |
-              {
-                "ref": "${{ github.ref_name }}",
-                "sha": "${{ github.sha }}",
-                "actor": "${{ github.actor }}",
-                "vllm_version": "${{ matrix.vllm_version }}"
-              }
+          token: ${{ secrets.GIT_PAT }}
+          ref: dev
+          repo: fsw-integration
+          owner: rebellions-sw
+          workflow: vllm_rbln_pr_ci.yaml
+          workflow_inputs: |
+            {
+              "vllm_rbln_ref": "${{ github.ref_name }}",
+              "vllm_version": "${{ matrix.vllm_version }}",
+              "distinct_id": "${{ steps.distinct.outputs.id }}"
+            }
+          workflow_timeout_seconds: 300
+          distinct_id: ${{ steps.distinct.outputs.id }}
+
+      - name: Await fsw-integration merge CI completion
+        uses: Codex-/await-remote-run@v1
+        with:
+          token: ${{ secrets.GIT_PAT }}
+          repo: fsw-integration
+          owner: rebellions-sw
+          run_id: ${{ steps.dispatch.outputs.run_id }}
+          run_timeout_seconds: 7200
+          poll_interval_ms: 60000

--- a/.github/workflows/rbln_trigger_fsw_nightly_e2e.yaml
+++ b/.github/workflows/rbln_trigger_fsw_nightly_e2e.yaml
@@ -22,19 +22,37 @@ jobs:
         vllm_version:
           - "0.18.0+cpu"
     steps:
-      - name: Dispatch to fsw-integration (vllm ${{ matrix.vllm_version }})
-        uses: Wandalen/wretry.action@v3
+      - name: Compute distinct id
+        id: distinct
+        shell: bash
+        run: |
+          echo "id=nightly-e2e-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.vllm_version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch fsw-integration nightly e2e and capture run id
+        id: dispatch
+        uses: Codex-/return-dispatch@v2
         with:
-          action: peter-evans/repository-dispatch@v4
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            token: ${{ secrets.GIT_PAT }}
-            repository: rebellions-sw/fsw-integration
-            event-type: vllm-rbln-nightly-e2e
-            client-payload: |
-              {
-                "ref": "${{ inputs.ref || 'dev' }}",
-                "actor": "${{ github.actor }}",
-                "vllm_version": "${{ matrix.vllm_version }}"
-              }
+          token: ${{ secrets.GIT_PAT }}
+          ref: dev
+          repo: fsw-integration
+          owner: rebellions-sw
+          workflow: vllm_rbln_nightly_e2e.yaml
+          workflow_inputs: |
+            {
+              "environment": "vllm_rbln-nightly",
+              "vllm_rbln_ref": "${{ inputs.ref || 'dev' }}",
+              "vllm_version": "${{ matrix.vllm_version }}",
+              "distinct_id": "${{ steps.distinct.outputs.id }}"
+            }
+          workflow_timeout_seconds: 300
+          distinct_id: ${{ steps.distinct.outputs.id }}
+
+      - name: Await fsw-integration nightly e2e completion
+        uses: Codex-/await-remote-run@v1
+        with:
+          token: ${{ secrets.GIT_PAT }}
+          repo: fsw-integration
+          owner: rebellions-sw
+          run_id: ${{ steps.dispatch.outputs.run_id }}
+          run_timeout_seconds: 7200
+          poll_interval_ms: 60000


### PR DESCRIPTION
## Summary

지금까지 vllm-rbln의 fsw-integration 트리거 워크플로우는 `peter-evans/repository-dispatch`를 통한 **fire-and-forget** 방식이라 Actions 결과에 "dispatch가 접수됐는지"만 표시되고, 정작 fsw-integration에서 도는 실제 PR/Merge CI 또는 Nightly E2E 작업 성패는 dispatcher 쪽에서 알 수 없었습니다.

이 PR은 두 트리거 워크플로우를 **dispatch + await 패턴**으로 전환합니다:

- `Codex-/return-dispatch@v2` — `workflow_dispatch`로 원격 워크플로우 실행하면서 `distinct_id`를 입력으로 넣고, 같은 id가 반영된 run-name으로 dispatch된 run을 찾아 `run_id`를 돌려줌.
- `Codex-/await-remote-run@v1` — 위에서 받은 `run_id`를 폴링해 완료까지 대기. 원격 run이 실패하면 이 step도 실패해서 vllm-rbln Actions 결과에 그대로 표시됨.

각 matrix iteration은 `${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.vllm_version }}`을 distinct_id로 사용해 동시 dispatch가 충돌하지 않습니다.

## Cross-repo dependency
이 PR은 [`rebellions-sw/fsw-integration#532`](https://github.com/rebellions-sw/fsw-integration/pull/532)에 포함된 다음 변경에 의존합니다:
- `vllm_rbln_pr_ci.yaml`에 `workflow_dispatch` + `distinct_id` 입력 + run-name 반영
- `vllm_rbln_nightly_e2e.yaml`에 `distinct_id` 입력 + run-name 반영

→ 해당 PR이 `dev`에 머지된 뒤 본 PR을 머지해야 동작합니다.

## Test plan
- [ ] fsw-integration #532 머지 후 본 PR 머지
- [ ] vllm-rbln dev/main에 vllm_rbln/** 변경 push → Trigger FSW Merge CI 가 실제 fsw-integration PR CI run id를 잡고 완료까지 대기하는지 확인
- [ ] dispatch된 fsw-integration run이 실패하면 vllm-rbln 트리거 워크플로우도 빨간불로 표시되는지 확인
- [ ] 02:00 KST cron에서 nightly e2e 트리거가 마찬가지 패턴으로 결과 노출되는지 확인 (또는 workflow_dispatch로 ad-hoc 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
