### PR TITLE
fix: sub-block cache copy compat with device tensor

### DIFF
--- a/tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
@@ -1,0 +1,108 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import random
+from dataclasses import asdict
+
+import pytest
+from vllm import LLM, EngineArgs, SamplingParams
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.inputs import TokensPrompt
+from vllm.v1.metrics.reader import Counter, Metric
+
+_RNG = random.Random(0)
+PREFIX = _RNG.sample(range(2000, 100000), 1600)
+PROMPTS = [
+    TokensPrompt(
+        prompt_token_ids=PREFIX + random.Random(i + 1).sample(range(2000, 100000), 10)
+    )
+    for i in range(4)
+]
+SAMPLING_PARAMS = SamplingParams(temperature=0.0, max_tokens=32)
+BLOCK_SIZE = 1024
+
+
+def _get_counter(metrics: list[Metric], name: str) -> int:
+    return sum(m.value for m in metrics if isinstance(m, Counter) and m.name == name)
+
+
+def _build_llm(*, enable_prefix_caching: bool) -> LLM:
+    args = EngineArgs(
+        model="Qwen/Qwen3-0.6B",
+        max_num_seqs=1,
+        max_model_len=4096,
+        enable_chunked_prefill=True,
+        max_num_batched_tokens=128,
+        enable_prefix_caching=enable_prefix_caching,
+        # First LLM leaks device memory on teardown, so the second LLM
+        # OOMs at default block count. 8 blocks × 1024 = 8192 tokens, enough
+        # to hold the warm-up plus one query.
+        num_gpu_blocks_override=8,
+        seed=0,
+    )
+    # block_size is validated in the EngineArgs ctor; assign post-hoc to bypass.
+    args.block_size = BLOCK_SIZE  # type: ignore[assignment]
+    return LLM(**asdict(args))
+
+
+def _generated_token_ids(outputs) -> list[list[int]]:
+    return [list(o.outputs[0].token_ids) for o in outputs]
+
+
+def _cleanup(llm: LLM) -> None:
+    del llm
+    try:
+        cleanup_dist_env_and_memory()
+    except RuntimeError as e:
+        # ignore error when not using torch-rbln
+        if "Cannot access accelerator device when none is available" not in str(e):
+            raise
+
+
+@pytest.mark.parametrize("use_device_tensor", [False, True])
+def test_sub_block_prefix_cache_matches_baseline(
+    monkeypatch: pytest.MonkeyPatch, use_device_tensor: bool
+) -> None:
+    monkeypatch.setenv("VLLM_RBLN_USE_DEVICE_TENSOR", "1" if use_device_tensor else "0")
+
+    # Baseline
+    baseline = _build_llm(enable_prefix_caching=False)
+    try:
+        baseline_tokens = _generated_token_ids(
+            baseline.generate(PROMPTS, SAMPLING_PARAMS)
+        )
+    finally:
+        _cleanup(baseline)
+
+    # Prefix-cached
+    cached = _build_llm(enable_prefix_caching=True)
+    try:
+        # Warm up prefix cache
+        cached.generate(PROMPTS[0], SAMPLING_PARAMS)
+
+        hits_before = _get_counter(cached.get_metrics(), "vllm:prefix_cache_hits")
+        outputs = cached.generate(PROMPTS, SAMPLING_PARAMS)
+        hits_after = _get_counter(cached.get_metrics(), "vllm:prefix_cache_hits")
+        cached_tokens = _generated_token_ids(outputs)
+    finally:
+        _cleanup(cached)
+
+    # Shared prefix is 1600 tokens (block_size=1024 + 576 trailing). Without
+    # sub-block caching each prompt would hit at most one full block, capping
+    # the total at len(PROMPTS) * BLOCK_SIZE. Sub-block caching extends the hit.
+    hits = hits_after - hits_before
+    assert hits > len(PROMPTS) * BLOCK_SIZE
+    assert cached_tokens == baseline_tokens

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner_kv_cache.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner_kv_cache.py
@@ -16,7 +16,8 @@
 
 Tests _add_dummy_requests, _make_dummy_scheduler_outputs,
 select_common_block_size, _prepare_kernel_block_sizes,
