### PR TITLE
fix(test): replace exact match test in spec decode by logprob similarity test

### DIFF
--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
@@ -22,6 +22,7 @@ import pytest
 from vllm import LLM, SamplingParams
 
 from .utils import (
+    assert_spec_matches_base_within_noise,
     ensure_vllm_compatible_eagle_draft_model,
     get_default_eagle_test_model_ids,
 )
@@ -79,6 +80,9 @@ def test_eagle_matches_base_generation(method: str, max_tokens: int) -> None:
         top_p=1.0,
         max_tokens=max_tokens,
         ignore_eos=True,
+        # Needed for the bf16 near-tie check in
+        # assert_spec_matches_base_within_noise.
+        logprobs=20,
     )
 
     base_llm = _build_base_llm(method)
@@ -100,8 +104,13 @@ def test_eagle_matches_base_generation(method: str, max_tokens: int) -> None:
                 base_output.outputs[0].finish_reason
                 == eagle_output.outputs[0].finish_reason
             )
-            assert base_output.outputs[0].text == eagle_output.outputs[0].text
-            assert base_output.outputs[0].token_ids == eagle_output.outputs[0].token_ids
+            # Greedy spec decode may flip a near-tie argmax due to bf16 ULP
+            # differences between the base decode and EAGLE verify kernels.
+            # Require a match up to the first divergence and that the
+            # divergence (if any) is genuine floating-point noise.
+            assert_spec_matches_base_within_noise(
+                base_output.outputs[0], eagle_output.outputs[0]
+            )
     finally:
         del eagle_llm
         gc.collect()

--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
@@ -25,15 +25,18 @@ from .utils import (
     assert_spec_matches_base_within_noise,
     ensure_vllm_compatible_eagle_draft_model,
     get_default_eagle_test_model_ids,
+    make_batch_prompts,
 )
 
-PROMPTS = [
-    "The capital of France is",
-]
 NUM_SPECULATIVE_TOKENS = 3
 
+# Batch sizes to exercise: batch=1 covers the single-sequence path, while
+# batch=8/16 exercises the wider verify-kernel shapes where bf16 rounding can
+# differ from the base path.
+BATCH_SIZES = [1, 8, 16]
 
-def _build_base_llm(method: str) -> LLM:
+
+def _build_base_llm(method: str, max_num_seqs: int) -> LLM:
     base_model_id, _ = get_default_eagle_test_model_ids(method)
     return LLM(
         model=base_model_id,
@@ -41,13 +44,13 @@ def _build_base_llm(method: str) -> LLM:
         block_size=1024,
         enable_chunked_prefill=True,
         max_num_batched_tokens=256,
-        max_num_seqs=1,
+        max_num_seqs=max_num_seqs,
         disable_log_stats=False,
         tensor_parallel_size=1,
     )
 
 
-def _build_eagle_llm(method: str) -> LLM:
+def _build_eagle_llm(method: str, max_num_seqs: int) -> LLM:
     base_model_id, draft_model_id = get_default_eagle_test_model_ids(method)
     draft_model_id = ensure_vllm_compatible_eagle_draft_model(
         eagle_model_id=draft_model_id,
@@ -59,7 +62,7 @@ def _build_eagle_llm(method: str) -> LLM:
         block_size=1024,
         enable_chunked_prefill=True,
         max_num_batched_tokens=256,
-        max_num_seqs=1,
+        max_num_seqs=max_num_seqs,
         speculative_config={
             "method": method,
             "model": draft_model_id,
@@ -70,34 +73,41 @@ def _build_eagle_llm(method: str) -> LLM:
     )
 
 
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
 @pytest.mark.parametrize(
     ("method", "max_tokens"),
     [("eagle", 8), ("eagle3", 32)],
 )
-def test_eagle_matches_base_generation(method: str, max_tokens: int) -> None:
+def test_eagle_matches_base_generation(
+    method: str, max_tokens: int, batch_size: int
+) -> None:
     sampling_params = SamplingParams(
         temperature=0.0,
         top_p=1.0,
         max_tokens=max_tokens,
         ignore_eos=True,
     )
+    prompts = make_batch_prompts(batch_size)
 
     # Generate with EAGLE speculative decoding first, then teacher-force the
     # resulting tokens through the base model and check, at every position,
     # that each spec token is the base model's greedy choice (up to bf16
     # near-tie flips). Only one engine is alive at a time to bound memory.
-    eagle_llm = _build_eagle_llm(method)
-    spec_req = eagle_llm.generate(PROMPTS, sampling_params=sampling_params)[0]
-    prompt_token_ids = list(spec_req.prompt_token_ids)
-    spec_token_ids = list(spec_req.outputs[0].token_ids)
+    eagle_llm = _build_eagle_llm(method, max_num_seqs=batch_size)
+    spec_reqs = eagle_llm.generate(prompts, sampling_params=sampling_params)
+    captured = [
+        (list(req.prompt_token_ids), list(req.outputs[0].token_ids))
+        for req in spec_reqs
+    ]
     del eagle_llm
     gc.collect()
 
-    base_llm = _build_base_llm(method)
+    base_llm = _build_base_llm(method, max_num_seqs=batch_size)
     try:
-        assert_spec_matches_base_within_noise(
-            base_llm, prompt_token_ids, spec_token_ids
-        )
+        for seq_idx, (prompt_token_ids, spec_token_ids) in enumerate(captured):
+            assert_spec_matches_base_within_noise(
+                base_llm, prompt_token_ids, spec_token_ids, seq_idx=seq_idx
+            )
     finally:
         del base_llm
         gc.collect()

--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
@@ -80,37 +80,24 @@ def test_eagle_matches_base_generation(method: str, max_tokens: int) -> None:
         top_p=1.0,
         max_tokens=max_tokens,
         ignore_eos=True,
-        # Needed for the bf16 near-tie check in
-        # assert_spec_matches_base_within_noise.
-        logprobs=20,
     )
 
