### PR TITLE
refactor: drop RBLN_FORCE_CCL_ASYNC (async is now the runtime default)

### DIFF
--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -210,16 +210,9 @@ class RblnPlatform(Platform):
                     "(TP, DP, EP, or PP)."
                 )
             os.environ["RBLN_CTX_STANDALONE"] = "1"
-            ccl_async_mode = os.environ.get("RBLN_FORCE_CCL_ASYNC")
-            # NOTE If users don't set RBLN_FORCE_CCL_ASYNC, we will set it to 1
-            # to enable async mode by default for better performance.
-            # However, if users explicitly set RBLN_FORCE_CCL_ASYNC to 0,
-            # we will respect their choice but print a warning message.
-            if ccl_async_mode is None:
-                os.environ["RBLN_FORCE_CCL_ASYNC"] = "1"
-            elif ccl_async_mode == "0":
+            if os.environ.get("RBLN_RUNTIME_FORCE_SYNC") == "1":
                 logger.warning(
-                    "RBLN_FORCE_CCL_ASYNC is set to 0, "
+                    "RBLN_RUNTIME_FORCE_SYNC=1 forces the synchronous runtime, "
                     "which may cause performance degradation "
                     "when using vLLM model parallel (TP, DP, EP, or PP)."
                 )


### PR DESCRIPTION
### 🚀 Summary of Changes

The async runtime is now the **default** in rebel_compiler (see RBLN-SW/rebel_compiler#10435), which removed the opt-in env var `RBLN_FORCE_CCL_ASYNC`. The replacement is the opt-**out** flag `RBLN_RUNTIME_FORCE_SYNC=1`.

1. **Drop `RBLN_FORCE_CCL_ASYNC` default-on:** the model-parallel path no longer force-sets `RBLN_FORCE_CCL_ASYNC=1` — async is already the runtime default, so the set was redundant.
2. **Warn on forced sync instead:** if the user opts out with `RBLN_RUNTIME_FORCE_SYNC=1` under model parallel (TP/DP/EP/PP), log a perf-degradation warning (mirrors the old `=0` warning, inverted to the new flag).

---

### 📌 Related Issues / Tickets

* Related to RBLN-SW/rebel_compiler#10435

---

### ✅ Type of Change

* [x] 🔁 Refactor or code cleanup (`refactor`)

---

### 🧪 How to Test

1. Run a model-parallel (TP>1) serving job — async runs by default, no `RBLN_FORCE_CCL_ASYNC` needed.
2. Set `RBLN_RUNTIME_FORCE_SYNC=1` and rerun → the perf-degradation warning is logged.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

Depends on rebel_compiler#10435 being merged (which removes `RBLN_FORCE_CCL_ASYNC` and adds `RBLN_RUNTIME_FORCE_SYNC`). The companion vllm-executor change maps `--disable-rbln-ccl-async` to `RBLN_RUNTIME_FORCE_SYNC=1`.
