### PR TITLE
feature(perf): support metrics file output

### DIFF
--- a/tests/torch_compile/unit/test_rbln_envs.py
+++ b/tests/torch_compile/unit/test_rbln_envs.py
@@ -92,6 +92,11 @@ def test_rbln_envs():
         got {rbln_envs.VLLM_RBLN_METRICS}"
     )
 
+    assert rbln_envs.VLLM_RBLN_METRICS_FILE == "", (
+        f"Expected VLLM_RBLN_METRICS_FILE to be empty by default, \
+        got {rbln_envs.VLLM_RBLN_METRICS_FILE}"
+    )
+
     assert not rbln_envs.VLLM_RBLN_AUTO_PORT, (
         f"Expected VLLM_RBLN_AUTO_PORT to be False, \
         got {rbln_envs.VLLM_RBLN_AUTO_PORT}"

--- a/tests/torch_compile/unit/v1/worker/test_metrics.py
+++ b/tests/torch_compile/unit/v1/worker/test_metrics.py
@@ -12,10 +12,12 @@ Covers StepMetrics, PrefillMetricsByRequestID, and PerformanceTracker
 with focus on edge cases, statistical correctness, and error paths.
 """
 
+import os
 from unittest.mock import patch
 
 import pytest
 
+import vllm_rbln.v1.worker.metrics as metrics_module
 from vllm_rbln.v1.worker.metrics import (
     PerformanceTracker,
     PrefillMetricsByRequestID,
@@ -422,3 +424,44 @@ class TestPrintFinalStats:
         pt.record_decode(0.01, 1, padded_decode=True)
         # Should not raise
         pt.print_final_stats()
+
+
+class TestMetricsFileOutput:
+    """Verify VLLM_RBLN_METRICS_FILE mirrors the final report to a file."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_handler_state(self):
+        metrics_module._metrics_file_attached = False
+        original = list(metrics_module.logger.handlers)
+        yield
+        for handler in list(metrics_module.logger.handlers):
+            if handler not in original:
+                metrics_module.logger.removeHandler(handler)
+                handler.close()
+        metrics_module._metrics_file_attached = False
+
+    def test_no_file_when_env_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VLLM_RBLN_METRICS_FILE", raising=False)
+        pt = PerformanceTracker("MODEL")
+        pt.record_prefill(0.5, 100, request_ids=["req-1"])
+        pt.print_final_stats()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_writes_pid_suffixed_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VLLM_RBLN_METRICS_FILE", str(tmp_path / "metrics.log"))
+        pt = PerformanceTracker("MODEL")
+        pt.record_prefill(0.5, 100, request_ids=["req-1"])
+        pt.print_final_stats()
+        expected = tmp_path / f"metrics.{os.getpid()}.log"
+        assert expected.exists()
+        content = expected.read_text()
+        assert "FINAL PERFORMANCE STATISTICS [MODEL]" in content
+        assert "PREFILL METRICS" in content
+
+    def test_handler_attached_once(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VLLM_RBLN_METRICS_FILE", str(tmp_path / "metrics.log"))
+        before = len(metrics_module.logger.handlers)
+        pt = PerformanceTracker("MODEL")
+        pt.print_final_stats()
+        pt.print_final_stats()
+        assert len(metrics_module.logger.handlers) - before == 1

--- a/vllm_rbln/logger.py
+++ b/vllm_rbln/logger.py
@@ -155,6 +155,25 @@ def _configure_vllm_root_logger() -> None:
         dictConfig(logging_config)
 
 
+def make_file_handler(file_path: str) -> logging.FileHandler:
+    """Create a file handler using the same format as the stdout handler.
+
+    Args:
+        file_path: Destination path for the log file.
+
+    Returns:
+        A :class:`logging.FileHandler` whose output matches console output.
+
+    Example:
+        >>> logger.addHandler(make_file_handler("/tmp/metrics.log"))
+    """
+    from vllm.logging_utils import NewLineFormatter
+
+    handler = logging.FileHandler(file_path)
+    handler.setFormatter(NewLineFormatter(_FORMAT))
+    return handler
+
+
 def init_logger(name: str) -> _VllmLogger:
     """The main purpose of this function is to ensure that loggers are
     retrieved in such a way that we can be sure the root vllm logger has

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_LOGITS_ALL_GATHER: bool = True
     VLLM_RBLN_NUM_RAY_NODES: int = 1
     VLLM_RBLN_METRICS: bool = False
+    VLLM_RBLN_METRICS_FILE: str = ""
     VLLM_RBLN_NUMA: bool = True
     VLLM_RBLN_SORT_BATCH: bool = False
     VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY: str = "exponential"
@@ -225,6 +226,10 @@ environment_variables = {
     "VLLM_RBLN_METRICS": (
         lambda: os.environ.get("VLLM_RBLN_METRICS", "False").lower() in ("true", "1")
     ),
+    # Mirror the final performance report to this file (in addition to stdout).
+    # The worker pid is appended before the extension to keep TP/DP workers
+    # from clobbering each other. Empty disables file output.
+    "VLLM_RBLN_METRICS_FILE": lambda: os.environ.get("VLLM_RBLN_METRICS_FILE", ""),
     # Enable NUMA-based CPU affinity binding for OpenMP threads
     "VLLM_RBLN_NUMA": (
         lambda: os.environ.get("VLLM_RBLN_NUMA", "True").lower() in ("true", "1")

--- a/vllm_rbln/v1/worker/metrics.py
+++ b/vllm_rbln/v1/worker/metrics.py
@@ -12,15 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TypeVar
 
-from vllm_rbln.logger import init_logger
+import vllm_rbln.rbln_envs as envs
+from vllm_rbln.logger import init_logger, make_file_handler
 
 logger = init_logger(__name__)
 
 T = TypeVar("T", int, float)
+
+_metrics_file_attached = False
+
+
+def _attach_metrics_file_handler() -> None:
+    """Mirror metrics output to VLLM_RBLN_METRICS_FILE if configured.
+
+    The configured path is suffixed with the worker pid so concurrent workers
+    (TP/DP) write to separate files instead of clobbering one another. Runs at
+    most once; a failure to open the file is logged and stdout output is kept.
+    """
+    global _metrics_file_attached
+    if _metrics_file_attached or not envs.VLLM_RBLN_METRICS_FILE:
+        return
+    _metrics_file_attached = True
+    root, ext = os.path.splitext(envs.VLLM_RBLN_METRICS_FILE)
+    path = f"{root}.{os.getpid()}{ext}"
+    try:
+        logger.addHandler(make_file_handler(path))
+    except OSError as e:
+        logger.warning("Failed to open metrics file %s: %s", path, e)
 
 
 @dataclass
@@ -276,6 +299,7 @@ class PerformanceTracker:
         )
 
     def print_final_stats(self):
+        _attach_metrics_file_handler()
         logger.info("=" * 80)
         if self.name:
             logger.info("FINAL PERFORMANCE STATISTICS [%s]", self.name)

--- a/vllm_rbln/v1/worker/metrics.py
+++ b/vllm_rbln/v1/worker/metrics.py
@@ -43,6 +43,7 @@ def _attach_metrics_file_handler() -> None:
     try:
         logger.addHandler(make_file_handler(path))
     except OSError as e:
+        _metrics_file_attached = False
         logger.warning("Failed to open metrics file %s: %s", path, e)
 
 


### PR DESCRIPTION
### 🚀 Summary of Changes

> *What does this PR do? What feature, fix, or improvement does it bring?*

When VLLM_RBLN_METRICS=1, the profile result regarding prefill and decode are dumped into a file, whose name is given by VLLM_RBLN_METRICS_FILE.

---

### 📌 Related Issues / Tickets

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run the following after installing vllm-rbln with rebel-compiler.
```
VLLM_RBLN_METRICS=1 VLLM_RBLN_METRICS_FILE="aaa" RBLN_RUNTIME_TIMER=1 python3 ./examples/experimental/offline_inference_basic.py --max-num-seq 1 --max-model-len 4096 --block-size 4096 
```

2. Verify output: You can check that 'aaa.xxxxx' file is created and it contains prefill and decode performance.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
