### PR TITLE
other: log KV cache layout, warm-up phases, rbln backend invocations

### DIFF
--- a/tests/torch_compile/unit/test_torch_compile_backend.py
+++ b/tests/torch_compile/unit/test_torch_compile_backend.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+import torch
+
+from vllm_rbln.torch_compile_backend import (
+    logged_rbln_backend,
+    set_warmup_active,
+)
+
+LOGGER_NAME = "vllm.vllm_rbln.torch_compile_backend"
+
+
+@pytest.fixture
+def caplog_vllm(caplog):
+    """vllm-rbln's "vllm" parent logger has propagate=False; re-enable it so
+    caplog (handler attached at root) sees records during the test."""
+    parent = logging.getLogger("vllm")
+    saved = parent.propagate
+    parent.propagate = True
+    try:
+        yield caplog
+    finally:
+        parent.propagate = saved
+
+
+@pytest.fixture
+def reset_warmup_flag():
+    yield
+    set_warmup_active(False)
+
+
+@pytest.mark.parametrize(
+    "warmup, expected_phase, expected_level",
+    [
+        (True, "warm-up", logging.INFO),
+        (False, "HOT PATH", logging.WARNING),
+    ],
+)
+def test_logged_rbln_backend(
+    warmup,
+    expected_phase,
+    expected_level,
+    monkeypatch,
+    caplog_vllm,
+    reset_warmup_flag,
+):
+    caplog = caplog_vllm
+    """Single end-to-end test for the backend wrapper.
+
+    Covers: phase-dependent log level + label, input-shape summary, call-chain
+    derivation, args/kwargs passthrough, and return-value passthrough.
+    """
+    captured = {}
+
+    def fake_rbln_backend(graph_module, inputs, **kwargs):
+        captured["gm"] = graph_module
+        captured["inputs"] = inputs
+        captured["kwargs"] = kwargs
+        return "RUNTIME_SENTINEL"
+
+    monkeypatch.setattr(
+        "vllm_rbln.torch_compile_backend._rbln_backend",
+        fake_rbln_backend,
+    )
+
+    set_warmup_active(warmup)
+
+    gm = torch.fx.symbolic_trace(torch.nn.Identity())
+    inputs = [
+        torch.empty((2, 3), dtype=torch.bfloat16),
+        torch.empty((4,), dtype=torch.int32),
+    ]
+    options = {"cache_dir": "/tmp/x"}
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        out = logged_rbln_backend(gm, inputs, options=options)
+
+    # Return value and arguments forwarded verbatim.
+    assert out == "RUNTIME_SENTINEL"
+    assert captured["gm"] is gm
+    assert captured["inputs"] is inputs
+    assert captured["kwargs"] == {"options": options}
+
+    records = [r for r in caplog.records if r.name == LOGGER_NAME]
+    assert len(records) == 2, f"expected 2 log lines, got {records}"
+    before, done = records
+
+    # Phase-dependent log level.
+    assert before.levelno == expected_level
+    assert done.levelno == expected_level
+
+    # First line carries phase label, input summary, and call chain.
+    msg = before.getMessage()
+    assert f"[{expected_phase}]" in msg
+    assert "(2, 3):torch.bfloat16" in msg
+    assert "(4,):torch.int32" in msg
+    # Call chain points back to this test file (and not torch / rebel internals).
+    assert "test_torch_compile_backend.py" in msg
+    assert "/torch/" not in msg
+    assert "/rebel/" not in msg
+
+    # Second line is the timing line.
+    assert "done:" in done.getMessage()

