### PR TITLE
fix(swa): cast seq_lens to int16 after arithmetic to avoid overflow

### DIFF
--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -1207,11 +1207,13 @@ class RBLNFlashAttentionMetadataBuilder(
                 num_computed_tokens_cpu if use_dt else num_computed_tokens[:num_reqs]
             )
             sl_src = seq_lens_cpu if use_dt else seq_lens[:num_reqs]
-            num_computed_tokens = nct_src.view(-1, 1).to(torch.int16)
-            seq_lens = sl_src.view(-1, 1).to(torch.int16)
+            num_computed_tokens = nct_src.view(-1, 1)
+            seq_lens = sl_src.view(-1, 1)
             query_lens = seq_lens - num_computed_tokens
             cache_seq_lens = torch.clamp(num_computed_tokens, max=sliding_window)
             cache_offsets = cache_seq_lens + query_lens
+            cache_seq_lens = cache_seq_lens.to(torch.int16)
+            cache_offsets = cache_offsets.to(torch.int16)
             if not is_prefill:
                 cache_seq_lens = rbln_utils.pad(cache_seq_lens, 0, batch_pad)
                 cache_offsets = rbln_utils.pad(cache_offsets, 0, batch_pad)


### PR DESCRIPTION
## Summary

Defer the `int16` cast of `num_computed_tokens` / `seq_lens` until after the SWA bookkeeping arithmetic so that long-context requests are not silently truncated.

## Why

In `RBLNFlashAttentionMetadataBuilder.build()`, the sliding-window branch was casting the source tensors to `int16` **before** computing derived values:

```python
num_computed_tokens = nct_src.view(-1, 1).to(torch.int16)
seq_lens = sl_src.view(-1, 1).to(torch.int16)
query_lens = seq_lens - num_computed_tokens
cache_seq_lens = torch.clamp(num_computed_tokens, max=sliding_window)
cache_offsets = cache_seq_lens + query_lens
```

`num_computed_tokens` / `seq_lens` carry absolute token positions and can exceed `2^15 - 1 = 32767` for long-context models. The signed wraparound turns e.g. `33000` into `-32536`, and `torch.clamp(-32536, max=sliding_window)` passes the negative value through unchanged, corrupting `cache_seq_lens` (and therefore `cache_offsets` and the SWA mask).

## Fix

Keep the source tensors in their original dtype, do the subtraction / clamp / add in higher precision, then cast only the bounded results:

```python
num_computed_tokens = nct_src.view(-1, 1)
seq_lens = sl_src.view(-1, 1)
query_lens = seq_lens - num_computed_tokens
cache_seq_lens = torch.clamp(num_computed_tokens, max=sliding_window)
cache_offsets = cache_seq_lens + query_lens
cache_seq_lens = cache_seq_lens.to(torch.int16)
cache_offsets = cache_offsets.to(torch.int16)
```

Range check for the final casts:
- `cache_seq_lens` ≤ `sliding_window` (e.g. 4096 for Gemma3 / Mistral) — fits in int16.
- `cache_offsets` ≤ `sliding_window + query_lens`. `query_lens = 1` for decode; for prefill it is bounded by the chunked-prefill size — fits in int16.
- `query_lens` itself is only consumed locally to compute `cache_offsets`, so no downstream `int16` consumer is affected.

Hardware still receives `int16` for the SWA kernel; only the intermediate math is widened.

## Test plan

- [ ] Sanity-run a sliding-window model (e.g. Gemma3) with a prompt long enough that `num_computed_tokens > 32767` and confirm SWA decode still produces correct output.
- [ ] Existing SWA unit/e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)