-_allocate_kv_cache_tensors, and _propagate_runtime_holder.
+_allocate_kv_cache_tensors, _process_kv_cache_copy_ops,
+and _propagate_runtime_holder.
 """
 
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,7 @@ import pytest
 import torch
 from vllm.v1.core.sched.output import NewRequestData
 
+from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 
 
@@ -454,6 +456,58 @@ class TestAllocateKvCacheTensors:
         assert result["layer_0"].device == runner.device
         assert result["layer_0"].shape == (768,)
         assert result["layer_0"].dtype == torch.int8
+
+
+# ============================================================
+# _process_kv_cache_copy_ops Tests
+# ============================================================
+
+
+class TestProcessKvCacheCopyOps:
+    def _bind(self, runner):
+        runner._process_kv_cache_copy_ops = (
+            RBLNModelRunner._process_kv_cache_copy_ops.__get__(runner)
+        )
+
+    def test_device_tensor_mode_uses_torch_copy(self):
+        runner = _make_runner_stub()
+        runner.model_config = MagicMock(enforce_eager=False)
+        runner.runtime_holder = []
+        kv_cache = torch.zeros((2, 3, 1, 1, 4, 1), dtype=torch.int64)
+        kv_cache[:, 0, :, :, :2, :] = 7
+        runner.kv_caches = [kv_cache]
+        self._bind(runner)
+
+        op = KVCacheCopyOp(group_id=0, src_block_id=0, dst_block_id=1, num_tokens=2)
+        with patch("vllm_rbln.v1.worker.rbln_model_runner.envs") as mock_envs:
+            mock_envs.VLLM_RBLN_USE_DEVICE_TENSOR = True
+            mock_envs.VLLM_RBLN_COMPILE_MODEL = True
+
+            runner._process_kv_cache_copy_ops([op])
+
+        assert torch.equal(kv_cache[:, 1, :, :, :2, :], kv_cache[:, 0, :, :, :2, :])
+        assert torch.all(kv_cache[:, 1, :, :, 2:, :] == 0)
+
+    def test_compiled_non_device_tensor_uses_runtime_copy(self):
+        # It's tricky to test the actual copy, so we only check that the
+        # runtime method is called with correct args.
+        runner = _make_runner_stub()
+        runner.model_config = MagicMock(enforce_eager=False)
+        runtime = MagicMock()
+        runner.runtime_holder = [runtime]
+        kv_cache = torch.zeros((2, 3, 1, 1, 4, 1), dtype=torch.int64)
+        kv_cache[:, 0, :, :, :2, :] = 7
+        runner.kv_caches = [kv_cache]
+        self._bind(runner)
+
+        op = KVCacheCopyOp(group_id=0, src_block_id=0, dst_block_id=1, num_tokens=2)
+        with patch("vllm_rbln.v1.worker.rbln_model_runner.envs") as mock_envs:
+            mock_envs.VLLM_RBLN_USE_DEVICE_TENSOR = False
+            mock_envs.VLLM_RBLN_COMPILE_MODEL = True
+
+            runner._process_kv_cache_copy_ops([op])
+
+        runtime._copy_kv_cache.assert_called_once_with(0, 1, 2)
 
 
 # ============================================================

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2781,7 +2781,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self,
         copy_ops: "list[KVCacheCopyOp]",
     ) -> None:
-        if self.model_config.enforce_eager or not envs.VLLM_RBLN_COMPILE_MODEL:
+        if (
+            envs.VLLM_RBLN_USE_DEVICE_TENSOR
+            or self.model_config.enforce_eager
+            or not envs.VLLM_RBLN_COMPILE_MODEL
+        ):
             for op in copy_ops:
                 for kv_cache in self.kv_caches:
                     kv_cache[:, op.dst_block_id, :, :, : op.num_tokens, :] = kv_cache[


### PR DESCRIPTION
### 🚀 Summary of Changes
VLLM_RBLN_USE_DEVICE_TENSOR=True does not use mark_static_address, so
_copy_kv_cache does not work. Use torch ops instead.

Note: torch-rbln d2d copy ops are not optimized yet.


While at it, add e2e test for sub-block caching.