--- a/tests/torch_compile/unit/v1/spec_decode/test_medusa.py
+++ b/tests/torch_compile/unit/v1/spec_decode/test_medusa.py
@@ -242,7 +242,7 @@ def test_compile_model_builds_expected_rbln_compile_options(
 
     assert output is compiled_sentinel
     assert captured["model"] is model
-    assert captured["backend"] == "rbln"
+    assert captured["backend"] is medusa_module.logged_rbln_backend
     assert captured["dynamic"] is False
 
     options = cast(dict[str, Any], captured["options"])

--- a/vllm_rbln/torch_compile_backend.py
+++ b/vllm_rbln/torch_compile_backend.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Logging wrapper for the rbln torch.compile backend.
+
+Dynamo invokes the backend once per unique guarded input shape; each call
+is either a fresh compile (cache miss) or a `.rbln` cache load (cache hit).
+We wrap rebel.core.torch_compile.rbln_backend so every invocation is
+logged. Invocations outside the warm-up window are flagged as warnings,
+since they mean an input shape was not pre-compiled and the compile (slow)
+or cache load happened on the serving hot path.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import traceback
+from typing import Any
+
+import torch
+from rebel.core.torch_compile import rbln_backend as _rbln_backend
+
+from vllm_rbln.logger import init_logger
+
+logger = init_logger(__name__)
+
+_warmup_active: bool = False
+
+_SELF_FILENAME = os.path.abspath(__file__)
+
+_CALL_CHAIN_DEPTH = 3
+
+
+def set_warmup_active(active: bool) -> None:
+    global _warmup_active
+    _warmup_active = active
+
+
+def _summarize_inputs(inputs: list[Any]) -> str:
+    parts = []
+    for t in inputs:
+        if isinstance(t, torch.Tensor):
+            parts.append(f"{tuple(t.shape)}:{t.dtype}")
+        else:
+            parts.append(type(t).__name__)
+    return "[" + ", ".join(parts) + "]"
+
+
+def _find_call_chain(depth: int = _CALL_CHAIN_DEPTH) -> str:
+    """Walk the stack and return up to `depth` user-level frames as a chain.
+
+    rbln_backend is invoked from deep inside Dynamo; we skip torch / rebel /
+    this file's frames and format the deepest user frame leftmost.
+    """
+    chain: list[str] = []
+    for frame in reversed(traceback.extract_stack()):
+        path = frame.filename
+        if "/torch/" in path or "/rebel/" in path:
+            continue
+        if os.path.abspath(path) == _SELF_FILENAME:
+            continue
+        chain.append(f"{os.path.basename(path)}:{frame.lineno}({frame.name})")
+        if len(chain) >= depth:
+            break
+    return " <- ".join(chain) if chain else "?"
+
+
+def logged_rbln_backend(graph_module: Any, inputs: list[Any], **kwargs: Any) -> Any:
+    in_warmup = _warmup_active
+    log = logger.info if in_warmup else logger.warning
+    phase = "warm-up" if in_warmup else "HOT PATH"
+    log(
+        "rbln_backend [%s] %s: inputs=%s",
+        phase,
+        _find_call_chain(),
+        _summarize_inputs(inputs),
+    )
+    t0 = time.perf_counter()
+    result = _rbln_backend(graph_module, inputs, **kwargs)
+    log("rbln_backend done: %.2fs", time.perf_counter() - t0)
+    return result

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -24,6 +24,7 @@ except ImportError:
     has_torch_rbln = False
 
 from vllm_rbln.logger import init_logger
+from vllm_rbln.torch_compile_backend import logged_rbln_backend
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler as VLLMSampler
 import rebel
@@ -175,7 +176,7 @@ class RBLNTopKTopPSampler(nn.Module):
             rbln_top_k_top_p_sample,
             dynamic=False,
             fullgraph=True,
-            backend="rbln",
+            backend=logged_rbln_backend,
             options=options,
         )
         self.forward = self.forward_rbln

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -30,6 +30,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 import vllm_rbln.rbln_envs as envs
 import vllm_rbln.utils as rbln_utils
 from vllm_rbln.logger import init_logger
+from vllm_rbln.torch_compile_backend import logged_rbln_backend
 from vllm_rbln.v1.attention.kv_cache_bindings import (
     attach_kv_cache_bindings,
     build_kv_cache_forward_context_kwargs,
@@ -515,7 +516,7 @@ class RBLNEagleProposer(EagleProposer):
 
         return torch.compile(
             model,
-            backend="rbln",
+            backend=logged_rbln_backend,
             options=copy(options),
             dynamic=False,
         )

--- a/vllm_rbln/v1/spec_decode/medusa.py
+++ b/vllm_rbln/v1/spec_decode/medusa.py
@@ -23,6 +23,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.medusa import MedusaProposer
 
 import vllm_rbln.rbln_envs as envs
+from vllm_rbln.torch_compile_backend import logged_rbln_backend
 
 
 class RBLNMedusaProposer(MedusaProposer):
@@ -74,7 +75,7 @@ class RBLNMedusaProposer(MedusaProposer):
 
         return torch.compile(
             model,
-            backend="rbln",
+            backend=logged_rbln_backend,
             options=copy(options),
             dynamic=False,
         )

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -124,6 +124,10 @@ from vllm_rbln.forward_context import RBLNDPMetadata
 from vllm_rbln.logger import init_logger
 from vllm_rbln.lora.inputs import LoRAInputs
 from vllm_rbln.lora.mask import LoRAMask
+from vllm_rbln.torch_compile_backend import (
+    logged_rbln_backend,
+    set_warmup_active,
+)
 from vllm_rbln.v1.attention.backends.flash_attention import (
     RBLNFlashAttentionMetadataBuilder,
 )
@@ -1476,14 +1480,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # FIXME(jiwoo.park): method assignment for torch.compile
         self.compute_logits = torch.compile(  # type: ignore[method-assign]
             self.compute_logits,
-            backend="rbln",
+            backend=logged_rbln_backend,
             options=copy(options),
             dynamic=False,
         )
 
         compiled_model = torch.compile(
             model,
-            backend="rbln",
+            backend=logged_rbln_backend,
             options=copy(options),
             dynamic=False,
         )
@@ -1883,9 +1887,15 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     @torch.inference_mode()
     def warm_up_model(self) -> None:
+        set_warmup_active(True)
+        try:
+            self._warm_up_model_inner()
+        finally:
+            set_warmup_active(False)
+
+    def _warm_up_model_inner(self) -> None:
         num_kv_cache_groups = len(self.kv_cache_config.kv_cache_groups)
 
-        logger.info("Warm up prefill graph")
         prefill_seq_len = (
             self.scheduler_config.max_num_batched_tokens
             if self.scheduler_config.enable_chunked_prefill
@@ -1911,6 +1921,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             dummy_prefill_num_scheduled_tokens,
             num_kv_cache_groups,
         )
+        logger.info("Warm-up: prefill (seq_len=%d)", prefill_seq_len)
         self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
 
         # FIXME(RBLN): At the moment, a single request can’t access multiple
@@ -1963,6 +1974,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 )
                 assert current_intermediate_tensors is not None
 
