### PR TITLE
fix: EAGLE3 logits remap for RBLN compile

### DIFF
--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -595,12 +595,11 @@ class RBLNEagleProposer(EagleProposer):
                 else last_hidden_states
             )
             # logits = self.model.compute_logits(sample_hidden_states)
-            # NOTE: Use scatter for RBLN compile instead of compute_logits' in-place remap.
+            # NOTE: Use scatter for RBLN compile instead of compute_logits
             logits = self.model.logits_processor(
                 self.model.lm_head, sample_hidden_states
             )
             if self.model.draft_id_to_target_id is not None:
-                
                 logits = logits[..., : self.model.config.draft_vocab_size]
                 base = torch.arange(
                     self.model.config.draft_vocab_size,

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -594,7 +594,28 @@ class RBLNEagleProposer(EagleProposer):
                 if last_token_indices is not None
                 else last_hidden_states
             )
-            logits = self.model.compute_logits(sample_hidden_states)
+            # logits = self.model.compute_logits(sample_hidden_states)
+            # NOTE: Use scatter for RBLN compile instead of compute_logits' in-place remap.
+            logits = self.model.logits_processor(
+                self.model.lm_head, sample_hidden_states
+            )
+            if self.model.draft_id_to_target_id is not None:
+                
+                logits = logits[..., : self.model.config.draft_vocab_size]
+                base = torch.arange(
+                    self.model.config.draft_vocab_size,
+                    device=logits.device,
+                )
+                targets = base + self.model.draft_id_to_target_id
+                target_indices = targets.unsqueeze(0).expand(logits.shape[0], -1)
+                remapped_logits = logits.new_full(
+                    (
+                        logits.shape[0],
+                        self.model.config.vocab_size,
+                    ),
+                    float("-inf"),
+                )
+                logits = remapped_logits.scatter(1, target_indices, logits)
 
             return hidden_states, logits
 


### PR DESCRIPTION
### 🚀 Summary of Changes

Fix EAGLE3 draft model compilation on RBLN by replacing `compute_logits()` in the compiled wrapper path with an equivalent `logits_processor()` + `scatter()` remap.

The original `compute_logits()` implementation uses an in-place logits remap, which is not handled by the RBLN compile path and can fail during EAGLE3 warmup compilation. This PR keeps the same remapping behavior while avoiding the unsupported in-place operation.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #398 

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run:
    `python examples/experimental/run_specdec_eagle_test.py --method eagle3`

2. Verify output:
    EAGLE3 warmup compilation completes without `warning unhandled case: <class 'NoneType'>` or engine initialization failure.



---

### 📸 Screenshots / Logs (if applicable)

<details>
<summary>Original Log</summary>