-    base_llm = _build_base_llm(method)
-    base_outputs = base_llm.generate(PROMPTS, sampling_params=sampling_params)
-    # Release the baseline engine before compiling the speculative variant.
-    del base_llm
+    # Generate with EAGLE speculative decoding first, then teacher-force the
+    # resulting tokens through the base model and check, at every position,
+    # that each spec token is the base model's greedy choice (up to bf16
+    # near-tie flips). Only one engine is alive at a time to bound memory.
+    eagle_llm = _build_eagle_llm(method)
+    spec_req = eagle_llm.generate(PROMPTS, sampling_params=sampling_params)[0]
+    prompt_token_ids = list(spec_req.prompt_token_ids)
+    spec_token_ids = list(spec_req.outputs[0].token_ids)
+    del eagle_llm
     gc.collect()
 
-    eagle_llm = _build_eagle_llm(method)
-    eagle_outputs = eagle_llm.generate(PROMPTS, sampling_params=sampling_params)
-
-    assert len(base_outputs) == len(eagle_outputs)
-
+    base_llm = _build_base_llm(method)
     try:
-        for base_output, eagle_output in zip(base_outputs, eagle_outputs, strict=True):
-            assert base_output.prompt == eagle_output.prompt
-            assert len(base_output.outputs) == len(eagle_output.outputs) == 1
-            assert (
-                base_output.outputs[0].finish_reason
-                == eagle_output.outputs[0].finish_reason
-            )
-            # Greedy spec decode may flip a near-tie argmax due to bf16 ULP
-            # differences between the base decode and EAGLE verify kernels.
-            # Require a match up to the first divergence and that the
-            # divergence (if any) is genuine floating-point noise.
-            assert_spec_matches_base_within_noise(
-                base_output.outputs[0], eagle_output.outputs[0]
-            )
+        assert_spec_matches_base_within_noise(
+            base_llm, prompt_token_ids, spec_token_ids
+        )
     finally:
-        del eagle_llm
+        del base_llm
         gc.collect()

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -73,33 +73,24 @@ def test_medusa_matches_base_generation() -> None:
         top_p=1.0,
         max_tokens=8,
         ignore_eos=True,
-        # Needed for the bf16 near-tie check in
-        # assert_spec_matches_base_within_noise.
-        logprobs=20,
     )
 
-    base_llm = _build_base_llm()
-    base_outputs = base_llm.generate(PROMPTS, sampling_params=sampling_params)
-    # Release the baseline engine before compiling the Medusa variant.
-    del base_llm
+    # Generate with Medusa speculative decoding first, then teacher-force the
+    # resulting tokens through the base model and check, at every position,
+    # that each spec token is the base model's greedy choice (up to bf16
+    # near-tie flips). Only one engine is alive at a time to bound memory.
+    medusa_llm = _build_medusa_llm()
+    spec_req = medusa_llm.generate(PROMPTS, sampling_params=sampling_params)[0]
+    prompt_token_ids = list(spec_req.prompt_token_ids)
+    spec_token_ids = list(spec_req.outputs[0].token_ids)
+    del medusa_llm
     gc.collect()
 
