### PR TITLE
fix(cache): include toolchain versions in optimum compiled model cache key

### DIFF
--- a/tests/optimum_compile/converter/test_dispatch.py
+++ b/tests/optimum_compile/converter/test_dispatch.py
@@ -1,0 +1,133 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from importlib.metadata import PackageNotFoundError
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_rbln.utils.optimum.converter import dispatch
+from vllm_rbln.utils.optimum.converter.dispatch import (
+    _generate_model_path_name,
+    _toolchain_versions,
+)
+
+
+def _make_vllm_config(
+    model="meta-llama/Llama-3-8B",
+    max_num_seqs=4,
+    block_size=128,
+    max_model_len=8192,
+    rbln_config=None,
+):
+    """Build a minimal stand-in for ``VllmConfig``.
+
+    Only the attributes touched by ``_generate_model_path_name`` are
+    populated.
+    """
+    additional_config = {}
+    if rbln_config is not None:
+        additional_config["rbln_config"] = rbln_config
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model=model, max_model_len=max_model_len),
+        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
+        cache_config=SimpleNamespace(block_size=block_size),
+        additional_config=additional_config,
+    )
+
+
+class TestToolchainVersions:
+    def test_resolves_both_packages(self, monkeypatch):
+        monkeypatch.setattr(
+            dispatch,
+            "version",
+            lambda pkg: {
+                "rebel-compiler": "1.2.3",
+                "optimum-rbln": "4.5.6",
+            }[pkg],
+        )
+        assert _toolchain_versions() == {
+            "rebel-compiler": "1.2.3",
+            "optimum-rbln": "4.5.6",
+        }
+
+    def test_missing_package_falls_back_to_unknown(self, monkeypatch):
+        def fake_version(pkg):
+            if pkg == "optimum-rbln":
+                raise PackageNotFoundError(pkg)
+            return "1.2.3"
+
+        monkeypatch.setattr(dispatch, "version", fake_version)
+        versions = _toolchain_versions()
+        assert versions["rebel-compiler"] == "1.2.3"
+        assert versions["optimum-rbln"] == "unknown"
+
+    def test_keys_cover_all_toolchain_packages(self, monkeypatch):
+        monkeypatch.setattr(dispatch, "version", lambda pkg: "0.0.0")
+        versions = _toolchain_versions()
+        assert set(versions) == set(dispatch._TOOLCHAIN_PACKAGES)
+
+
+class TestGenerateModelPathName:
+    def test_deterministic_for_same_inputs(self, monkeypatch):
+        monkeypatch.setattr(dispatch.envs, "VLLM_RBLN_TP_SIZE", 1)
+        monkeypatch.setattr(
+            dispatch, "_toolchain_versions", lambda: {"rebel-compiler": "1.0"}
+        )
+        first = _generate_model_path_name(_make_vllm_config())
+        second = _generate_model_path_name(_make_vllm_config())
+        assert first == second
+
+    def test_toolchain_version_change_changes_hash(self, monkeypatch):
+        monkeypatch.setattr(dispatch.envs, "VLLM_RBLN_TP_SIZE", 1)
+
+        monkeypatch.setattr(
+            dispatch, "_toolchain_versions", lambda: {"rebel-compiler": "1.0"}
+        )
+        old = _generate_model_path_name(_make_vllm_config())
+
+        monkeypatch.setattr(
+            dispatch, "_toolchain_versions", lambda: {"rebel-compiler": "2.0"}
+        )
+        new = _generate_model_path_name(_make_vllm_config())
+
+        assert old != new
+
+    def test_user_param_change_changes_hash(self, monkeypatch):
+        monkeypatch.setattr(dispatch.envs, "VLLM_RBLN_TP_SIZE", 1)
+        monkeypatch.setattr(dispatch, "_toolchain_versions", lambda: {})
+        base = _generate_model_path_name(_make_vllm_config(max_num_seqs=4))
+        bumped = _generate_model_path_name(_make_vllm_config(max_num_seqs=8))
+        assert base != bumped
+
+    def test_runtime_only_keys_do_not_affect_hash(self, monkeypatch):
+        monkeypatch.setattr(dispatch.envs, "VLLM_RBLN_TP_SIZE", 1)
+        monkeypatch.setattr(dispatch, "_toolchain_versions", lambda: {})
+        without = _generate_model_path_name(
+            _make_vllm_config(rbln_config={"tensor_parallel_size": 4})
+        )
+        # Adding only runtime-only keys must not change the compiled-artifact
+        # cache key.
+        with_runtime = _generate_model_path_name(
+            _make_vllm_config(
+                rbln_config={
+                    "tensor_parallel_size": 4,
+                    "create_runtimes": True,
+                    "device": [0, 1],
+                    "kvcache_num_blocks": 1024,
+                }
+            )
+        )
+        assert without == with_runtime

--- a/vllm_rbln/utils/optimum/converter/dispatch.py
+++ b/vllm_rbln/utils/optimum/converter/dispatch.py
@@ -15,6 +15,7 @@
 import hashlib
 import json
 import os
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
 import vllm_rbln.rbln_envs as envs
@@ -53,6 +54,31 @@ def _strip_runtime_only_keys(obj: dict) -> dict:
     return obj
 
 
+# Packages whose version changes the compiled binary, so a version bump must
+# invalidate the cache to avoid loading an artifact built by a different
+# toolchain.
+_TOOLCHAIN_PACKAGES: tuple[str, ...] = ("rebel-compiler", "optimum-rbln")
+
+
+def _toolchain_versions() -> dict[str, str]:
+    """Resolve installed versions of the compile-time toolchain packages.
+
+    A missing package maps to ``"unknown"`` so hashing stays deterministic
+    instead of raising when a package can't be located.
+    """
+    versions: dict[str, str] = {}
+    for pkg in _TOOLCHAIN_PACKAGES:
+        try:
+            versions[pkg] = version(pkg)
+        except PackageNotFoundError:
+            logger.warning(
+                "Could not resolve version of %s for cache key; using 'unknown'.",
+                pkg,
+            )
+            versions[pkg] = "unknown"
+    return versions
+
+
 def _generate_model_path_name(
     vllm_config: VllmConfig,
 ) -> str:
@@ -64,14 +90,16 @@ def _generate_model_path_name(
     tp_size = envs.VLLM_RBLN_TP_SIZE
     additional_config = vllm_config.additional_config.get("rbln_config", None)
 
-    # FIXME: To avoid cache collisions, the cache key should also include
-    # the versions of the compiler and optimum-rbln.
+    # The compiled binary depends on the toolchain that produced it, so the
+    # toolchain versions are part of the cache key to avoid collisions across
+    # compiler / optimum-rbln upgrades.
     config_dict = {
         "model_name": model_name,
         "batch_size": batch_size,
         "block_size": block_size,
         "max_model_len": max_model_len,
         "tp_size": tp_size,
+        "toolchain_versions": _toolchain_versions(),
     }
     if additional_config:
         config_dict["rbln_config"] = _strip_runtime_only_keys(additional_config)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

`_generate_model_path_name` computes the cache key (directory name under compiled_models/) for a compiled model. Until now it hashed only user-provided parameters (model, batch size, block size, max len, TP size, rbln_config), but not the versions of the toolchain that actually produces the binary.

This meant that after upgrading `rebel-compiler` or `optimum-rbln`, the same key could resolve to a stale cache entry compiled by a different toolchain — a silent cache collision. This was already flagged by a FIXME in the code.

This PR folds the installed `rebel-compiler` / `optimum-rbln` versions into the hash, so a toolchain upgrade naturally invalidates the cache and triggers a recompile.


---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
