### PR TITLE
fix(platform): set device attrs at class definition for spawn compatibility

### DIFF
--- a/examples/experimental/eager_basic.py
+++ b/examples/experimental/eager_basic.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from vllm import LLM, SamplingParams
+import os
+
+# enforce_eager bypasses torch.compile, so the model must run on real
+# device='rbln' tensors rather than the compile-backend fake-CPU tensors used
+# by the default path.
+os.environ.setdefault("VLLM_RBLN_USE_VLLM_MODEL", "1")
+os.environ.setdefault("VLLM_RBLN_USE_DEVICE_TENSOR", "1")
+
+from vllm import LLM, SamplingParams  # noqa: E402
 
 # Sample prompts.
 prompts = [

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -123,6 +123,7 @@ def _make_vllm_config(
         ),
         cache_config=_make_cache_config(),
         scheduler_config=_make_scheduler_config(),
+        device_config=SimpleNamespace(device=torch.device("cpu"), device_type="cpu"),
         kv_transfer_config=None,
         instance_id="test-instance",
     )
@@ -179,6 +180,7 @@ def _fake_super_init(
     self.parallel_config = vllm_config.parallel_config
     self.cache_config = vllm_config.cache_config
     self.scheduler_config = vllm_config.scheduler_config
+    self.device_config = vllm_config.device_config
 
 
 def _create_worker(

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -54,13 +54,17 @@ register_backend(name="bypass", compiler_fn=bypass_backend)
 class RblnPlatform(Platform):
     _enum = PlatformEnum.OOT
 
-    # TODO(jiwoo.park): GroupCoordinator uses the device_name
-    # when torch.device(device_name) is called.
-    # But we don't support the 'rbln'' device yet.
-    # To support this, we must use PyTorch-RBLN
+    # Compute device_name/device_type/dist_backend once at class definition
+    # from env vars so that subprocesses spawned under
+    # VLLM_WORKER_MULTIPROC_METHOD=spawn (which re-import this module fresh)
+    # observe identical values to the parent without any extra plumbing.
+    _USE_DEVICE_TENSOR: bool = (
+        envs.VLLM_RBLN_USE_VLLM_MODEL and envs.VLLM_RBLN_USE_DEVICE_TENSOR
+    )
     plugin_name: str = "rbln"
-    device_name: str = "cpu"
-    device_type: str = "cpu"
+    device_name: str = "rbln" if _USE_DEVICE_TENSOR else "cpu"
+    device_type: str = "rbln" if _USE_DEVICE_TENSOR else "cpu"
+    dist_backend: str = "rbln-ccl" if _USE_DEVICE_TENSOR else ""
     dispatch_key: str = "CPU"
     ray_device_key: str = "RBLN"
     simple_compile_backend = "bypass"
@@ -150,6 +154,26 @@ class RblnPlatform(Platform):
                 )
 
     @classmethod
+    def maybe_override_eager_mode_device(cls, vllm_config: VllmConfig) -> None:
+        """Force ``device_type='rbln'`` for the vLLM model + enforce_eager path.
+
+        Ideally this mutation should be avoided so that subprocesses spawned under
+        VLLM_WORKER_MULTIPROC_METHOD=spawn (which re-import this module fresh)
+        observe identical values to the parent without any extra plumbing.
+        But the standard ``enforce_eager`` configuration lives on ``model_config``,
+        which isn't available at class-definition time.
+
+        TODO: This path itself is a temporary workaround.
+        Remove this when it's retired.
+        """
+        if (
+            envs.VLLM_RBLN_USE_VLLM_MODEL
+            and not envs.VLLM_RBLN_USE_DEVICE_TENSOR
+            and vllm_config.model_config.enforce_eager
+        ):
+            cls.device_type = "rbln"
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
@@ -159,18 +183,10 @@ class RblnPlatform(Platform):
             scheduler_config.async_scheduling = False
             logger.warning("Async scheduler not supported on RBLN.")
 
+        cls.maybe_override_eager_mode_device(vllm_config)
+
         if envs.VLLM_RBLN_USE_VLLM_MODEL:
             cls.validate_and_setup_prerequisite(vllm_config)
-            if envs.VLLM_RBLN_USE_DEVICE_TENSOR:
-                # Use RBLN device tensors for torch.compile/runtime on the
-                # native vLLM model path.
-                RblnPlatform.device_name = "rbln"
-                RblnPlatform.device_type = "rbln"
-                RblnPlatform.dist_backend = "rbln-ccl"
-                vllm_config.device_config.device_type = RblnPlatform.device_type
-                vllm_config.device_config.device = torch.device(
-                    RblnPlatform.device_type
-                )
 
             if envs.VLLM_RBLN_ENFORCE_MODEL_FP32:
                 logger.info("original model_config.dtype = %s", model_config.dtype)
@@ -217,11 +233,12 @@ class RblnPlatform(Platform):
                     hf_config, "use_sliding_window", True
                 )
 
