### PR TITLE
feature: add no_export_fallback mode

### DIFF
--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -167,13 +167,10 @@ class RBLNTopKTopPSampler(nn.Module):
                     else rebel.CompileContext()
                 )
             )
-        modes = []
         if envs.VLLM_RBLN_COMPILE_STRICT_MODE:
-            modes.append("strict")
+            options["mode"] = "strict"
         if use_dt:
-            modes.append("no_export_fallback")
-        if modes:
-            options["mode"] = modes
+            options["model_trace_method"] = "export"
 
         if has_torch_rbln or use_dt:
             options["tensor_parallel_size"] = 1

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -167,8 +167,13 @@ class RBLNTopKTopPSampler(nn.Module):
                     else rebel.CompileContext()
                 )
             )
+        modes = []
         if envs.VLLM_RBLN_COMPILE_STRICT_MODE:
-            options["mode"] = "strict"
+            modes.append("strict")
+        if use_dt:
+            modes.append("no_export_fallback")
+        if modes:
+            options["mode"] = modes
 
         if has_torch_rbln or use_dt:
             options["tensor_parallel_size"] = 1

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -624,7 +624,9 @@ class RBLNEagleProposer(EagleProposer):
             "tensor_parallel_size": envs.VLLM_RBLN_TP_SIZE,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
-            "mode": "strict",
+            "mode": ["strict", "no_export_fallback"]
+            if envs.VLLM_RBLN_USE_DEVICE_TENSOR
+            else "strict",
         }
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             logger.info(

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -624,10 +624,10 @@ class RBLNEagleProposer(EagleProposer):
             "tensor_parallel_size": envs.VLLM_RBLN_TP_SIZE,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
-            "mode": ["strict", "no_export_fallback"]
-            if envs.VLLM_RBLN_USE_DEVICE_TENSOR
-            else "strict",
+            "mode": "strict",
         }
+        if envs.VLLM_RBLN_USE_DEVICE_TENSOR:
+            options["model_trace_method"] = "export"
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             logger.info(
                 "Once the model is compiled for the first time, "

--- a/vllm_rbln/v1/spec_decode/medusa.py
+++ b/vllm_rbln/v1/spec_decode/medusa.py
@@ -68,7 +68,9 @@ class RBLNMedusaProposer(MedusaProposer):
             "tensor_parallel_size": envs.VLLM_RBLN_TP_SIZE,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
-            "mode": "strict",
+            "mode": ["strict", "no_export_fallback"]
+            if envs.VLLM_RBLN_USE_DEVICE_TENSOR
+            else "strict",
         }
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             options["cache_dir"] = os.path.join(envs.VLLM_CACHE_ROOT, "rbln")

--- a/vllm_rbln/v1/spec_decode/medusa.py
+++ b/vllm_rbln/v1/spec_decode/medusa.py
@@ -68,10 +68,10 @@ class RBLNMedusaProposer(MedusaProposer):
             "tensor_parallel_size": envs.VLLM_RBLN_TP_SIZE,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
-            "mode": ["strict", "no_export_fallback"]
-            if envs.VLLM_RBLN_USE_DEVICE_TENSOR
-            else "strict",
+            "mode": "strict",
         }
+        if envs.VLLM_RBLN_USE_DEVICE_TENSOR:
+            options["model_trace_method"] = "export"
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             options["cache_dir"] = os.path.join(envs.VLLM_CACHE_ROOT, "rbln")
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1478,12 +1478,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             "tensor_parallel_size": envs.VLLM_RBLN_TP_SIZE,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
-            "mode": ["strict", "no_export_fallback"]
-            if envs.VLLM_RBLN_USE_DEVICE_TENSOR
-            else "strict",
+            "mode": "strict",
             "_runtime_holder": self.runtime_holder,
         }
-        if not envs.VLLM_RBLN_USE_DEVICE_TENSOR:
+        if envs.VLLM_RBLN_USE_DEVICE_TENSOR:
+            options["model_trace_method"] = "export"
+        else:
             options["compile_context"] = self.compile_context
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             logger.info(

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1478,7 +1478,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             "tensor_parallel_size": envs.VLLM_RBLN_TP_SIZE,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
-            "mode": "strict",
+            "mode": ["strict", "no_export_fallback"]
+            if envs.VLLM_RBLN_USE_DEVICE_TENSOR
+            else "strict",
             "_runtime_holder": self.runtime_holder,
         }
         if not envs.VLLM_RBLN_USE_DEVICE_TENSOR:


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

When `VLLM_RBLN_USE_DEVICE_TENSOR=1`, add "no_export_fallback" to the mode option passed to `torch.compile(..., backend=logged_rbln_backend, options=...)`. This makes torch.export.export failures fatal in the RBLN compiler backend instead of silently falling back to torch.jit.trace.

Applied to all four torch.compile call sites that use the RBLN backend:
  - v1/worker/rbln_model_runner.py — main model + compute_logits
  - v1/sample/rbln_sampler.py — top-k/top-p sampler
  - v1/spec_decode/eagle.py — Eagle draft model
  - v1/spec_decode/medusa.py — Medusa draft model

  No behavior change when `VLLM_RBLN_USE_DEVICE_TENSOR` is unset.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
