### PR TITLE
fix: pass hf_config to optimum compilation

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -222,7 +222,7 @@ class RBLNOptimumModelBase(nn.Module):
                 json.dumps(spec.rbln_config, indent=2, default=str),
             )
             model = spec.model_cls.from_pretrained(
-                self.model_config.model, rbln_config=spec.rbln_config
+                self.model_config.model, rbln_config=spec.rbln_config, config=hf_config
             )
             model.save_pretrained(cached_model_path)  # type: ignore[attr-defined]
             self.vllm_config.model_config.model = cached_model_path


### PR DESCRIPTION
## Summary
Pass the resolved HF `config` to `from_pretrained` during optimum model compilation so the model is built with the correct HF config instead of relying on the default loaded from the model path.

## Changes
- `vllm_rbln/model_executor/models/optimum/model_base.py`: forward `config=hf_config` to `spec.model_cls.from_pretrained(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)