```
(EngineCore pid=3909509)     compiled_gm = compiler_fn(gm, example_inputs)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/torch/__init__.py", line 2509, in __call__
(EngineCore pid=3909509)     return self.compiler_fn(model_, inputs_, **self.kwargs)
(EngineCore pid=3909509)   File "<frozen core.torch_compile>", line 56, in wrapper
(EngineCore pid=3909509)   File "<frozen core.torch_compile>", line 259, in wrapped_rbln_backend
(EngineCore pid=3909509)   File "<frozen core.torch_compile>", line 442, in rbln_backend
(EngineCore pid=3909509)   File "<frozen core.torch_compile>", line 390, in rbln_backend
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/rebel/compile_from_any.py", line 194, in compile_from_torch
(EngineCore pid=3909509)     return _compile_from_torch(
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/rebel/compile_from_any.py", line 216, in _compile_from_torch
(EngineCore pid=3909509)     mod = torch_to_ir(
(EngineCore pid=3909509)   File "<frozen core.compilation._impl>", line 558, in torch_to_ir
(EngineCore pid=3909509)   File "<frozen core.compilation._impl>", line 381, in jittrace_and_to_ir
(EngineCore pid=3909509)   File "<frozen core.utility>", line 52, in wrapper
(EngineCore pid=3909509)   File "<frozen core.compilation._impl>", line 710, in torchscript_to_ir
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/pytorch.py", line 5553, in from_pytorch
(EngineCore pid=3909509)     outputs = converter.convert_operators(operator_nodes, outputs, ret_name)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/pytorch.py", line 4654, in convert_operators
(EngineCore pid=3909509)     relay_out = set_span(relay_out, self.source_map[op_node])
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1226, in set_span
(EngineCore pid=3909509)     return _SpanFiller(span).fill(sym)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1165, in fill
(EngineCore pid=3909509)     return self.visit(sym)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1085, in visit
(EngineCore pid=3909509)     return super().visit(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/expr_functor.py", line 48, in visit
(EngineCore pid=3909509)     res = self.visit_call(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1101, in visit_call
(EngineCore pid=3909509)     new_args = [self.visit(arg) for arg in call.args]
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1101, in <listcomp>
(EngineCore pid=3909509)     new_args = [self.visit(arg) for arg in call.args]
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1085, in visit
(EngineCore pid=3909509)     return super().visit(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/expr_functor.py", line 48, in visit
(EngineCore pid=3909509)     res = self.visit_call(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1101, in visit_call
(EngineCore pid=3909509)     new_args = [self.visit(arg) for arg in call.args]
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1101, in <listcomp>
(EngineCore pid=3909509)     new_args = [self.visit(arg) for arg in call.args]
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1085, in visit
(EngineCore pid=3909509)     return super().visit(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/expr_functor.py", line 58, in visit
(EngineCore pid=3909509)     res = self.visit_tuple(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1124, in visit_tuple
(EngineCore pid=3909509)     tup, [self.visit(field) for field in tup.fields], None, self._span
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1124, in <listcomp>
(EngineCore pid=3909509)     tup, [self.visit(field) for field in tup.fields], None, self._span
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/frontend/common.py", line 1085, in visit
(EngineCore pid=3909509)     return super().visit(expr)
(EngineCore pid=3909509)   File "/workspace/vllm-rbln-sqzb/.venv/lib/python3.10/site-packages/tvm/relay/expr_functor.py", line 76, in visit
(EngineCore pid=3909509)     raise Exception(f"warning unhandled case: {type(expr)}")
(EngineCore pid=3909509) torch._dynamo.exc.BackendCompilerFailed: backend='rbln' raised:
(EngineCore pid=3909509) Exception: warning unhandled case: <class 'NoneType'>
(EngineCore pid=3909509)
(EngineCore pid=3909509) Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```
</details>

<details>
<summary>This PR's Log</summary>