-    medusa_llm = _build_medusa_llm()
-    medusa_outputs = medusa_llm.generate(PROMPTS, sampling_params=sampling_params)
-
-    assert len(base_outputs) == len(medusa_outputs)
-
-    for base_output, medusa_output in zip(base_outputs, medusa_outputs, strict=True):
-        assert base_output.prompt == medusa_output.prompt
-        assert len(base_output.outputs) == len(medusa_output.outputs) == 1
-        assert (
-            base_output.outputs[0].finish_reason
-            == medusa_output.outputs[0].finish_reason
-        )
-        # Greedy spec decode may flip a near-tie argmax due to bf16 ULP
-        # differences between the base decode and Medusa verify kernels.
-        # Require a match up to the first divergence and that the divergence
-        # (if any) is genuine floating-point noise, not a regression.
+    base_llm = _build_base_llm()
+    try:
         assert_spec_matches_base_within_noise(
-            base_output.outputs[0], medusa_output.outputs[0]
+            base_llm, prompt_token_ids, spec_token_ids
         )
+    finally:
+        del base_llm
+        gc.collect()

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -23,6 +23,7 @@ from vllm import LLM, SamplingParams
 from .utils import (
     DEFAULT_MEDUSA_MODEL_ID,
     DEFAULT_MODEL_ID,
+    assert_spec_matches_base_within_noise,
     ensure_converted_medusa_adapter,
 )
 
@@ -72,6 +73,9 @@ def test_medusa_matches_base_generation() -> None:
         top_p=1.0,
         max_tokens=8,
         ignore_eos=True,
+        # Needed for the bf16 near-tie check in
+        # assert_spec_matches_base_within_noise.
+        logprobs=20,
     )
 
     base_llm = _build_base_llm()
@@ -92,5 +96,10 @@ def test_medusa_matches_base_generation() -> None:
             base_output.outputs[0].finish_reason
             == medusa_output.outputs[0].finish_reason
         )
-        assert base_output.outputs[0].text == medusa_output.outputs[0].text
-        assert base_output.outputs[0].token_ids == medusa_output.outputs[0].token_ids
+        # Greedy spec decode may flip a near-tie argmax due to bf16 ULP
+        # differences between the base decode and Medusa verify kernels.
+        # Require a match up to the first divergence and that the divergence
+        # (if any) is genuine floating-point noise, not a regression.
+        assert_spec_matches_base_within_noise(
+            base_output.outputs[0], medusa_output.outputs[0]
+        )

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import gc
 