-                RblnPlatform.device_type = "rbln"
-                vllm_config.device_config.device_type = RblnPlatform.device_type
-                vllm_config.device_config.device = torch.device(
-                    RblnPlatform.device_type
-                )
+                # cls.device_type was already set to "rbln" by
+                # maybe_override_eager_mode_device(); propagate that into
+                # device_config (DeviceConfig.__post_init__ already ran with
+                # the pre-override value).
+                vllm_config.device_config.device_type = cls.device_type
+                vllm_config.device_config.device = torch.device(cls.device_type)
                 # NOTE - force dtype into fp16 for eager mode
                 model_config.dtype = torch.float16
 

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -154,26 +154,6 @@ class RblnPlatform(Platform):
                 )
 
     @classmethod
-    def maybe_override_eager_mode_device(cls, vllm_config: VllmConfig) -> None:
-        """Force ``device_type='rbln'`` for the vLLM model + enforce_eager path.
-
-        Ideally this mutation should be avoided so that subprocesses spawned under
-        VLLM_WORKER_MULTIPROC_METHOD=spawn (which re-import this module fresh)
-        observe identical values to the parent without any extra plumbing.
-        But the standard ``enforce_eager`` configuration lives on ``model_config``,
-        which isn't available at class-definition time.
-
-        TODO: This path itself is a temporary workaround.
-        Remove this when it's retired.
-        """
-        if (
-            envs.VLLM_RBLN_USE_VLLM_MODEL
-            and not envs.VLLM_RBLN_USE_DEVICE_TENSOR
-            and vllm_config.model_config.enforce_eager
-        ):
-            cls.device_type = "rbln"
-
-    @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
@@ -182,8 +162,6 @@ class RblnPlatform(Platform):
         if scheduler_config.async_scheduling:
             scheduler_config.async_scheduling = False
             logger.warning("Async scheduler not supported on RBLN.")
-
-        cls.maybe_override_eager_mode_device(vllm_config)
 
         if envs.VLLM_RBLN_USE_VLLM_MODEL:
             cls.validate_and_setup_prerequisite(vllm_config)
@@ -228,17 +206,18 @@ class RblnPlatform(Platform):
 
             # FIXME(jiwoo.park) This is a temporary workaround.
             if model_config.enforce_eager:
+                if not envs.VLLM_RBLN_USE_DEVICE_TENSOR:
+                    raise ValueError(
+                        "enforce_eager=True requires VLLM_RBLN_USE_DEVICE_TENSOR=1. "
+                        "Eager mode bypasses torch.compile, so ops must dispatch "
+                        "to a real device='rbln' rather than the compile-backend "
+                        "fake-CPU tensors used by the default vLLM model path."
+                    )
                 hf_config = vllm_config.model_config.hf_config
                 assert not hasattr(hf_config, "sliding_window") or not getattr(
                     hf_config, "use_sliding_window", True
                 )
 
-                # cls.device_type was already set to "rbln" by
-                # maybe_override_eager_mode_device(); propagate that into
-                # device_config (DeviceConfig.__post_init__ already ran with
-                # the pre-override value).
-                vllm_config.device_config.device_type = cls.device_type
-                vllm_config.device_config.device = torch.device(cls.device_type)
                 # NOTE - force dtype into fp16 for eager mode
                 model_config.dtype = torch.float16
 

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -62,7 +62,6 @@ from vllm.v1.worker.worker_base import WorkerBase
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
-from vllm_rbln.platform import RblnPlatform
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.v1.worker.utils import (
     estimate_available_memory,
@@ -96,9 +95,6 @@ class RBLNWorker(WorkerBase):
             distributed_init_method=distributed_init_method,
             is_driver_worker=is_driver_worker,
         )
-        # For compatibility with VLLM_WORKER_MULTIPROC_METHOD=spawn.
-        # See comment in maybe_override_eager_mode_device for details.
-        RblnPlatform.maybe_override_eager_mode_device(vllm_config)
         self.device = self.device_config.device
 
         self.local_world_size = (

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -62,6 +62,7 @@ from vllm.v1.worker.worker_base import WorkerBase
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
+from vllm_rbln.platform import RblnPlatform
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.v1.worker.utils import (
     estimate_available_memory,
@@ -95,7 +96,10 @@ class RBLNWorker(WorkerBase):
             distributed_init_method=distributed_init_method,
             is_driver_worker=is_driver_worker,
         )
-        self.device = torch.device(current_platform.device_type)
+        # For compatibility with VLLM_WORKER_MULTIPROC_METHOD=spawn.
+        # See comment in maybe_override_eager_mode_device for details.
+        RblnPlatform.maybe_override_eager_mode_device(vllm_config)
+        self.device = self.device_config.device
 
         self.local_world_size = (
             self.parallel_config.world_size // envs.VLLM_RBLN_NUM_RAY_NODES


### PR DESCRIPTION
### 🚀 Summary of Changes
Problem:
RblnPlatform mutated its class attributes (device_name, device_type, dist_backend) inside check_and_update_config based on env vars.  Under VLLM_WORKER_MULTIPROC_METHOD=spawn the worker subprocess re-imports the module fresh and does not inherit these mutations.

Solution:
Match the upstream pattern: compute device attrs once at class definition, never mutate at runtime.
The enforce_eager-without-device-tensor case still depends on vllm_config, so isolate it in maybe_override_eager_mode_device and re-invoke it from `RblnWorker.__init__` so spawn subprocesses converge to the same device_type as the parent.


---

### 📌 Related Issues / Tickets

* Resolves https://github.com/rebellions-sw/LMCache-RBLN/pull/14#discussion_r3216803651

