### PR TITLE
fix(core): cast RBLN sampler logits before processors

### DIFF
--- a/tests/v1/worker/test_sampler.py
+++ b/tests/v1/worker/test_sampler.py
@@ -16,6 +16,13 @@ import pytest
 import torch
 from torch._dynamo.testing import CompileCounter
 from vllm.platforms import current_platform
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.sample.logits_processor.interface import BatchUpdate
+from vllm.v1.sample.metadata import SamplingMetadata
+
+from vllm_rbln.v1.sample.rbln_sampler import RBLNSampler
 
 from .utils import (
     _schedule_new_request_from_request,
@@ -223,6 +230,72 @@ def test_forward_sampling_parameters(
 
 
 # TODO mix the requests with different sampling parameters
+
+
+def test_rbln_sampler_casts_bfloat16_logits_before_min_tokens_processor(monkeypatch):
+    device = torch.device("cpu")
+    stop_token_id = 1
+    sampled_token_id = 2
+    output_token_ids: list[list[int]] = [[]]
+
+    min_tokens_processor = MinTokensLogitsProcessor(
+        vllm_config=None,
+        device=device,
+        is_pin_memory=False,
+    )
+    sampling_params = SamplingParams(
+        min_tokens=2,
+        stop_token_ids=[stop_token_id],
+    )
+    min_tokens_processor.update_state(
+        BatchUpdate(
+            batch_size=1,
+            removed=[],
+            added=[(0, sampling_params, None, output_token_ids[0])],
+            moved=[],
+        )
+    )
+
+    sampling_metadata = SamplingMetadata(
+        temperature=None,
+        all_greedy=True,
+        all_random=False,
+        top_p=None,
+        top_k=None,
+        generators={},
+        max_num_logprobs=-1,
+        no_penalties=True,
+        prompt_token_ids=None,
+        frequency_penalties=torch.tensor([], device=device),
+        presence_penalties=torch.tensor([], device=device),
+        repetition_penalties=torch.tensor([], device=device),
+        output_token_ids=output_token_ids,
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=LogitsProcessors([min_tokens_processor]),
+    )
+    logits = torch.tensor([[0.0, 10.0, 1.0]], dtype=torch.bfloat16, device=device)
+    observed: dict[str, torch.Tensor] = {}
+
+    def fake_sample(self, processed_logits, sampling_metadata):
+        observed["processed_logits"] = processed_logits.detach().clone()
+        return processed_logits.argmax(dim=-1), None
+
+    monkeypatch.setattr(RBLNSampler, "sample", fake_sample)
+
+    sampler = RBLNSampler.__new__(RBLNSampler)
+    torch.nn.Module.__init__(sampler)
+    sampler.logprobs_mode = "raw_logits"
+
+    sampler_output = sampler.forward(logits, sampling_metadata)
+
+    processed_logits = observed["processed_logits"]
+    assert processed_logits.dtype == torch.float32
+    assert processed_logits[0, stop_token_id].item() == float("-inf")
+    assert sampler_output.sampled_token_ids.item() == sampled_token_id
+    assert sampler_output.sampled_token_ids.item() != stop_token_id
+    assert sampler_output.logprobs_tensors is not None
+    assert sampler_output.logprobs_tensors.logprobs[0, stop_token_id].item() == 10.0
 
 
 def test_sampler_logits_reshape_prevents_torch_compile_recompile(monkeypatch):

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -268,9 +268,10 @@ class RBLNSampler(VLLMSampler):
                 else:
                     raw_logprobs = logits.to(torch.float32)
 
-        # NOTE(eunji.lee) To reduce the copy overhead, we turned off type casting.
-        # Use float32 for the logits.
-        # logits = logits.to(torch.float32)
+        # Logits processors can mutate logits in-place with float32 tensors
+        # such as MinTokensLogitsProcessor.neg_inf_tensor.
+        if logits.dtype != torch.float32:
+            logits = logits.to(torch.float32)
 
         logits = self.apply_logits_processors(
             logits, sampling_metadata, predict_bonus_token


### PR DESCRIPTION
### 🚀 Summary of Changes

This PR fixes RBLN sampler compatibility with `min_tokens` when model logits arrive as `bfloat16`.

`RBLNSampler.forward` previously passed incoming logits directly into `apply_logits_processors`. When `min_tokens` is active, vLLM's `MinTokensLogitsProcessor` writes a float32 `neg_inf_tensor` via `index_put_`, which raises a dtype mismatch if the destination logits tensor is `bfloat16`.

This change casts the mutable logits tensor to `torch.float32` before applying logits processors, matching upstream vLLM `Sampler.forward` behavior. Raw logprob/raw logits capture remains before processor application, preserving existing raw output semantics. The cast is skipped when logits are already float32.

A focused regression test covers `bfloat16` logits with an active min-tokens processor and verifies that the stop token is masked before sampling.

---

### 📌 Related Issues / Tickets

* Fixes #494

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `uvx ruff check vllm_rbln/v1/sample/rbln_sampler.py tests/v1/worker/test_sampler.py`
2. Run `uvx ruff format --check vllm_rbln/v1/sample/rbln_sampler.py tests/v1/worker/test_sampler.py`
3. Run `uv run --python 3.12 --no-project python -m py_compile vllm_rbln/v1/sample/rbln_sampler.py tests/v1/worker/test_sampler.py`
4. On a supported Linux x86_64 test environment, run `python3 -m pytest tests/v1/worker/test_sampler.py::test_rbln_sampler_casts_bfloat16_logits_before_min_tokens_processor -q`

Local results:

* `ruff check`: passed
* `ruff format --check`: passed
* `py_compile`: passed
* Focused pytest was not run locally because the default Python lacks `pytest`, and this repo's `tool.uv.environments` is constrained to Linux x86_64 while the local machine is macOS.

---

### 📸 Screenshots / Logs (if applicable)

N/A

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The regression test avoids invoking the compiled RBLN sampler by monkeypatching `RBLNSampler.sample`, so it focuses on the dtype boundary and min-tokens masking behavior inside `RBLNSampler.forward`.
