### PR TITLE
[DO NOT MERGE ] fix(test): isolate torchinductor cache per xdist worker

### DIFF
--- a/.github/workflows/rbln_vllm-rbln_pytest.yaml
+++ b/.github/workflows/rbln_vllm-rbln_pytest.yaml
@@ -328,7 +328,6 @@ jobs:
               pytest tests/entrypoints/openai -vv --durations 0
               ;;
             "sampler")
-              pytest -n auto -k "warm_upTrue" tests/v1/worker/test_sampler.py -vv --durations 0
               pytest -n auto -k "warm_upFalse" tests/v1/worker/test_sampler.py -vv --durations 0
               ;;
           esac

--- a/tests/v1/worker/conftest.py
+++ b/tests/v1/worker/conftest.py
@@ -23,8 +23,9 @@ import torch
 @pytest.fixture(autouse=True)
 def fresh_inductor_cache_per_test(monkeypatch):
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "root")
-    cache_dir = f"/tmp/torchinductor_{worker_id}"
+    cache_dir = f"/tmp/torchinductor_{worker_id}_{os.getpid()}"
     shutil.rmtree(cache_dir, ignore_errors=True)
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", cache_dir)
 
     torch._dynamo.reset()
 

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -206,8 +206,21 @@ class RBLNTopKTopPSampler(nn.Module):
                 "RBLN Sampling does not support "
                 "per-request generators. Ignoring generators."
             )
+        result = self.top_k_top_p_sample(logits, k, p)
+        vocab_size = 50272
 
-        return self.top_k_top_p_sample(logits, k, p), None
+        bad = (result < 0) | (result >= vocab_size)
+        if bad.any():
+            print(
+                "OOB result (forward_rbln):",
+                result.tolist(),
+                "vocab:",
+                vocab_size,
+                flush=True,
+            )
+            raise RuntimeError("result OOB AFTER top_k_top_p_sample")
+
+        return result, None
 
 
 class RBLNSampler(VLLMSampler):

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -275,6 +275,7 @@ class RBLNSampler(VLLMSampler):
         predict_bonus_token: bool = False,
         logprobs_mode_override: LogprobsMode | None = None,
     ) -> SamplerOutput:
+        print("@@ raw logits", logits)
         logprobs_mode = logprobs_mode_override or self.logprobs_mode
         # NOTE(woosuk): Use the original logits (before any penalties or
         # temperature scaling) for the top-k logprobs.
@@ -350,7 +351,11 @@ class RBLNSampler(VLLMSampler):
         # in torchinductor
         if not all_random:
             temp = torch.where(temp < _SAMPLING_EPS, 1.0, temp)
-        return logits.div(temp.unsqueeze(dim=1))
+        print("@@ temp", temp)
+        print("@@ before logits", logits)
+        result = logits.div(temp.unsqueeze(dim=1))
+        print("@@ after logits", logits)
+        return result
 
 
 WARM_UP_CONFIGS = [

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -286,6 +286,13 @@ class RBLNSampler(VLLMSampler):
         )
         # Sample the next token.
         sampled, processed_logprobs = self.sample(logits, sampling_metadata)
+        import torch
+        torch._dynamo.graph_break()  # 후속 ops가 같은 graph에 fuse되지 않게 끊기
+        vocab_size = logits.shape[-1]
+        bad = (sampled < 0) | (sampled >= vocab_size)
+        if bad.any():
+            print("OOB sampled:", sampled.tolist(), "vocab:", vocab_size, flush=True)
+            raise RuntimeError("sampled OOB BEFORE gather")
         if processed_logprobs is not None:
             raw_logprobs = processed_logprobs
         # Convert sampled token ids to int64 (long) type to ensure compatibility

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -286,7 +286,6 @@ class RBLNSampler(VLLMSampler):
         )
         # Sample the next token.
         sampled, processed_logprobs = self.sample(logits, sampling_metadata)
-        import torch
         torch._dynamo.graph_break()  # 후속 ops가 같은 graph에 fuse되지 않게 끊기
         vocab_size = logits.shape[-1]
         bad = (sampled < 0) | (sampled >= vocab_size)

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -304,6 +304,7 @@ class RBLNSampler(VLLMSampler):
         vocab_size = logits.shape[-1]
         bad = (sampled < 0) | (sampled >= vocab_size)
         if bad.any():
+            print("@@@ logits", logits)
             print("OOB sampled:", sampled.tolist(), "vocab:", vocab_size, flush=True)
             raise RuntimeError("sampled OOB BEFORE gather")
         if processed_logprobs is not None:

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -207,7 +207,7 @@ class RBLNTopKTopPSampler(nn.Module):
                 "per-request generators. Ignoring generators."
             )
         result = self.top_k_top_p_sample(logits, k, p)
-        vocab_size = 50272
+        vocab_size = logits.shape[1]
 
         bad = (result < 0) | (result >= vocab_size)
         if bad.any():