+import pytest
 from vllm import LLM, SamplingParams
 
 from .utils import (
@@ -25,27 +26,29 @@ from .utils import (
     DEFAULT_MODEL_ID,
     assert_spec_matches_base_within_noise,
     ensure_converted_medusa_adapter,
+    make_batch_prompts,
 )
 
-PROMPTS = [
-    "The capital of France is",
-]
+# Batch sizes to exercise: batch=1 covers the single-sequence path, while
+# batch=8/16 exercises the wider verify-kernel shapes where bf16 rounding can
+# differ from the base path.
+BATCH_SIZES = [1, 8, 16]
 
 
-def _build_base_llm() -> LLM:
+def _build_base_llm(max_num_seqs: int) -> LLM:
     return LLM(
         model=DEFAULT_MODEL_ID,
         max_model_len=2048,
         block_size=1024,
         enable_chunked_prefill=True,
         max_num_batched_tokens=256,
-        max_num_seqs=1,
+        max_num_seqs=max_num_seqs,
         disable_log_stats=False,
         tensor_parallel_size=1,
     )
 
 
-def _build_medusa_llm() -> LLM:
+def _build_medusa_llm(max_num_seqs: int) -> LLM:
     medusa_model_id, num_speculative_tokens = ensure_converted_medusa_adapter(
         medusa_model_id=DEFAULT_MEDUSA_MODEL_ID,
         base_model_id=DEFAULT_MODEL_ID,
@@ -56,7 +59,7 @@ def _build_medusa_llm() -> LLM:
         block_size=1024,
         enable_chunked_prefill=True,
         max_num_batched_tokens=256,
-        max_num_seqs=1,
+        max_num_seqs=max_num_seqs,
         speculative_config={
             "method": "medusa",
             "model": medusa_model_id,
@@ -67,30 +70,35 @@ def _build_medusa_llm() -> LLM:
     )
 
 
-def test_medusa_matches_base_generation() -> None:
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+def test_medusa_matches_base_generation(batch_size: int) -> None:
     sampling_params = SamplingParams(
         temperature=0.0,
         top_p=1.0,
         max_tokens=8,
         ignore_eos=True,
     )
+    prompts = make_batch_prompts(batch_size)
 
     # Generate with Medusa speculative decoding first, then teacher-force the
     # resulting tokens through the base model and check, at every position,
     # that each spec token is the base model's greedy choice (up to bf16
     # near-tie flips). Only one engine is alive at a time to bound memory.
-    medusa_llm = _build_medusa_llm()
-    spec_req = medusa_llm.generate(PROMPTS, sampling_params=sampling_params)[0]
-    prompt_token_ids = list(spec_req.prompt_token_ids)
-    spec_token_ids = list(spec_req.outputs[0].token_ids)
+    medusa_llm = _build_medusa_llm(max_num_seqs=batch_size)
+    spec_reqs = medusa_llm.generate(prompts, sampling_params=sampling_params)
+    captured = [
+        (list(req.prompt_token_ids), list(req.outputs[0].token_ids))
+        for req in spec_reqs
+    ]
     del medusa_llm
     gc.collect()
 
-    base_llm = _build_base_llm()
+    base_llm = _build_base_llm(max_num_seqs=batch_size)
     try:
-        assert_spec_matches_base_within_noise(
-            base_llm, prompt_token_ids, spec_token_ids
-        )
+        for seq_idx, (prompt_token_ids, spec_token_ids) in enumerate(captured):
+            assert_spec_matches_base_within_noise(
+                base_llm, prompt_token_ids, spec_token_ids, seq_idx=seq_idx
+            )
     finally:
         del base_llm
         gc.collect()

--- a/tests/torch_compile/e2e/v1/spec_decode/utils.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/utils.py
@@ -47,6 +47,23 @@ def get_default_eagle_test_model_ids(method: str) -> tuple[str, str]:
         raise ValueError(f"Unsupported speculative method: {method}") from exc
 
 
+# A small pool of distinct, deterministic-completion prompts. Batches are built
+# by cycling this pool, so a batch of N exercises the verify kernel at batch
+# size N with varied sequences (not N identical requests).
+_BATCH_PROMPT_POOL = [
+    "The capital of France is",
+    "The largest planet in the solar system is",
+    "The chemical symbol for gold is",
+    "The first person to walk on the Moon was",
+]
+
+
+def make_batch_prompts(batch_size: int) -> list[str]:
+    """Build ``batch_size`` prompts by cycling the prompt pool."""
+    assert batch_size >= 1
+    return [_BATCH_PROMPT_POOL[i % len(_BATCH_PROMPT_POOL)] for i in range(batch_size)]
+
+
 # Greedy speculative decoding should reproduce, token for token, what the
 # target model would greedily generate on the SAME trajectory. It is truly
 # lossless only when the verify-path logits are bit-identical to the base
@@ -72,9 +89,14 @@ def get_default_eagle_test_model_ids(method: str) -> tuple[str, str]:
 #
 # Note: teacher forcing uses the base PREFILL kernel as reference, which itself
 # differs from the verify kernel by bf16 ULP, so the near-tie tolerance is
-# still required. 0.25 ~= 1-2 ULP at typical argmax magnitudes (~16-32, where a
-# bf16 ULP is 0.125); a real verify-path bug diverges by >=~1 nat.
-DEFAULT_MAX_LOGPROB_GAP = 0.25
+# still required. The bound is set from measured data: across all Medusa/Eagle
+# batch=1/8/16 runs the largest gap ever seen was exactly 0.125 (= 1 bf16 ULP
+# at argmax magnitudes ~[16,32)), and only in eagle3 — Medusa and eagle had
+# zero divergence. bf16 gaps are ULP-quantized, so any threshold strictly
+# between the observed 1 ULP (0.125) and the next step (0.25 = 2 ULP) behaves
+# identically; we use 0.2 to keep f32 jitter margin above 0.125 while staying
+# well under 0.25. A real verify-path bug diverges by >=~1 nat, far above this.
+DEFAULT_MAX_LOGPROB_GAP = 0.2
 
 
 def assert_spec_matches_base_within_noise(
@@ -84,10 +106,19 @@ def assert_spec_matches_base_within_noise(
     *,
     max_logprob_gap: float = DEFAULT_MAX_LOGPROB_GAP,
     logprobs: int = 20,
+    seq_idx: int | None = None,
 ) -> None:
     """Teacher-force the spec-decoded sequence through the non-speculative
     ``base_llm`` and assert every generated token is the base model's greedy
     choice, tolerating bf16 near-tie argmax flips.
+
+    A position passes when the spec token is the base argmax, or its logprob
+    gap from the argmax is ``<= max_logprob_gap`` (nats). The gap is taken
+    within the base distribution at a single position, where the shared
+    logsumexp cancels, so it equals the raw logit gap.
+
+    ``seq_idx`` is an optional label for the sequence within a batch, used only
+    to make failure messages identify which batched request diverged.
 
     Each position is teacher-forced independently: the spec trajectory prefix
     (``prompt_token_ids + spec_token_ids[:i]``) is fed back and the base model
@@ -122,14 +153,15 @@ def assert_spec_matches_base_within_noise(
             # spec token is outside the base top-k => far from argmax.
             offenders.append((i, tok, argmax_tok, float("inf")))
             continue
-        argmax_logprob = dist[argmax_tok].logprob
-        gap = argmax_logprob - dist[tok].logprob
+        gap = dist[argmax_tok].logprob - dist[tok].logprob
         if gap > max_logprob_gap:
             offenders.append((i, tok, argmax_tok, gap))
 
+    seq_label = "" if seq_idx is None else f"batch seq {seq_idx}: "
     assert not offenders, (
-        "Spec-decoded tokens diverge from the base model's greedy choice by "
-        f"more than {max_logprob_gap} logprob (not a bf16 near-tie):\n"
+        f"Spec-decoded tokens ({seq_label or 'single seq'}) diverge from the "
+        f"base model's greedy choice by more than {max_logprob_gap} logprob "
+        f"(not a bf16 near-tie):\n"
         + "\n".join(
             f"  pos {i}: spec={tok} base_argmax={am} gap={gap:.4f}"
             for i, tok, am, gap in offenders
@@ -374,4 +406,5 @@ __all__ = [
     "ensure_converted_medusa_adapter",
     "ensure_vllm_compatible_eagle_draft_model",
     "get_default_eagle_test_model_ids",
+    "make_batch_prompts",
 ]

--- a/tests/torch_compile/e2e/v1/spec_decode/utils.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/utils.py
@@ -47,83 +47,94 @@ def get_default_eagle_test_model_ids(method: str) -> tuple[str, str]:
         raise ValueError(f"Unsupported speculative method: {method}") from exc
 
 
-# Greedy speculative decoding is only token-for-token lossless when the target
-# model's verify-path logits are bit-identical to its base decode-path logits.
-# On RBLN the two paths run different compiled kernels (batch-shape-1 decode vs
-# batch-shape-N verify), and bf16 arithmetic is non-associative, so the same
-# logit can round to a value that differs by ~1 ULP between the two paths. At a
-# near-tie position that single ULP flips the argmax (e.g. "Paris." vs
-# "Paris,"), which then cascades into a completely different — but equally
-# valid — continuation. This is floating-point noise, not a quality
-# regression, so an exact text/token match is too strict. Instead we require
-# the streams to be identical up to the first divergence and that the first
-# divergence is a genuine near-tie in BOTH models' logprob distributions.
+# Greedy speculative decoding should reproduce, token for token, what the
+# target model would greedily generate on the SAME trajectory. It is truly
+# lossless only when the verify-path logits are bit-identical to the base
+# path's, but on RBLN the two run different compiled kernels (batch-shape-1
+# decode/prefill vs batch-shape-N verify) and bf16 arithmetic is
+# non-associative, so a logit can differ by ~1 ULP and flip the argmax at a
+# near-tie (e.g. "Paris." vs "Paris,"). That is floating-point noise, not a
+# quality regression, so an exact text/token match is too strict.
 #
-# logprob(t) = logit(t) - logsumexp(logits), so a logprob *gap* between two
-# tokens equals their raw logit gap. A bf16 ULP near typical LLM logit
-# magnitudes (~10-40) is 0.06-0.25, so a threshold of 0.5 accepts a few-ULP
-# flip while still rejecting a real divergence (where the chosen token wins by
-# a clear margin in at least one model).
-DEFAULT_MAX_LOGPROB_GAP = 0.5
+# To check this at EVERY position (not just up to the first divergence, which
+# is blind to anything after the cascade), we teacher-force the spec-generated
+# sequence back through the non-speculative base model: for each position we
+# feed the spec prefix and let the base model generate one token, exposing its
+# greedy choice and per-token logprobs there. We accept the spec token if it is
+# the base argmax OR within `max_logprob_gap` of it (a near-tie). A position
+# where the base model favours a different token by a clear margin is a real
+# divergence and fails. (We use generation logprobs rather than prompt_logprobs
+# because the latter is currently broken on RBLN.)
+#
+# The gap is taken WITHIN the base distribution at a single position, where the
+# shared logsumexp cancels, so logprob_gap == raw logit_gap. (We never subtract
+# logprobs across engines, whose logsumexp differ.)
+#
+# Note: teacher forcing uses the base PREFILL kernel as reference, which itself
+# differs from the verify kernel by bf16 ULP, so the near-tie tolerance is
+# still required. 0.25 ~= 1-2 ULP at typical argmax magnitudes (~16-32, where a
+# bf16 ULP is 0.125); a real verify-path bug diverges by >=~1 nat.
+DEFAULT_MAX_LOGPROB_GAP = 0.25
 
 
 def assert_spec_matches_base_within_noise(
-    base_output: Any,
-    spec_output: Any,
+    base_llm: Any,
+    prompt_token_ids: list[int],
+    spec_token_ids: list[int],
     *,
     max_logprob_gap: float = DEFAULT_MAX_LOGPROB_GAP,
+    logprobs: int = 20,
 ) -> None:
-    """Assert a speculative-decode generation matches the base greedy
-    generation, tolerating bf16 near-tie argmax flips.
+    """Teacher-force the spec-decoded sequence through the non-speculative
+    ``base_llm`` and assert every generated token is the base model's greedy
+    choice, tolerating bf16 near-tie argmax flips.
 
-    ``base_output`` / ``spec_output`` are ``CompletionOutput`` objects (i.e.
-    ``RequestOutput.outputs[i]``) produced with ``SamplingParams(logprobs=k)``
-    so that per-position logprobs are available for the near-tie check.
+    Each position is teacher-forced independently: the spec trajectory prefix
+    (``prompt_token_ids + spec_token_ids[:i]``) is fed back and the base model
+    generates one token, exposing its greedy choice and per-token logprobs at
+    that position. All prefixes are submitted in a single batched ``generate``
+    call (and share KV via prefix caching).
+
+    NOTE: we intentionally use the per-token generation logprobs path rather
+    than ``prompt_logprobs``; the latter is currently broken on RBLN
+    (``_get_prompt_logprobs_dict`` -> ``gather_logprobs`` shape mismatch).
     """
-    base_ids = list(base_output.token_ids)
-    spec_ids = list(spec_output.token_ids)
-    base_lps = base_output.logprobs
-    spec_lps = spec_output.logprobs
-    assert base_lps is not None and spec_lps is not None, (
-        "Per-token logprobs are required for the noise-level comparison. "
-        "Pass SamplingParams(logprobs=k) when generating."
+    from vllm import SamplingParams
+
+    prompt_token_ids = list(prompt_token_ids)
+    spec_token_ids = list(spec_token_ids)
+
+    prompts = [
+        {"prompt_token_ids": prompt_token_ids + spec_token_ids[:i]}
+        for i in range(len(spec_token_ids))
+    ]
+    base_outs = base_llm.generate(
+        prompts,
+        SamplingParams(max_tokens=1, temperature=0.0, logprobs=logprobs),
     )
 
-    for pos, (b, s) in enumerate(zip(base_ids, spec_ids)):
-        if b == s:
+    offenders = []
+    for i, (tok, out) in enumerate(zip(spec_token_ids, base_outs, strict=True)):
+        dist = out.outputs[0].logprobs[0]
+        assert dist is not None, f"no logprobs at spec position {i}"
+        argmax_tok = max(dist.items(), key=lambda kv: kv[1].logprob)[0]
+        if tok not in dist:
+            # spec token is outside the base top-k => far from argmax.
+            offenders.append((i, tok, argmax_tok, float("inf")))
             continue
+        argmax_logprob = dist[argmax_tok].logprob
+        gap = argmax_logprob - dist[tok].logprob
+        if gap > max_logprob_gap:
+            offenders.append((i, tok, argmax_tok, gap))
 
-        # First divergence. Accept it only if both tokens are near-tied in
-        # both distributions, which is the signature of a bf16 ULP flip.
-        b_dist = base_lps[pos]
-        s_dist = spec_lps[pos]
-        missing = []
-        if b not in b_dist or s not in b_dist:
-            missing.append("base")
-        if b not in s_dist or s not in s_dist:
-            missing.append("spec")
-        assert not missing, (
-            f"Streams diverge at position {pos} (base token={b}, "
-            f"spec token={s}), but the alternative token is outside the "
-            f"top-{len(b_dist)} logprobs of the {'/'.join(missing)} "
-            f"distribution. The divergence is therefore not a near-tie; "
-            f"either increase `logprobs` or treat this as a real regression."
+    assert not offenders, (
+        "Spec-decoded tokens diverge from the base model's greedy choice by "
+        f"more than {max_logprob_gap} logprob (not a bf16 near-tie):\n"
+        + "\n".join(
+            f"  pos {i}: spec={tok} base_argmax={am} gap={gap:.4f}"
+            for i, tok, am, gap in offenders
         )
-        gap_base = b_dist[b].logprob - b_dist[s].logprob
-        gap_spec = s_dist[s].logprob - s_dist[b].logprob
-        assert gap_base <= max_logprob_gap and gap_spec <= max_logprob_gap, (
-            f"Streams diverge at position {pos} (base token={b}, "
-            f"spec token={s}) and it is NOT a bf16 near-tie: logprob gap in "
-            f"base={gap_base:.4f}, in spec={gap_spec:.4f} "
-            f"(threshold={max_logprob_gap}). This indicates a real "
-            f"correctness regression in the speculative verify path, not "
-            f"floating-point noise."
-        )
-        # Past the first divergence the two runs condition on different
-        # tokens, so further token-by-token comparison is meaningless.
-        return
-
-    # No divergence: the streams are identical (the ideal lossless case).
+    )
 
 
 def _load_json(path: str | Path) -> dict[str, Any]:

--- a/tests/torch_compile/e2e/v1/spec_decode/utils.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/utils.py
@@ -47,6 +47,85 @@ def get_default_eagle_test_model_ids(method: str) -> tuple[str, str]:
         raise ValueError(f"Unsupported speculative method: {method}") from exc
 
 
+# Greedy speculative decoding is only token-for-token lossless when the target
+# model's verify-path logits are bit-identical to its base decode-path logits.
+# On RBLN the two paths run different compiled kernels (batch-shape-1 decode vs
+# batch-shape-N verify), and bf16 arithmetic is non-associative, so the same
+# logit can round to a value that differs by ~1 ULP between the two paths. At a
+# near-tie position that single ULP flips the argmax (e.g. "Paris." vs
+# "Paris,"), which then cascades into a completely different — but equally
+# valid — continuation. This is floating-point noise, not a quality
+# regression, so an exact text/token match is too strict. Instead we require
+# the streams to be identical up to the first divergence and that the first
+# divergence is a genuine near-tie in BOTH models' logprob distributions.
+#
+# logprob(t) = logit(t) - logsumexp(logits), so a logprob *gap* between two
+# tokens equals their raw logit gap. A bf16 ULP near typical LLM logit
+# magnitudes (~10-40) is 0.06-0.25, so a threshold of 0.5 accepts a few-ULP
+# flip while still rejecting a real divergence (where the chosen token wins by
+# a clear margin in at least one model).
+DEFAULT_MAX_LOGPROB_GAP = 0.5
+
+
+def assert_spec_matches_base_within_noise(
+    base_output: Any,
+    spec_output: Any,
+    *,
+    max_logprob_gap: float = DEFAULT_MAX_LOGPROB_GAP,
+) -> None:
+    """Assert a speculative-decode generation matches the base greedy
+    generation, tolerating bf16 near-tie argmax flips.
+
+    ``base_output`` / ``spec_output`` are ``CompletionOutput`` objects (i.e.
+    ``RequestOutput.outputs[i]``) produced with ``SamplingParams(logprobs=k)``
+    so that per-position logprobs are available for the near-tie check.
+    """
+    base_ids = list(base_output.token_ids)
+    spec_ids = list(spec_output.token_ids)
+    base_lps = base_output.logprobs
+    spec_lps = spec_output.logprobs
+    assert base_lps is not None and spec_lps is not None, (
+        "Per-token logprobs are required for the noise-level comparison. "
+        "Pass SamplingParams(logprobs=k) when generating."
+    )
+
+    for pos, (b, s) in enumerate(zip(base_ids, spec_ids)):
+        if b == s:
+            continue
+
+        # First divergence. Accept it only if both tokens are near-tied in
+        # both distributions, which is the signature of a bf16 ULP flip.
+        b_dist = base_lps[pos]
+        s_dist = spec_lps[pos]
+        missing = []
+        if b not in b_dist or s not in b_dist:
+            missing.append("base")
+        if b not in s_dist or s not in s_dist:
+            missing.append("spec")
+        assert not missing, (
+            f"Streams diverge at position {pos} (base token={b}, "
+            f"spec token={s}), but the alternative token is outside the "
+            f"top-{len(b_dist)} logprobs of the {'/'.join(missing)} "
+            f"distribution. The divergence is therefore not a near-tie; "
+            f"either increase `logprobs` or treat this as a real regression."
+        )
+        gap_base = b_dist[b].logprob - b_dist[s].logprob
+        gap_spec = s_dist[s].logprob - s_dist[b].logprob
+        assert gap_base <= max_logprob_gap and gap_spec <= max_logprob_gap, (
+            f"Streams diverge at position {pos} (base token={b}, "
+            f"spec token={s}) and it is NOT a bf16 near-tie: logprob gap in "
+            f"base={gap_base:.4f}, in spec={gap_spec:.4f} "
+            f"(threshold={max_logprob_gap}). This indicates a real "
+            f"correctness regression in the speculative verify path, not "
+            f"floating-point noise."
+        )
+        # Past the first divergence the two runs condition on different
+        # tokens, so further token-by-token comparison is meaningless.
+        return
+
+    # No divergence: the streams are identical (the ideal lossless case).
+
+
 def _load_json(path: str | Path) -> dict[str, Any]:
     with Path(path).open("r", encoding="utf-8") as f:
         return json.load(f)
@@ -277,8 +356,10 @@ def ensure_vllm_compatible_eagle_draft_model(
 
 __all__ = [
     "DEFAULT_EAGLE_TEST_MODEL_IDS",
+    "DEFAULT_MAX_LOGPROB_GAP",
     "DEFAULT_MEDUSA_MODEL_ID",
     "DEFAULT_MODEL_ID",
+    "assert_spec_matches_base_within_noise",
     "ensure_converted_medusa_adapter",
     "ensure_vllm_compatible_eagle_draft_model",
     "get_default_eagle_test_model_ids",


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

Replace the exact-match correctness test for speculative decoding with a
noise-aware, **every-position** check, and parametrize it over batch sizes
**1 / 8 / 16**.

Greedy spec decode can flip the argmax at a bf16 **near-tie**, producing a
different but equally valid continuation, so exact text/token equality is too
strict. We instead teacher-force the spec-generated tokens back through the
base model and verify, at every position, that each spec token is the base
model's greedy choice (or a near-tie within a small logprob gap).

---

## The Phenomenon

Prompt `The capital of France is` (greedy) diverges between base and spec
decoding one token after `" Paris"`:

* **Base:** `" Paris. The city is located in the"`
* **Spec:** `" Paris, and it is the most visited"`

Raw logits at the branch point:

| Token | Base (decode) | Spec (verify) |
| --- | --- | --- |
| `.` | **23.625** | 23.5 |
| `,` | 23.5 | 23.5 |
| others (top-k) | identical | identical |

Base picks `.` (23.625 > 23.5). In spec, `.` rounds down one step to 23.5, ties
with `,`, and the argmax tie-break (lower index) picks `,`.

## Root Cause: bf16 Rounding Noise (Not a Bug)

`Paris` is causal, so its logit should be identical in both paths. But base
(batch 1) and verify (batch N) run **different compiled kernels**, and bf16
addition is non-associative — a different accumulation order rounds the same
value to an adjacent bf16 grid point. At magnitude ~23 the bf16 step (ULP) is
exactly `0.125`, which is the observed shift. Only `.` moved (by 1 ULP) while
every other top-k logit stayed bit-identical — the fingerprint of rounding, not
a logic bug. 

This is not a quality regression: `.` and `,` are equally valid continuations.

---

## Verification: `assert_spec_matches_base_within_noise`

Exact match is too strict, and comparing only "up to the first divergence" is
blind to anything after the cascade. So:

1. Generate the sequence with spec decode.
2. **Teacher-force** it through the base model: for each position `i`, feed
   `prompt + spec[:i]` and read the base model's greedy choice + logprobs there
   (all prefixes in one batched `generate`). Base and spec are now aligned on
   the same trajectory at **every** position.
3. A position passes if the spec token is the base argmax, or its logprob gap
   from the argmax is **≤ 0.2** (a near-tie). Any larger gap fails as a real
   regression — reporting every offending position.

Notes:
* The gap is taken **within the base distribution** at one position, so the
  softmax `logsumexp` cancels and `logprob_gap == raw logit_gap`.
* Tolerance `0.2` is set from data: the largest gap observed across all
  Medusa/Eagle **batch 1/8/16** runs was `0.125` (= 1 bf16 ULP, eagle3 only;
  Medusa/eagle had zero divergence). `0.2` sits above 1 ULP and below the next
  step (`0.25`); a real bug diverges by ≥ ~1 nat.
* Teacher forcing uses the base **prefill** kernel (itself ~1 ULP off the verify
  kernel), so the tolerance is still required. We use generation logprobs
  because RBLN's `prompt_logprobs` path is currently broken (worth a separate
  fix).

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

### 🧪 How to Test

```
pytest -s -v tests/torch_compile/e2e/v1/spec_decode
```

Expected: 9 cases pass — `test_medusa_matches_base_generation[1/8/16]` and
`test_eagle_matches_base_generation[eagle-8 | eagle3-32][1/8/16]`.

### 📋 Checklist

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated

### 💬 Notes

RBLN `prompt_logprobs` is broken (surfaced while building this test); worked
around here, worth fixing separately.