```
root@ece8701f76c4:/workspace/vllm-rbln# python examples/experimental/run_specdec_eagle_test.py  --method eagle3
INFO 05-08 06:26:02 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 05-08 06:26:02 [__init__.py:46] - rbln -> vllm_rbln:register
INFO 05-08 06:26:02 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-08 06:26:02 [__init__.py:239] Platform plugin rbln is activated
/opt/python/versions/3.10.19/lib/python3.10/site-packages/optimum/rbln/__init__.py:577: ImportWarning: Version mismatch detected: optimum-rbln v0.10.3 and rebel-compiler v0.10.2 have different base versions. For optimal performance and compatibility, please ensure both packages share the same major and minor version numbers. Please refer to our SDK release notes at https://docs.rbln.ai/about_atom/release_note.html
  check_version_compats()
[vllm-rbln] INFO 2026-05-08 06:26:03,911 [importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
[vllm-rbln] INFO 2026-05-08 06:26:03,912 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
[vllm-rbln] INFO 2026-05-08 06:26:05,878 [layer.py:513] [RBLN] fused moe, RBLN optimize moe custom kernel
[vllm-rbln] WARNING 2026-05-08 06:26:06,324 [platform.py:95] Pin memory is not supported on RBLN.
[vllm-rbln] INFO 2026-05-08 06:26:06,486 [utils.py:233] non-default args: {'max_model_len': 2048, 'block_size': 1024, 'max_num_batched_tokens': 256, 'max_num_seqs': 1, 'enable_chunked_prefill': True, 'speculative_config': {'method': 'eagle3', 'model': 'AngelSlim/Qwen3-1.7B_eagle3', 'num_speculative_tokens': 3}, 'model': 'Qwen/Qwen3-1.7B'}
[vllm-rbln] INFO 2026-05-08 06:26:08,119 [model.py:533] Resolved architecture: Qwen3ForCausalLM
[vllm-rbln] INFO 2026-05-08 06:26:08,120 [model.py:1582] Using max model len 2048
[vllm-rbln] INFO 2026-05-08 06:26:09,348 [model.py:533] Resolved architecture: LlamaForCausalLMEagle3
[vllm-rbln] INFO 2026-05-08 06:26:09,349 [model.py:1582] Using max model len 40960
[vllm-rbln] INFO 2026-05-08 06:26:09,350 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=256.
[vllm-rbln] INFO 2026-05-08 06:26:09,350 [vllm.py:775] Asynchronous scheduling is enabled.
[vllm-rbln] WARNING 2026-05-08 06:26:09,350 [platform.py:162] Async scheduler not supported on RBLN.
[vllm-rbln] INFO 2026-05-08 06:26:09,350 [platform.py:185] original model_config.dtype = torch.bfloat16
[vllm-rbln] INFO 2026-05-08 06:26:09,350 [platform.py:195] RBLN use model_config.dtype = torch.bfloat16
[vllm-rbln] WARNING 2026-05-08 06:26:09,350 [platform.py:225] Using RBLNSampler with speculative decoding is not supported yet.
[vllm-rbln] WARNING 2026-05-08 06:26:09,350 [platform.py:278] uni is not supported on RBLN, fallback to mp distributed executor backend.
[vllm-rbln] INFO 2026-05-08 06:26:09,351 [platform.py:294] RBLN doesn't @support_torch_compile decorator
[vllm-rbln] INFO 2026-05-08 06:26:09,351 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,701 [core.py:103] Initializing a V1 LLM engine (v0.18.2.dev0+ga26e8dc7f.d20260507) with config: model='Qwen/Qwen3-1.7B', speculative_config=SpeculativeConfig(method='eagle3', model='AngelSlim/Qwen3-1.7B_eagle3', num_spec_tokens=3), tokenizer='Qwen/Qwen3-1.7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-1.7B, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'bypass', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': None, 'compile_ranges_endpoints': [256], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,875 [rbln_worker.py:177] Local rank: 0, Selected devices: 0
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,875 [parallel_state.py:1395] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.3:40343 backend=
(EngineCore pid=914298) [vllm-rbln] WARNING 2026-05-08 06:26:10,875 [parallel_state.py:1408] Distributed backend  is not available; falling back to gloo.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,964 [parallel_state.py:1717] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,966 [rbln_model_runner.py:316] Using default vLLM sampler.
(EngineCore pid=914298) [vllm-rbln] WARNING 2026-05-08 06:26:10,973 [__init__.py:204] min_p and logit_bias parameters won't work with speculative decoding.
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,978 [rbln_model_runner.py:552] Using ExponentialBucketingManager bucketing manager
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,978 [rbln_model_runner.py:553] decode batch buckets: [1]
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,979 [rbln_model_runner.py:3489] Starting to load model Qwen/Qwen3-1.7B...
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:10,980 [rbln_model_runner.py:3492] Loading model from scratch...
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:11,000 [platform.py:325] Using RBLN Attention Backend: vllm_rbln.v1.attention.backends.flash_attention.RBLNAttentionBackend
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  7.09it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00, 14.13it/s]
(EngineCore pid=914298) 
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,404 [default_loader.py:384] Loading weights took 0.22 seconds
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512] load_model = Qwen3ForCausalLM(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]   (model): Qwen3Model(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]     (embed_tokens): VocabParallelEmbedding(num_embeddings=151936, embedding_dim=2048, org_vocab_size=151936, num_embeddings_padded=151936, tp_size=1)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]     (layers): ModuleList(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]       (0-27): 28 x Qwen3DecoderLayer(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]         (self_attn): Qwen3Attention(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (qkv_proj): QKVParallelLinear(in_features=2048, output_features=4096, bias=False, tp_size=1, gather_output=False)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (o_proj): RowParallelLinear(in_features=2048, output_features=2048, bias=False, tp_size=1, reduce_results=True)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (rotary_emb): RotaryEmbedding(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]             head_size=128, rotary_dim=128, max_position_embeddings=40960, base=1000000, is_neox_style=True
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]             (apply_rotary_emb): ApplyRotaryEmb(is_neox_style=True, enable_fp32_compute=False)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (attn): Attention(head_size=128, num_heads=16, num_kv_heads=8, scale=0.08837890625, backend=RBLNFlashAttentionImpl)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (q_norm): RMSNorm(hidden_size=128, eps=1e-06)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (k_norm): RMSNorm(hidden_size=128, eps=1e-06)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]         )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]         (mlp): Qwen2MLP(
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (gate_up_proj): MergedColumnParallelLinear(in_features=2048, output_features=12288, bias=False, tp_size=1, gather_output=False)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (down_proj): RowParallelLinear(in_features=6144, output_features=2048, bias=False, tp_size=1, reduce_results=True)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]           (act_fn): SiluAndMul()
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]         )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]         (input_layernorm): RMSNorm(hidden_size=2048, eps=1e-06)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]         (post_attention_layernorm): RMSNorm(hidden_size=2048, eps=1e-06)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]       )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]     )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]     (norm): RMSNorm(hidden_size=2048, eps=1e-06)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]   )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]   (lm_head): ParallelLMHead(num_embeddings=151936, embedding_dim=2048, org_vocab_size=151936, num_embeddings_padded=151936, tp_size=1)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512]   (logits_processor): LogitsProcessor(vocab_size=151936, org_vocab_size=151936, scale=1.0, logits_as_input=False)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,412 [rbln_model_runner.py:3512] )
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,414 [rbln_model_runner.py:3513] model_config.num_layers = 28
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:12,414 [rbln_model_runner.py:3580] Loading drafter model...
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 14.19it/s]
(EngineCore pid=914298) 
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,116 [default_loader.py:384] Loading weights took 0.09 seconds
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,117 [eagle.py:1336] Detected EAGLE model without its own embed_tokens in the checkpoint. Sharing target model embedding weights with the draft model.
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,117 [eagle.py:1412] Detected EAGLE model with distinct lm_head weights. Keeping separate lm_head weights from the target model.
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,171 [rbln_worker.py:295] n_model_bytes = 3.20 GB
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,176 [rbln_worker.py:343] draft_n_model_bytes = 0.83 GB
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,176 [rbln_worker.py:344] draft_model_kernel_size = 0.26 GB
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,178 [rbln_worker.py:353] available_memory_estimate = 10.23 GiB
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,179 [kv_cache_utils.py:1316] GPU KV cache size: 92,160 tokens
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,179 [kv_cache_utils.py:1321] Maximum concurrency for 2,048 tokens per request: 45.00x
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,182 [rbln_model_runner.py:4475] KV cache: num_blocks=90, num_groups=1, num_tensors=29, total=10.195 GiB
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,182 [rbln_model_runner.py:4492] KV cache: 29 layer(s) shape/dtype=((2, 90, 8, 1, 1024, 128), 'torch.bfloat16'), e.g. model.layers.0.self_attn.attn
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,204 [utils.py:333] auto thread-binding: rank 0 (rank_across_dp 0) -> NUMA node 0, CPUs: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31 (exclusive allocation, id, physical core): [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20), (21, 21), (22, 22), (23, 23), (24, 24), (25, 25), (26, 26), (27, 27), (28, 28), (29, 29), (30, 30), (31, 31)]
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,205 [utils.py:477] Set torch.num_threads to 16 for rank 0 (local_rank 0)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:13,206 [rbln_model_runner.py:1924] Warm-up: prefill (seq_len=256)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:26:17,033 [torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2932(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1925(_warm_up_model_inner): inputs=[(1, 256):torch.int64, (1, 256):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (2,):torch.int32, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16]
(EngineCore pid=914298) 2026-05-08 06:26:19,826 INFO [rebel-compiler] Export done. Elapsed time: 0:00:02
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:26:38,396 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:13, Memory change: 7.18 MB
(EngineCore pid=914298) 2026-05-08 06:26:38,505 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:26:38,507 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:26:38,508 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:26:38,508 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:26:38,508 INFO [rebel-compiler] |Compile(#0), mod_name=dccb17, input_info_index=0|
(EngineCore pid=914298) 2026-05-08 06:26:38,508 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:03
Computation graph optimization  ████████████████████████████████████████ 100% 00:02
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:04,343 [torch_compile_backend.py:91] rbln_backend done: 47.31s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:05,358 [torch_compile_backend.py:83] rbln_backend [warm-up] eagle.py:171(propose) <- rbln_model_runner.py:3473(propose_draft_token_ids) <- rbln_model_runner.py:3155(propose_draft_token_ids): inputs=[(1, 256):torch.int32, (1, 256, 2048):torch.bfloat16, (1, 256):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (2,):torch.int32, (1,):torch.int32]
(EngineCore pid=914298) 2026-05-08 06:27:05,543 INFO [rebel-compiler] Export done. Elapsed time: 0:00:00
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:27:06,467 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:00, Memory change: 5.19 MB
(EngineCore pid=914298) 2026-05-08 06:27:06,521 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:27:06,523 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:27:06,523 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:27:06,523 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:27:06,523 INFO [rebel-compiler] |Compile(#0), mod_name=eb6835, input_info_index=0|
(EngineCore pid=914298) 2026-05-08 06:27:06,523 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:00
Computation graph optimization  ████████████████████████████████████████ 100% 00:00
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:10,962 [torch_compile_backend.py:91] rbln_backend done: 5.60s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:11,239 [torch_compile_backend.py:83] rbln_backend [warm-up] eagle.py:329(propose) <- rbln_model_runner.py:3473(propose_draft_token_ids) <- rbln_model_runner.py:3155(propose_draft_token_ids): inputs=[(1, 1):torch.int32, (1, 1, 2048):torch.bfloat16, (1, 1):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32]
(EngineCore pid=914298) 2026-05-08 06:27:11,449 INFO [rebel-compiler] Export done. Elapsed time: 0:00:00
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:27:12,375 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:00, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:27:12,430 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:27:12,432 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:27:12,432 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:27:12,432 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:27:12,432 INFO [rebel-compiler] |Compile(#1), mod_name=eb6835, input_info_index=1|
(EngineCore pid=914298) 2026-05-08 06:27:12,432 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:00
Computation graph optimization  ████████████████████████████████████████ 100% 00:00
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:15,235 [torch_compile_backend.py:91] rbln_backend done: 4.00s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:15,301 [rbln_model_runner.py:1977] Warm-up: decode (batch_bucket=1, query_len=1)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:27:18,644 [torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2932(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1990(_warm_up_model_inner): inputs=[(1, 1):torch.int64, (1, 1):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16]
(EngineCore pid=914298) 2026-05-08 06:27:21,247 INFO [rebel-compiler] Export done. Elapsed time: 0:00:01
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:27:40,131 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:13, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:27:40,238 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:27:40,241 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:27:40,241 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:27:40,241 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:27:40,241 INFO [rebel-compiler] |Compile(#1), mod_name=dccb17, input_info_index=1|
(EngineCore pid=914298) 2026-05-08 06:27:40,241 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:02
Computation graph optimization  ████████████████████████████████████████ 100% 00:02
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:28:03,637 [torch_compile_backend.py:91] rbln_backend done: 44.99s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:28:04,573 [torch_compile_backend.py:83] rbln_backend [warm-up] eagle.py:171(propose) <- rbln_model_runner.py:3473(propose_draft_token_ids) <- rbln_model_runner.py:3155(propose_draft_token_ids): inputs=[(1, 1):torch.int32, (1, 1, 2048):torch.bfloat16, (1, 1):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (1,):torch.int32]
(EngineCore pid=914298) 2026-05-08 06:28:04,727 INFO [rebel-compiler] Export done. Elapsed time: 0:00:00
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:28:05,631 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:00, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:28:05,687 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:28:05,689 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:28:05,689 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:28:05,690 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:28:05,690 INFO [rebel-compiler] |Compile(#2), mod_name=eb6835, input_info_index=2|
(EngineCore pid=914298) 2026-05-08 06:28:05,690 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:00
Computation graph optimization  ████████████████████████████████████████ 100% 00:00
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:28:10,976 [torch_compile_backend.py:91] rbln_backend done: 6.40s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:28:11,053 [rbln_model_runner.py:1977] Warm-up: decode (batch_bucket=1, query_len=2)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:28:14,476 [torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2932(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1990(_warm_up_model_inner): inputs=[(1, 2):torch.int64, (1, 2):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16]
(EngineCore pid=914298) 2026-05-08 06:28:17,458 INFO [rebel-compiler] Export done. Elapsed time: 0:00:02
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:28:37,249 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:14, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:28:37,360 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:28:37,363 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:28:37,363 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:28:37,363 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:28:37,363 INFO [rebel-compiler] |Compile(#2), mod_name=dccb17, input_info_index=2|
(EngineCore pid=914298) 2026-05-08 06:28:37,363 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:03
Computation graph optimization  ████████████████████████████████████████ 100% 00:03
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:29:01,950 [torch_compile_backend.py:91] rbln_backend done: 47.47s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:29:02,896 [torch_compile_backend.py:83] rbln_backend [warm-up] eagle.py:171(propose) <- rbln_model_runner.py:3473(propose_draft_token_ids) <- rbln_model_runner.py:3155(propose_draft_token_ids): inputs=[(1, 2):torch.int32, (1, 2, 2048):torch.bfloat16, (1, 2):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (1,):torch.int32]
(EngineCore pid=914298) 2026-05-08 06:29:03,067 INFO [rebel-compiler] Export done. Elapsed time: 0:00:00
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:29:04,012 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:00, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:29:04,068 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:29:04,071 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:29:04,071 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:29:04,071 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:29:04,071 INFO [rebel-compiler] |Compile(#3), mod_name=eb6835, input_info_index=3|
(EngineCore pid=914298) 2026-05-08 06:29:04,071 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:00
Computation graph optimization  ████████████████████████████████████████ 100% 00:00
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:29:08,267 [torch_compile_backend.py:91] rbln_backend done: 5.37s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:29:08,334 [rbln_model_runner.py:1977] Warm-up: decode (batch_bucket=1, query_len=3)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:29:11,719 [torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2932(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1990(_warm_up_model_inner): inputs=[(1, 3):torch.int64, (1, 3):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16]
(EngineCore pid=914298) 2026-05-08 06:29:14,411 INFO [rebel-compiler] Export done. Elapsed time: 0:00:01
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:29:33,773 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:13, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:29:33,883 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:29:33,886 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:29:33,886 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:29:33,886 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:29:33,886 INFO [rebel-compiler] |Compile(#3), mod_name=dccb17, input_info_index=3|
(EngineCore pid=914298) 2026-05-08 06:29:33,886 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:03
Computation graph optimization  ████████████████████████████████████████ 100% 00:04
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:29:59,236 [torch_compile_backend.py:91] rbln_backend done: 47.52s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:30:00,183 [torch_compile_backend.py:83] rbln_backend [warm-up] eagle.py:171(propose) <- rbln_model_runner.py:3473(propose_draft_token_ids) <- rbln_model_runner.py:3155(propose_draft_token_ids): inputs=[(1, 3):torch.int32, (1, 3, 2048):torch.bfloat16, (1, 3):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (1,):torch.int32]
(EngineCore pid=914298) 2026-05-08 06:30:00,352 INFO [rebel-compiler] Export done. Elapsed time: 0:00:00
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:30:01,267 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:00, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:30:01,323 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:30:01,326 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:30:01,326 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:30:01,326 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:30:01,326 INFO [rebel-compiler] |Compile(#4), mod_name=eb6835, input_info_index=4|
(EngineCore pid=914298) 2026-05-08 06:30:01,326 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:00
Computation graph optimization  ████████████████████████████████████████ 100% 00:00
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:30:05,489 [torch_compile_backend.py:91] rbln_backend done: 5.31s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:30:05,557 [rbln_model_runner.py:1977] Warm-up: decode (batch_bucket=1, query_len=4)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:30:08,928 [torch_compile_backend.py:83] rbln_backend [warm-up] rbln_model_runner.py:2932(execute_model) <- rbln_model_runner.py:2105(_execute_dummy_requests) <- rbln_model_runner.py:1990(_warm_up_model_inner): inputs=[(1, 4):torch.int64, (1, 4):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (2, 90, 8, 1, 1024, 128):torch.bfloat16]
(EngineCore pid=914298) 2026-05-08 06:30:11,623 INFO [rebel-compiler] Export done. Elapsed time: 0:00:01
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:30:31,381 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:14, Memory change: 0.00 MB
(EngineCore pid=914298) 2026-05-08 06:30:31,491 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:30:31,494 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:30:31,494 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:30:31,494 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:30:31,494 INFO [rebel-compiler] |Compile(#4), mod_name=dccb17, input_info_index=4|
(EngineCore pid=914298) 2026-05-08 06:30:31,494 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:03
Computation graph optimization  ████████████████████████████████████████ 100% 00:04
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:30:56,857 [torch_compile_backend.py:91] rbln_backend done: 47.93s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:30:57,809 [torch_compile_backend.py:83] rbln_backend [warm-up] eagle.py:171(propose) <- rbln_model_runner.py:3473(propose_draft_token_ids) <- rbln_model_runner.py:3155(propose_draft_token_ids): inputs=[(1, 4):torch.int32, (1, 4, 2048):torch.bfloat16, (1, 4):torch.int64, (2, 90, 8, 1, 1024, 128):torch.bfloat16, (1, 2):torch.int16, (1, 2):torch.int32, (1,):torch.int32]
(EngineCore pid=914298) 2026-05-08 06:30:57,980 INFO [rebel-compiler] Export done. Elapsed time: 0:00:00
(EngineCore pid=914298) /opt/python/versions/3.10.19/lib/python3.10/copyreg.py:101: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
(EngineCore pid=914298)   return cls.__new__(cls, *args)
(EngineCore pid=914298) 2026-05-08 06:30:58,902 INFO [rebel-compiler] Exported model conversion done. Elapsed time: 0:00:00, Memory change: 0.03 MB
(EngineCore pid=914298) 2026-05-08 06:30:58,960 INFO [rebel-compiler] RBLN SDK compiler version: 0.10.2
(EngineCore pid=914298) 2026-05-08 06:30:58,963 INFO [rebel-compiler] -- Target NPU: RBLN-CA25
(EngineCore pid=914298) 2026-05-08 06:30:58,963 INFO [rebel-compiler] -- Tensor parallel size: 1
(EngineCore pid=914298) 2026-05-08 06:30:58,963 INFO [rebel-compiler] +------------------------------------------------+
(EngineCore pid=914298) 2026-05-08 06:30:58,963 INFO [rebel-compiler] |Compile(#5), mod_name=eb6835, input_info_index=5|
(EngineCore pid=914298) 2026-05-08 06:30:58,963 INFO [rebel-compiler] +------------------------------------------------+
Computation graph generation ████████████████████████████████████████ 100% 00:00
Computation graph optimization  ████████████████████████████████████████ 100% 00:00
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:03,183 [torch_compile_backend.py:91] rbln_backend done: 5.37s
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:03,252 [rbln_model_runner.py:2024] Warm-up: sampler (decode_batch=1)
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:03,298 [utils.py:333] auto thread-binding: rank 0 (rank_across_dp 0) -> NUMA node 0, CPUs: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31 (exclusive allocation, id, physical core): [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20), (21, 21), (22, 22), (23, 23), (24, 24), (25, 25), (26, 26), (27, 27), (28, 28), (29, 29), (30, 30), (31, 31)]
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:03,299 [utils.py:425] Set CPU affinity for rank 0 (local_rank 0): CPUs 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:03,299 [core.py:281] init engine (profile, create kv cache, warmup model) took 290.13 seconds
(EngineCore pid=914298) [vllm-rbln] WARNING 2026-05-08 06:31:04,640 [scheduler.py:173] Using custom scheduler class vllm_rbln.v1.core.rbln_scheduler.RBLNScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:04,643 [rbln_scheduler.py:95] Sub-block prefix caching enabled: block_size=1024, sub_block_size=256
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:05,270 [vllm.py:775] Asynchronous scheduling is disabled.
(EngineCore pid=914298) [vllm-rbln] WARNING 2026-05-08 06:31:05,270 [vllm.py:820] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:05,270 [platform.py:185] original model_config.dtype = torch.bfloat16
(EngineCore pid=914298) [vllm-rbln] INFO 2026-05-08 06:31:05,270 [platform.py:195] RBLN use model_config.dtype = torch.bfloat16
(EngineCore pid=914298) [vllm-rbln] WARNING 2026-05-08 06:31:05,270 [platform.py:278] uni is not supported on RBLN, fallback to mp distributed executor backend.
[vllm-rbln] INFO 2026-05-08 06:31:05,277 [llm.py:391] Supported tasks: ['generate']
Rendering prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 162.36it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:05<00:00,  2.70s/it, est. speed input: 2.59 toks/s, output: 47.37 toks/s]
--------------------------------------------------
prompt: A robot may not injure a human being
generated text: . This is a fundamental law of the robot's programming. The robot must protect humans, even if it means that it has to destroy the enemy. This is the first law. The robot must do the right thing. This is the second law. The robot must do the right thing. This is the second law. The robot must do the right thing. This is the second law. The robot must do the right thing. This is the second law. The robot must do the right thing. This is the second law. The robot must do the right thing. This is the second law. The robot must do the right thing.
--------------------------------------------------
--------------------------------------------------
prompt: The capital of France is
generated text:  Paris. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of Portugal is Lisbon. The capital of Germany is Berlin. The capital of the United Kingdom is London. The capital of the United States is Washington, D.C. The capital of Canada is Ottawa. The capital of Mexico is Mexico City. The capital of Japan is Tokyo. The capital of Australia is Canberra. The capital of New Zealand is Wellington. The capital of South Korea is Seoul. The capital of Vietnam is Hanoi. The capital of Thailand is Bangkok. The capital of Indonesia is Jakarta. The capital of Malaysia is Kuala Lumpur. The capital
--------------------------------------------------
--------------------------------------------------
total_num_output_tokens: 256
num_drafts: 118
num_draft_tokens: 354
num_accepted_tokens: 137
mean acceptance length: 2.16
--------------------------------------------------
acceptance at token 0: 0.65
acceptance at token 1: 0.32
acceptance at token 2: 0.19
```
</details>

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The root cause is the in-place remap inside upstream `compute_logits()`:

[`logits_new[:, targets] = logits`](https://github.com/vllm-project/vllm/blob/v0.19.1/vllm/model_executor/models/llama_eagle3.py#L359)

The RBLN wrapper now performs the remap with `scatter()` to keep the graph compile-friendly.