+                logger.info(
+                    "Warm-up: decode (batch_bucket=%d, query_len=%d)",
+                    batch_bucket_size,
+                    query_len,
+                )
                 if self.specialized_moe_decode:
                     self._execute_dummy_requests(
                         so,
@@ -2005,6 +2021,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 batch_bucket_size
             )
             assert current_intermediate_tensors is not None
+            logger.info("Warm-up: sampler (decode_batch=%d)", decode_batch)
             self._execute_dummy_requests(so, cso, current_intermediate_tensors)
 
     def _add_dummy_requests(
@@ -4388,7 +4405,38 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             for kv_cache, name in zip(self.kv_caches, kv_cache_names):
                 self.compile_context.mark_static_address(kv_cache, name)
 
+        self._log_kv_cache_info(kv_cache_config, kv_caches)
         return kv_caches
+
+    def _log_kv_cache_info(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kv_caches: dict[str, torch.Tensor],
+    ) -> None:
+        total_bytes = sum(t.size for t in kv_cache_config.kv_cache_tensors)
+        logger.info(
+            "KV cache: num_blocks=%d, num_groups=%d, num_tensors=%d, total=%.3f GiB",
+            kv_cache_config.num_blocks,
+            len(kv_cache_config.kv_cache_groups),
+            len(kv_cache_config.kv_cache_tensors),
+            total_bytes / 1024**3,
+        )
+        # Group layers by (shape, dtype)
+        groups: dict[Any, list[str]] = defaultdict(list)
+        for layer_name, tensor in kv_caches.items():
+            key: Any
+            if isinstance(tensor, list):
+                key = tuple((tuple(s.shape), str(s.dtype)) for s in tensor)
+            else:
+                key = (tuple(tensor.shape), str(tensor.dtype))
+            groups[key].append(layer_name)
+        for key, layer_names in groups.items():
+            logger.info(
+                "KV cache: %d layer(s) shape/dtype=%s, e.g. %s",
+                len(layer_names),
+                key,
+                layer_names[0],
+            )
 
     def maybe_add_kv_sharing_layers_to_kv_cache_groups(
         self, kv_cache_config: KVCacheConfig


### PR DESCRIPTION
### 🚀 Summary of Changes

To improve observability, log
* summary of KV cache shape and size
* warm up phases
* information about each invocation of torch.compile rbln backend (call stack, input shape, and whether the compilation is outside warm up phase)


---

### 📌 Related Issues / Tickets

https://github.com/rebellions-sw/vllm-rbln-internal/issues/63


### ✅ Type of Change

* [x] ❓ Other (`other`): please describe

### example

```
$ VLLM_RBLN_USE_VLLM_MODEL=1 VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY=manual VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS=1,8 python examples/experimental/offline_inference_basic.py
...
[rbln_model_runner.py:4417] KV cache: num_blocks=370, num_groups=1, num_tensors=16, total=11.562 GiB
[rbln_model_runner.py:4434] KV cache: 16 layer(s) shape/dtype
...
[rbln_model_runner.py:1924] Warm-up: prefill (seq_len=128)
...
[torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2924(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1925(_warm_up_model_inner): inputs=[(1, 128):torch.int64, (1, 128):torch.int64, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (1, 40):torch.int16, (40,):torch.int32, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (1,):torch.int32]
...
[torch_compile_backend.py:91] rbln_backend done: xx s
[rbln_model_runner.py:1977] Warm-up: decode (batch_bucket=8, query_len=1)
[torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2924(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1990(_warm_up_model_inner): inputs=[(8, 1):torch.int64, (8, 1):torch.int64, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (8, 40):torch.int16, (8, 40):torch.int32, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16]
...
[torch_compile_backend.py:91] rbln_backend done: xx s
[rbln_model_runner.py:1977] Warm-up: decode (batch_bucket=8, query_len=1)
[torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2924(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1990(_warm_up_model_inner): inputs=[(8, 1):torch.int64, (8, 1):torch.int64, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (8, 40):torch.int16, (8, 40):torch.int32, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16, (2, 370, 8, 1, 1024, 64):torch.bfloat16]
```


