### PR TITLE
fix(attn): normalize seq_lens to int32 so custom kernel compiles

### DIFF
--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -1129,6 +1129,9 @@ class RBLNFlashAttentionMetadataBuilder(
             num_computed_tokens = seq_lens - query_seq_lens
             seq_idx = positions[query_start_loc[:num_reqs]].view(-1, 1)
 
+        # custom (triton) kernel's to_dynamic_index rejects int64 seq_lens
+        seq_idx = seq_idx.to(torch.int32)
+
         cu_prefix_query_lens = None
         prefix_kv_lens = None
         suffix_kv_lens = None


### PR DESCRIPTION


<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

PR #616 removed the in-graph dtype casts on attention custom op args. Since `positions` are int64, `seq_idx` (and the `seq_lens_tensor` / `dyn_size_for_partitions` derived from it) became int64. With RBLN_USE_CUSTOM_KERNEL=1 attention lowers `seq_lens` through the triton kernels' `rtosa.to_dynamic_index`, which rejects int64 operands and fails compilation:
```
  flash_causal_attention.py: 'rtosa.to_dynamic_index' op operand #0 must be
  ... 32-bit signless integer ... but got 'tensor<1x4xi64>'
```
`block_tables` is natively int32 so it passed; only the int64 `seq_lens` broke, and only on the custom-kernel path (rbln_custom_ops accepts int64).

Normalize `seq_idx` to int32 in the metadata builder. This runs eagerly during metadata construction, so the dtype is correct before the tensors enter the compiled graph -- honoring #616's "no in-graph casts" intent while giving the triton kernels a valid dtype. int32 covers the full position range (unlike the original int16, which overflows at max_model_len >= 32768).

Verified on NPU: both RBLN_USE_CUSTOM_KERNEL=0 and =1 compile and generate correctly with identical output.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
