### PR TITLE
fix(test): deterministic engine shutdown

### DIFF
--- a/tests/torch_compile/e2e/models/test_pooling_model_embed.py
+++ b/tests/torch_compile/e2e/models/test_pooling_model_embed.py
@@ -14,9 +14,8 @@
 
 import pytest
 import torch
-from vllm import LLM
 
-from ..utils import patch_and_run
+from ..utils import managed_llm
 
 LLM_PARAMS = [
     {
@@ -34,7 +33,17 @@ def get_detailed_instruct(task_description: str, query: str) -> str:
     return f"Instruct: {task_description}\nQuery:{query}"
 
 
-def run_vllm_score(llm_kwargs: dict) -> None:
+@pytest.mark.parametrize("llm_params", LLM_PARAMS)
+def test_pooling_model_embed(
+    monkeypatch: pytest.MonkeyPatch,
+    llm_params: dict,
+) -> None:
+    env = {
+        "VLLM_RBLN_USE_VLLM_MODEL": "1",
+        "VLLM_DISABLE_COMPILE_CACHE": "1",
+        "VLLM_RBLN_COMPILE_STRICT_MODE": "1",
+    }
+
     task = "Given a query, retrieve relevant passages that answer the query"
 
     queries = [
@@ -50,37 +59,18 @@ def run_vllm_score(llm_kwargs: dict) -> None:
     ]
     input_prompts = queries + documents
 
-    try:
-        llm = LLM(runner="pooling", **llm_kwargs)
-
+    with managed_llm(monkeypatch, env, runner="pooling", **llm_params) as llm:
         outputs = llm.embed(input_prompts)
-        embeddings = torch.tensor([o.outputs.embedding for o in outputs])
-        scores = embeddings[:2] @ embeddings[2:].T
+    embeddings = torch.tensor([o.outputs.embedding for o in outputs])
+    scores = embeddings[:2] @ embeddings[2:].T
 
-        assert scores[0][0] > scores[0][1], (
-            f'The score between the "{queries[0]}" and the "{documents[0]}" '
-            f'should be larger than the score between the "{queries[0]}" '
-            f'and the "{documents[1]}".'
-        )
-        assert scores[1][0] < scores[1][1], (
-            f'The score between the "{queries[1]}" and the "{documents[0]}" '
-            f'should be smaller than the score between the "{queries[1]}" '
-            f'and the "{documents[1]}".'
-        )
-
-    except Exception as e:
-        raise e
-
-
-@pytest.mark.parametrize("llm_params", LLM_PARAMS)
-def test_pooling_model_embed(
-    monkeypatch: pytest.MonkeyPatch,
-    llm_params: dict,
-) -> None:
-    env = {
-        "VLLM_RBLN_USE_VLLM_MODEL": "1",
-        "VLLM_DISABLE_COMPILE_CACHE": "1",
-        "VLLM_RBLN_COMPILE_STRICT_MODE": "1",
-    }
-
-    patch_and_run(monkeypatch, env, run_vllm_score, llm_kwargs=llm_params)
+    assert scores[0][0] > scores[0][1], (
+        f'The score between the "{queries[0]}" and the "{documents[0]}" '
+        f'should be larger than the score between the "{queries[0]}" '
+        f'and the "{documents[1]}".'
+    )
+    assert scores[1][0] < scores[1][1], (
+        f'The score between the "{queries[1]}" and the "{documents[0]}" '
+        f'should be smaller than the score between the "{queries[1]}" '
+        f'and the "{documents[1]}".'
+    )

--- a/tests/torch_compile/e2e/models/test_pooling_model_score.py
+++ b/tests/torch_compile/e2e/models/test_pooling_model_score.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import pytest
-from vllm import LLM
 
-from ..utils import patch_and_run
+from ..utils import managed_llm
 
 LLM_PARAMS = [
     {
@@ -34,7 +33,17 @@ LLM_PARAMS = [
 ]
 
 
-def run_vllm_score(llm_kwargs: dict) -> None:
+@pytest.mark.parametrize("llm_params", LLM_PARAMS)
+def test_pooling_model_score(
+    monkeypatch: pytest.MonkeyPatch,
+    llm_params: dict,
+) -> None:
+    env = {
+        "VLLM_RBLN_USE_VLLM_MODEL": "1",
+        "VLLM_DISABLE_COMPILE_CACHE": "1",
+        "VLLM_RBLN_COMPILE_STRICT_MODE": "1",
+    }
+
     prefix = (
         "<|im_start|>system\nJudge whether the Document meets the "
         + "requirements based on the Query and the Instruct provided. "
@@ -68,9 +77,8 @@ def run_vllm_score(llm_kwargs: dict) -> None:
         document_template.format(doc=doc, suffix=suffix) for doc in documents
     ]
 
-    llm = LLM(runner="pooling", **llm_kwargs)
-
-    outputs = llm.score(templated_queries, templated_documents)
+    with managed_llm(monkeypatch, env, runner="pooling", **llm_params) as llm:
+        outputs = llm.score(templated_queries, templated_documents)
 
     assert outputs[0].outputs.score > 0.8, (
         f"Score ({outputs[0].outputs.score}) should be large."
@@ -84,17 +92,3 @@ def run_vllm_score(llm_kwargs: dict) -> None:
         f"Score ({outputs[2].outputs.score}) should be large."
         f" <Query>: {queries[2]} <Document>: {documents[2]}."
     )
-
-
-@pytest.mark.parametrize("llm_params", LLM_PARAMS)
-def test_pooling_model_score(
-    monkeypatch: pytest.MonkeyPatch,
-    llm_params: dict,
-) -> None:
-    env = {
-        "VLLM_RBLN_USE_VLLM_MODEL": "1",
-        "VLLM_DISABLE_COMPILE_CACHE": "1",
-        "VLLM_RBLN_COMPILE_STRICT_MODE": "1",
-    }
-
-    patch_and_run(monkeypatch, env, run_vllm_score, llm_kwargs=llm_params)

--- a/tests/torch_compile/e2e/test_structured_output.py
+++ b/tests/torch_compile/e2e/test_structured_output.py
@@ -27,10 +27,10 @@ from enum import Enum
 import pytest
 from pydantic import BaseModel
 from transformers import GenerationConfig
-from vllm import LLM, SamplingParams
+from vllm import SamplingParams
 from vllm.sampling_params import StructuredOutputsParams
 
-from .utils import patch_and_run
+from .utils import managed_llm
 
 MODEL_ID = "Qwen/Qwen3-1.7B"
 
@@ -63,39 +63,45 @@ def sampling_kwargs(request: pytest.FixtureRequest) -> dict:
     }
 
 
-def _run_choice(sampling_kwargs: dict) -> None:
+def test_choice_sentiment_classification(
+    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
+) -> None:
     choices = ["Positive", "Negative"]
-    llm = LLM(**LLM_KWARGS)
-    outputs = llm.generate(
-        prompts="Classify this sentiment: vLLM is wonderful!",
-        sampling_params=SamplingParams(
-            **sampling_kwargs,
-            structured_outputs=StructuredOutputsParams(choice=choices),
-        ),
-    )
+    with managed_llm(monkeypatch, ENV, **LLM_KWARGS) as llm:
+        outputs = llm.generate(
+            prompts="Classify this sentiment: vLLM is wonderful!",
+            sampling_params=SamplingParams(
+                **sampling_kwargs,
+                structured_outputs=StructuredOutputsParams(choice=choices),
+            ),
+        )
     assert outputs[0].outputs[0].text in choices
 
 
-def _run_regex(sampling_kwargs: dict) -> None:
-    llm = LLM(**LLM_KWARGS)
-    outputs = llm.generate(
-        prompts=(
-            "Generate an example email address for Alan Turing, "
-            "who works in Enigma. End in .com and new line. "
-            "Example result: alan.turing@enigma.com\n"
-        ),
-        sampling_params=SamplingParams(
-            **sampling_kwargs,
-            structured_outputs=StructuredOutputsParams(regex=r"\w+@\w+\.com\n?"),
-        ),
-    )
+def test_regex_email_format(
+    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
+) -> None:
+    with managed_llm(monkeypatch, ENV, **LLM_KWARGS) as llm:
+        outputs = llm.generate(
+            prompts=(
+                "Generate an example email address for Alan Turing, "
+                "who works in Enigma. End in .com and new line. "
+                "Example result: alan.turing@enigma.com\n"
+            ),
+            sampling_params=SamplingParams(
+                **sampling_kwargs,
+                structured_outputs=StructuredOutputsParams(regex=r"\w+@\w+\.com\n?"),
+            ),
+        )
     text = outputs[0].outputs[0].text
     assert re.fullmatch(r"\w+@\w+\.com\n?", text), (
         f"Output does not match regex: {text!r}"
     )
 
 
-def _run_json(sampling_kwargs: dict) -> None:
+def test_json_car_description(
+    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
+) -> None:
     class CarType(str, Enum):
         sedan = "sedan"
         suv = "SUV"
@@ -107,20 +113,20 @@ def _run_json(sampling_kwargs: dict) -> None:
         model: str
         car_type: CarType
 
-    llm = LLM(**LLM_KWARGS)
-    outputs = llm.generate(
-        prompts=(
-            "Generate a JSON with the brand, model and car_type "
-            "of the most iconic car from the 90's"
-        ),
-        sampling_params=SamplingParams(
-            **sampling_kwargs,
-            max_tokens=32,
-            structured_outputs=StructuredOutputsParams(
-                json=CarDescription.model_json_schema()
+    with managed_llm(monkeypatch, ENV, **LLM_KWARGS) as llm:
+        outputs = llm.generate(
+            prompts=(
+                "Generate a JSON with the brand, model and car_type "
+                "of the most iconic car from the 90's"
             ),
-        ),
-    )
+            sampling_params=SamplingParams(
+                **sampling_kwargs,
+                max_tokens=32,
+                structured_outputs=StructuredOutputsParams(
+                    json=CarDescription.model_json_schema()
+                ),
+            ),
+        )
     text = outputs[0].outputs[0].text
     parsed = json.loads(text)
     car = CarDescription(**parsed)
@@ -129,7 +135,9 @@ def _run_json(sampling_kwargs: dict) -> None:
     assert car.car_type in CarType
 
 
-def _run_grammar(sampling_kwargs: dict) -> None:
+def test_grammar_sql_query(
+    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
+) -> None:
     simplified_sql_grammar = """
         root ::= select_statement
 
@@ -143,24 +151,28 @@ def _run_grammar(sampling_kwargs: dict) -> None:
 
         number ::= "1 " | "2 "
     """
-    llm = LLM(**LLM_KWARGS)
-    outputs = llm.generate(
-        prompts=(
-            "Generate a SQL query to show the 'username' and 'email' "
-            "from the 'users' table."
-        ),
-        sampling_params=SamplingParams(
-            **sampling_kwargs,
-            structured_outputs=StructuredOutputsParams(grammar=simplified_sql_grammar),
-        ),
-    )
+    with managed_llm(monkeypatch, ENV, **LLM_KWARGS) as llm:
+        outputs = llm.generate(
+            prompts=(
+                "Generate a SQL query to show the 'username' and 'email' "
+                "from the 'users' table."
+            ),
+            sampling_params=SamplingParams(
+                **sampling_kwargs,
+                structured_outputs=StructuredOutputsParams(
+                    grammar=simplified_sql_grammar
+                ),
+            ),
+        )
     text = outputs[0].outputs[0].text
     assert text.startswith("SELECT "), f"Expected SQL SELECT, got: {text!r}"
     assert " from " in text
     assert " where " in text
 
 
-def _run_structural_tag(sampling_kwargs: dict) -> None:
+def test_structural_tag_function_call(
+    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
+) -> None:
     structural_tag_obj = {
         "type": "structural_tag",
         "structures": [
@@ -198,16 +210,16 @@ Example:
 
 What is the weather in New York City?
 """
-    llm = LLM(**LLM_KWARGS)
-    outputs = llm.generate(
-        prompts=prompt,
-        sampling_params=SamplingParams(
-            **sampling_kwargs,
-            structured_outputs=StructuredOutputsParams(
-                structural_tag=json.dumps(structural_tag_obj)
+    with managed_llm(monkeypatch, ENV, **LLM_KWARGS) as llm:
+        outputs = llm.generate(
+            prompts=prompt,
+            sampling_params=SamplingParams(
+                **sampling_kwargs,
+                structured_outputs=StructuredOutputsParams(
+                    structural_tag=json.dumps(structural_tag_obj)
+                ),
             ),
-        ),
-    )
+        )
     text = outputs[0].outputs[0].text
 
     assert "<function=get_weather>" in text, (
@@ -219,33 +231,3 @@ What is the weather in New York City?
     assert match is not None, f"Could not extract function call from: {text!r}"
     params = json.loads(match.group(1))
     assert "city" in params
-
-
-def test_choice_sentiment_classification(
-    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
-) -> None:
-    patch_and_run(monkeypatch, ENV, _run_choice, sampling_kwargs)
-
-
-def test_regex_email_format(
-    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
-) -> None:
-    patch_and_run(monkeypatch, ENV, _run_regex, sampling_kwargs)
-
-
-def test_json_car_description(
-    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
-) -> None:
-    patch_and_run(monkeypatch, ENV, _run_json, sampling_kwargs)
-
-
-def test_grammar_sql_query(
-    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
-) -> None:
-    patch_and_run(monkeypatch, ENV, _run_grammar, sampling_kwargs)
-
-
-def test_structural_tag_function_call(
-    monkeypatch: pytest.MonkeyPatch, sampling_kwargs: dict
-) -> None:
-    patch_and_run(monkeypatch, ENV, _run_structural_tag, sampling_kwargs)

--- a/tests/torch_compile/e2e/utils.py
+++ b/tests/torch_compile/e2e/utils.py
@@ -12,32 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import multiprocessing
-from collections.abc import Callable
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
+from vllm import LLM
 
 
-def patch_and_run(
+@contextmanager
+def managed_llm(
     monkeypatch: pytest.MonkeyPatch,
-    env: dict,
-    target_func: Callable,
-    *target_func_args: Any,
-    **target_func_kwargs: dict[str, Any],
-):
-    with monkeypatch.context() as m:
-        for k, i in env.items():
-            m.setenv(k, i)
+    env: dict | None = None,
+    **llm_kwargs: Any,
+) -> Iterator[LLM]:
+    """Set env vars, build an ``LLM``, and deterministically free it on exit.
 
-        # rebellions SDK somewhat requires LLM instance to be
-        # instantiated in separated process
-        p = multiprocessing.Process(
-            target=target_func,
-            args=target_func_args,
-            kwargs=target_func_kwargs,
-        )
-        p.start()
-        p.join()
+    vLLM tears its EngineCore subprocess down only through a GC-lazy
+    ``weakref.finalize``. Relying on that both leaks device memory across tests
+    until GC happens to run (cross-test OOM) and can block the process at
+    interpreter exit (CI hang). Calling the explicit, bounded shutdown
+    (``terminate -> join(5s) -> SIGKILL``) kills EngineCore immediately, so the
+    kernel driver reclaims the device before the next test builds its engine.
 
-        assert not p.exitcode, f"Process exited with code {p.exitcode}"
+    ``monkeypatch`` is the test's fixture; the env vars are reverted at test
+    teardown. ``env`` may be omitted when the env is set elsewhere (e.g. a
+    module-scoped fixture); the deterministic teardown still applies.
+    """
+    for key, value in (env or {}).items():
+        monkeypatch.setenv(key, value)
+    llm = LLM(**llm_kwargs)
+    try:
+        yield llm
+    finally:
+        llm.llm_engine.engine_core.shutdown()

--- a/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_eagle_correctness.py
@@ -16,11 +16,10 @@
 
 from __future__ import annotations
 
-import gc
-
 import pytest
-from vllm import LLM, SamplingParams
+from vllm import SamplingParams
 
+from ...utils import managed_llm
 from .utils import (
     assert_spec_matches_base_within_noise,
     ensure_vllm_compatible_eagle_draft_model,
@@ -36,41 +35,41 @@ NUM_SPECULATIVE_TOKENS = 3
 BATCH_SIZES = [1, 8, 16]
 
 
-def _build_base_llm(method: str, max_num_seqs: int) -> LLM:
+def _base_llm_kwargs(method: str, max_num_seqs: int) -> dict:
     base_model_id, _ = get_default_eagle_test_model_ids(method)
-    return LLM(
-        model=base_model_id,
-        max_model_len=2048,
-        block_size=1024,
-        enable_chunked_prefill=True,
-        max_num_batched_tokens=256,
-        max_num_seqs=max_num_seqs,
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-    )
+    return {
+        "model": base_model_id,
+        "max_model_len": 2048,
+        "block_size": 1024,
+        "enable_chunked_prefill": True,
+        "max_num_batched_tokens": 256,
+        "max_num_seqs": max_num_seqs,
+        "disable_log_stats": False,
+        "tensor_parallel_size": 1,
+    }
 
 
-def _build_eagle_llm(method: str, max_num_seqs: int) -> LLM:
+def _eagle_llm_kwargs(method: str, max_num_seqs: int) -> dict:
     base_model_id, draft_model_id = get_default_eagle_test_model_ids(method)
     draft_model_id = ensure_vllm_compatible_eagle_draft_model(
         eagle_model_id=draft_model_id,
         base_model_id=base_model_id,
     )
-    return LLM(
-        model=base_model_id,
-        max_model_len=2048,
-        block_size=1024,
-        enable_chunked_prefill=True,
-        max_num_batched_tokens=256,
-        max_num_seqs=max_num_seqs,
-        speculative_config={
+    return {
+        "model": base_model_id,
+        "max_model_len": 2048,
+        "block_size": 1024,
+        "enable_chunked_prefill": True,
+        "max_num_batched_tokens": 256,
+        "max_num_seqs": max_num_seqs,
+        "speculative_config": {
             "method": method,
             "model": draft_model_id,
             "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
         },
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-    )
+        "disable_log_stats": False,
+        "tensor_parallel_size": 1,
+    }
 
 
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
@@ -79,7 +78,7 @@ def _build_eagle_llm(method: str, max_num_seqs: int) -> LLM:
     [("eagle", 8), ("eagle3", 32)],
 )
 def test_eagle_matches_base_generation(
-    method: str, max_tokens: int, batch_size: int
+    monkeypatch: pytest.MonkeyPatch, method: str, max_tokens: int, batch_size: int
 ) -> None:
     sampling_params = SamplingParams(
         temperature=0.0,
@@ -92,22 +91,22 @@ def test_eagle_matches_base_generation(
     # Generate with EAGLE speculative decoding first, then teacher-force the
     # resulting tokens through the base model and check, at every position,
     # that each spec token is the base model's greedy choice (up to bf16
-    # near-tie flips). Only one engine is alive at a time to bound memory.
-    eagle_llm = _build_eagle_llm(method, max_num_seqs=batch_size)
-    spec_reqs = eagle_llm.generate(prompts, sampling_params=sampling_params)
-    captured = [
-        (list(req.prompt_token_ids), list(req.outputs[0].token_ids))
-        for req in spec_reqs
-    ]
-    del eagle_llm
-    gc.collect()
+    # near-tie flips). Only one engine is alive at a time to bound memory:
+    # managed_llm shuts the eagle engine down deterministically before the base
+    # engine is built.
+    with managed_llm(
+        monkeypatch, **_eagle_llm_kwargs(method, max_num_seqs=batch_size)
+    ) as eagle_llm:
+        spec_reqs = eagle_llm.generate(prompts, sampling_params=sampling_params)
+        captured = [
+            (list(req.prompt_token_ids), list(req.outputs[0].token_ids))
+            for req in spec_reqs
+        ]
 
-    base_llm = _build_base_llm(method, max_num_seqs=batch_size)
-    try:
+    with managed_llm(
+        monkeypatch, **_base_llm_kwargs(method, max_num_seqs=batch_size)
+    ) as base_llm:
         for seq_idx, (prompt_token_ids, spec_token_ids) in enumerate(captured):
             assert_spec_matches_base_within_noise(
                 base_llm, prompt_token_ids, spec_token_ids, seq_idx=seq_idx
             )
-    finally:
-        del base_llm
-        gc.collect()

--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -16,11 +16,10 @@
 
 from __future__ import annotations
 
-import gc
-
 import pytest
-from vllm import LLM, SamplingParams
+from vllm import SamplingParams
 
+from ...utils import managed_llm
 from .utils import (
     DEFAULT_MEDUSA_MODEL_ID,
     DEFAULT_MODEL_ID,
@@ -35,43 +34,45 @@ from .utils import (
 BATCH_SIZES = [1, 8, 16]
 
 
-def _build_base_llm(max_num_seqs: int) -> LLM:
-    return LLM(
-        model=DEFAULT_MODEL_ID,
-        max_model_len=2048,
-        block_size=1024,
-        enable_chunked_prefill=True,
-        max_num_batched_tokens=256,
-        max_num_seqs=max_num_seqs,
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-    )
+def _base_llm_kwargs(max_num_seqs: int) -> dict:
+    return {
+        "model": DEFAULT_MODEL_ID,
+        "max_model_len": 2048,
+        "block_size": 1024,
+        "enable_chunked_prefill": True,
+        "max_num_batched_tokens": 256,
+        "max_num_seqs": max_num_seqs,
+        "disable_log_stats": False,
+        "tensor_parallel_size": 1,
+    }
 
 
-def _build_medusa_llm(max_num_seqs: int) -> LLM:
+def _medusa_llm_kwargs(max_num_seqs: int) -> dict:
     medusa_model_id, num_speculative_tokens = ensure_converted_medusa_adapter(
         medusa_model_id=DEFAULT_MEDUSA_MODEL_ID,
         base_model_id=DEFAULT_MODEL_ID,
     )
-    return LLM(
-        model=DEFAULT_MODEL_ID,
-        max_model_len=2048,
-        block_size=1024,
-        enable_chunked_prefill=True,
-        max_num_batched_tokens=256,
-        max_num_seqs=max_num_seqs,
-        speculative_config={
+    return {
+        "model": DEFAULT_MODEL_ID,
+        "max_model_len": 2048,
+        "block_size": 1024,
+        "enable_chunked_prefill": True,
+        "max_num_batched_tokens": 256,
+        "max_num_seqs": max_num_seqs,
+        "speculative_config": {
             "method": "medusa",
             "model": medusa_model_id,
             "num_speculative_tokens": num_speculative_tokens,
         },
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-    )
+        "disable_log_stats": False,
+        "tensor_parallel_size": 1,
+    }
 
 
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
-def test_medusa_matches_base_generation(batch_size: int) -> None:
+def test_medusa_matches_base_generation(
+    monkeypatch: pytest.MonkeyPatch, batch_size: int
+) -> None:
     sampling_params = SamplingParams(
         temperature=0.0,
         top_p=1.0,
@@ -83,22 +84,22 @@ def test_medusa_matches_base_generation(batch_size: int) -> None:
     # Generate with Medusa speculative decoding first, then teacher-force the
     # resulting tokens through the base model and check, at every position,
     # that each spec token is the base model's greedy choice (up to bf16
-    # near-tie flips). Only one engine is alive at a time to bound memory.
-    medusa_llm = _build_medusa_llm(max_num_seqs=batch_size)
-    spec_reqs = medusa_llm.generate(prompts, sampling_params=sampling_params)
-    captured = [
-        (list(req.prompt_token_ids), list(req.outputs[0].token_ids))
-        for req in spec_reqs
-    ]
-    del medusa_llm
-    gc.collect()
+    # near-tie flips). Only one engine is alive at a time to bound memory:
+    # managed_llm shuts the medusa engine down deterministically before the
+    # base engine is built.
+    with managed_llm(
+        monkeypatch, **_medusa_llm_kwargs(max_num_seqs=batch_size)
+    ) as medusa_llm:
+        spec_reqs = medusa_llm.generate(prompts, sampling_params=sampling_params)
+        captured = [
+            (list(req.prompt_token_ids), list(req.outputs[0].token_ids))
+            for req in spec_reqs
+        ]
 
-    base_llm = _build_base_llm(max_num_seqs=batch_size)
-    try:
+    with managed_llm(
+        monkeypatch, **_base_llm_kwargs(max_num_seqs=batch_size)
+    ) as base_llm:
         for seq_idx, (prompt_token_ids, spec_token_ids) in enumerate(captured):
             assert_spec_matches_base_within_noise(
                 base_llm, prompt_token_ids, spec_token_ids, seq_idx=seq_idx
             )
-    finally:
-        del base_llm
-        gc.collect()

--- a/tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
@@ -18,11 +18,11 @@ import random
 from dataclasses import asdict
 
 import pytest
-from vllm import LLM, EngineArgs, SamplingParams
+from vllm import EngineArgs, SamplingParams
 from vllm.inputs import TokensPrompt
 from vllm.v1.metrics.reader import Counter, Metric
 
-from ..utils import patch_and_run
+from ..utils import managed_llm
 
 _RNG = random.Random(0)
 PREFIX = _RNG.sample(range(2000, 100000), 1600)
@@ -40,7 +40,7 @@ def _get_counter(metrics: list[Metric], name: str) -> int:
     return sum(m.value for m in metrics if isinstance(m, Counter) and m.name == name)
 
 
-def _build_llm(*, enable_prefix_caching: bool) -> LLM:
+def _llm_kwargs(*, enable_prefix_caching: bool) -> dict:
     args = EngineArgs(
         model="Qwen/Qwen3-0.6B",
         max_num_seqs=1,
@@ -48,41 +48,20 @@ def _build_llm(*, enable_prefix_caching: bool) -> LLM:
         enable_chunked_prefill=True,
         max_num_batched_tokens=128,
         enable_prefix_caching=enable_prefix_caching,
-        # Use small number of blocks so that two instances can coexist without OOM.
-        # We do this because `del llm` does not realiably clean up device memory.
+        # Small KV budget keeps each engine cheap. The shared 1600-token prefix
+        # still spans more than one BLOCK_SIZE block, which is what the hit-count
+        # assertion below exercises.
         num_gpu_blocks_override=8,
         seed=0,
     )
     # block_size is validated in the EngineArgs ctor; assign post-hoc to bypass.
-    args.block_size = BLOCK_SIZE  # type: ignore[assignment]
-    return LLM(**asdict(args))
+    kwargs = asdict(args)
+    kwargs["block_size"] = BLOCK_SIZE
+    return kwargs
 
 
 def _generated_token_ids(outputs) -> list[list[int]]:
     return [list(o.outputs[0].token_ids) for o in outputs]
-
-
-def _run() -> None:
-    # Baseline
-    baseline = _build_llm(enable_prefix_caching=False)
-    baseline_tokens = _generated_token_ids(baseline.generate(PROMPTS, SAMPLING_PARAMS))
-
-    # Prefix-cached
-    cached = _build_llm(enable_prefix_caching=True)
-    # Warm up prefix cache
-    cached.generate(PROMPTS[0], SAMPLING_PARAMS)
-
-    hits_before = _get_counter(cached.get_metrics(), "vllm:prefix_cache_hits")
-    outputs = cached.generate(PROMPTS, SAMPLING_PARAMS)
-    hits_after = _get_counter(cached.get_metrics(), "vllm:prefix_cache_hits")
-    cached_tokens = _generated_token_ids(outputs)
-
-    # Shared prefix is 1600 tokens (block_size=1024 + 576 trailing). Without
-    # sub-block caching each prompt would hit at most one full block, capping
-    # the total at len(PROMPTS) * BLOCK_SIZE. Sub-block caching extends the hit.
-    hits = hits_after - hits_before
-    assert hits > len(PROMPTS) * BLOCK_SIZE
-    assert cached_tokens == baseline_tokens
 
 
 # TODO: re-enable True once the device tensor path is stable
@@ -91,4 +70,29 @@ def test_sub_block_prefix_cache_matches_baseline(
     monkeypatch: pytest.MonkeyPatch, use_device_tensor: bool
 ) -> None:
     env = {"VLLM_RBLN_USE_DEVICE_TENSOR": "1" if use_device_tensor else "0"}
-    patch_and_run(monkeypatch, env, _run)
+
+    # Each engine is shut down before the next is built, so they never coexist.
+    with managed_llm(
+        monkeypatch, env, **_llm_kwargs(enable_prefix_caching=False)
+    ) as baseline:
+        baseline_tokens = _generated_token_ids(
+            baseline.generate(PROMPTS, SAMPLING_PARAMS)
+        )
+
+    with managed_llm(
+        monkeypatch, env, **_llm_kwargs(enable_prefix_caching=True)
+    ) as cached:
+        # Warm up prefix cache
+        cached.generate(PROMPTS[0], SAMPLING_PARAMS)
+
+        hits_before = _get_counter(cached.get_metrics(), "vllm:prefix_cache_hits")
+        outputs = cached.generate(PROMPTS, SAMPLING_PARAMS)
+        hits_after = _get_counter(cached.get_metrics(), "vllm:prefix_cache_hits")
+        cached_tokens = _generated_token_ids(outputs)
+
+    # Shared prefix is 1600 tokens (block_size=1024 + 576 trailing). Without
+    # sub-block caching each prompt would hit at most one full block, capping
+    # the total at len(PROMPTS) * BLOCK_SIZE. Sub-block caching extends the hit.
+    hits = hits_after - hits_before
+    assert hits > len(PROMPTS) * BLOCK_SIZE
+    assert cached_tokens == baseline_tokens


### PR DESCRIPTION
### 🚀 Summary of Changes

Problem:
patch_and_run ran each LLM-using e2e test in a multiprocessing.Process and joined it untimed, to dodge vLLM's GC-lazy EngineCore teardown (the cross-test OOM). But the isolation subprocess itself blocks indefinitely in post-body / process-exit teardown:
* EngineCore is a non-daemon child
* vLLM's weakref.finalize may have not terminated it yet.
* multiprocessing's atexit handler join()s it with no timeout

Solution:
Own the EngineCore lifecycle instead of leaning on GC. Add managed_llm(), a context manager that builds the LLM and on exit calls vLLM's explicit, bounded
shutdown (llm.llm_engine.engine_core.shutdown(): terminate -> join(5s) ->
SIGKILL), reclaiming the device deterministically. Drop patch_and_run and the subprocess machinery; the affected tests (structured_output, the two pooling tests, sub_block) now build in-process via managed_llm.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves https://github.com/rebellions-sw/vllm-rbln-internal/issues/110

