### PR TITLE
other: switch vllm source to rebellions internal pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pyyaml",
     "datasets",
     "qwen_vl_utils",
-    "vllm==0.18.0+cpu",
+    "vllm==0.18.1.dev2+g4a5535958.d20260417.cpu",
     "torch",
     "torchvision",
     "torchaudio",
@@ -140,8 +140,13 @@ name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
+[[tool.uv.index]]
+name = "rebellions"
+url = "https://pypi.rebellions.in/simple"
+explicit = true
+
 [tool.uv.sources]
-vllm = { index = "vllm-cpu" }
+vllm = { index = "rebellions" }
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 torchaudio = { index = "pytorch-cpu" }


### PR DESCRIPTION
### 🚀 Summary of Changes

Switches the `vllm` dependency from the public `vllm-cpu` index to the internal `rebellions` PyPI (`https://pypi.rebellions.in/simple`), and bumps the pinned version to `0.18.1.dev2+g4a5535958.d20260417.cpu`.

- `pyproject.toml`
  - `vllm==0.18.0+cpu` → `vllm==0.18.1.dev2+g4a5535958.d20260417.cpu`
  - Added a new `[[tool.uv.index]]` entry named `rebellions`
  - `[tool.uv.sources]` updated so that `vllm = { index = "rebellions" }`

---

### 📌 Related Issues / Tickets

- Resolves #
- Related to #

---

### ✅ Type of Change

- [ ] 🚀 Release (`release`)
- [ ] ✨ Feature (`feature`)
- [ ] 🧠 Model support (`model`)
- [ ] 🧬 Core engine changes (`core`)
- [ ] 🛠 Bug fix (`fix`)
- [ ] ⚙️ Performance improvement (`perf`)
- [ ] 🔁 Refactor or code cleanup (`refactor`)
- [ ] 📄 Documentation (`docs`)
- [x] ❓ Other (`other`): dependency / package index change

---

### 🧪 How to Test

1. Run `uv sync`
2. Verify output: `uv pip show vllm` reports `0.18.1.dev2+g4a5535958.d20260417.cpu`, sourced from `pypi.rebellions.in`
3. Edge case tested: run an existing `0.18.0-ax-k1-fp8` inference path and confirm no regression

---

### 📸 Screenshots / Logs (if applicable)

N/A

---

### 📋 Checklist

- [x] PR title follows Conventional Commits format
- [ ] This PR is linked to an existing issue
- [x] The test method is described, and the expected result is clearly stated
- [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- Base branch: `0.18.0-ax-k1-fp8`
- `uv.lock` is not included in this commit. If needed, it can be regenerated and pushed as a separate commit.
- The `rebellions` index may require internal network / VPN access. Please verify that CI environments can reach it.