--- a/vllm_rbln/v1/worker/optimum_input_batch.py
+++ b/vllm_rbln/v1/worker/optimum_input_batch.py
@@ -49,7 +49,7 @@ class RBLNInputBatch(InputBatch):
             # which propagate into the sampled token ids as out-of-vocab values.
             # Those ids are later used as indices in torch.gather (e.g. for logprobs),
             # triggering an "index out of bounds" RuntimeError in the CPU kernel.
-            self.temperature_cpu_tensor.fill_(1.0)
+            # self.temperature_cpu_tensor.fill_(1.0)
 
     def refresh_metadata_rbln(self, bucket_size: int):
         """Apply any batch updates to sampling metadata."""

--- a/vllm_rbln/v1/worker/optimum_input_batch.py
+++ b/vllm_rbln/v1/worker/optimum_input_batch.py
@@ -32,13 +32,22 @@ class RBLNInputBatch(InputBatch):
         if use_rbln_sampler:
             # Overwrite sampling_metadata with RBLN sampling metadata
             self.sampling_metadata = self._make_sampling_metadata_rbln(self.num_reqs)
-            # Add top_k as vocab_size
-            # to prevent runtime error while running top_p_top_k_ops
-            # https://github.com/vllm-project/vllm/blob/01efc7ef781391e744ed08c3292817a773d654e6/vllm/v1/worker/gpu_input_batch.py#L348
-            # If not, error will be raised here:
-            # https://github.com/vllm-project/vllm/blob/01efc7ef781391e744ed08c3292817a773d654e6/vllm/v1/sample/ops/topk_topp_sampler.py#L151
+            # Default top_k to vocab_size to guard against runtime errors in top_k/top_p ops:
+            # an unset top_k is still used as an index in the fused kernel, so vocab_size
+            # acts as "no filtering" while staying in a valid range.
+            #
+            # Refs:
+            #   - upstream default: https://github.com/vllm-project/vllm/blob/01efc7ef781391e744ed08c3292817a773d654e6/vllm/v1/worker/gpu_input_batch.py#L348
+            #   - failure site:    https://github.com/vllm-project/vllm/blob/01efc7ef781391e744ed08c3292817a773d654e6/vllm/v1/sample/ops/topk_topp_sampler.py#L151
             self.top_k.fill_(self.vocab_size)
             self.top_k_cpu_tensor.fill_(self.vocab_size)
+            # Default temperature to 1.0 to guard against NaN logits.
+            #
+            # Why: top_k / top_p applied to unscaled logits can produce NaNs,
+            # which propagate into the sampled token ids as out-of-vocab values.
+            # Those ids are later used as indices in torch.gather (e.g. for logprobs),
+            # triggering an "index out of bounds" RuntimeError in the CPU kernel.
+            self.temperature_cpu_tensor.fill_(1.0)
 
     def refresh_metadata_rbln(self, bucket_size: int):
         """Apply any batch updates to sampling metadata."""

--- a/vllm_rbln/v1/worker/optimum_input_batch.py
+++ b/vllm_rbln/v1/worker/optimum_input_batch.py
@@ -32,8 +32,10 @@ class RBLNInputBatch(InputBatch):
         if use_rbln_sampler:
             # Overwrite sampling_metadata with RBLN sampling metadata
             self.sampling_metadata = self._make_sampling_metadata_rbln(self.num_reqs)
-            # Default top_k to vocab_size to guard against runtime errors in top_k/top_p ops:
-            # an unset top_k is still used as an index in the fused kernel, so vocab_size
+            # Default top_k to vocab_size to guard
+            # against runtime errors in top_k/top_p ops:
+            # an unset top_k is still used as an index
+            # in the fused kernel, so vocab_size
             # acts as "no filtering" while staying in a valid range.
             #
             # Refs:

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -1310,7 +1310,7 @@ class RBLNOptimumModelRunner(
         logger.debug("Bucket sizes for RBLN sampler: %s", self.bucket_sizes)
         with torch.inference_mode():
             for bucket_size in self.bucket_sizes:
-                self.pooled_tensors[bucket_size] = torch.empty(
+                self.pooled_tensors[bucket_size] = torch.zeros(
                     (bucket_size, self.model_config.get_vocab_size()),
                     dtype=self.model.dtype,
                 )


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Set TORCHINDUCTOR_CACHE_DIR per worker so xdist workers no longer share the default inductor cache, fixing gather index OOB under `pytest -n auto`.

  - The fixture builds a per-worker cache dir name but never tells TorchInductor to use it (TORCHINDUCTOR_CACHE_DIR is not set).
  - TorchInductor's real default path is /tmp/torchinductor_<username> — in CI it runs as root, so /tmp/torchinductor_root, which matches the path in the error (/tmp/torchinductor_root/4c/...).
  - So shutil.rmtree deletes a non-existent /tmp/torchinductor_gw42, while the actual cache /tmp/torchinductor_root is shared by every pytest -n auto worker.
  - dummy_sampler_run() triggers warmup compilation → workers concurrently write to and read from the same cache → one worker hits a kernel produced by another worker (different graph shape/penalty combination), causing the gather index out-of-bounds mismatch.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `pytest -n auto -k "warm_upTrue" tests/v1/worker/test_sampler.py -vv --durations 0`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---