### PR TITLE
fix: add warmup config and fix logits dtype casting in apply_temperature

### DIFF
--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -417,6 +417,7 @@ class RBLNSampler(VLLMSampler):
             temperature = torch.where(
                 temperature < _SAMPLING_EPS, _GREEDY_EPS, temperature
             )
+        temperature = temperature.to(logits.dtype)
         return logits.div(temperature.unsqueeze(dim=1))
 
 
@@ -427,6 +428,13 @@ WARM_UP_CONFIGS = [
         "all_greedy": True,
         "all_random": False,
         "temperature": 0.0,
+    },
+    {
+        "name": "no_penalty_random",
+        "no_penalties": True,
+        "all_greedy": False,
+        "all_random": True,
+        "temperature": 0.5,
     },
     {
         "name": "no_penalty_topp",


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

1. Add warmup config 
    a. top_k=None and top_p=None is not all_greedy. It's random sampling
2. logits dtype casting
    b.  If logits is bfloat16 and temperature is float32, logits is cast to float32 after division by temperature.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [x] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
4. Verify output: `...`
5. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
