### PR TITLE
fix(scheduler): re-emit KV block dropped by mixed-batching eviction

### DIFF
--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -127,6 +127,108 @@ def test_new_prefill_uses_full_budget_when_decode_running():
     assert output.num_scheduled_tokens[req_b.request_id] == max_num_batched_tokens
 
 
+def test_evicted_decode_block_is_restashed_and_reemitted():
+    """Regression: a decode request whose next KV block is allocated exactly
+    on the prefill->decode transition step, and which is then evicted by the
+    "disable mixed batching" path, must not lose that block.
+
+    The block is already committed in the coordinator, so the next step's
+    allocate_slots returns an empty delta — without re-emitting the stashed
+    delta the runner's block table would keep a stale block-id 0. This is the
+    failure mode observed for block-aligned prompts (prompt length an exact
+    multiple of block_size), whose second block is needed on the very first
+    decode step that the eviction targets.
+    """
+    block_size = 16
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_num_seqs=4,
+        block_size=block_size,
+        num_blocks=10000,
+    )
+
+    # Block-aligned prompt: exactly one block of prompt tokens.
+    req_a = create_requests(
+        num_requests=1, num_tokens=block_size, block_size=block_size, req_ids=["A"]
+    )[0]
+    scheduler.add_request(req_a)
+
+    # Prefill req_a (fits in one chunk); after the update it enters decode
+    # with exactly one allocated block (num_computed == block_size).
+    out1 = scheduler.schedule()
+    assert out1.num_scheduled_tokens[req_a.request_id] == block_size
+    scheduler.update_from_output(out1, create_runner_output(out1, 1))
+    assert req_a.num_computed_tokens == block_size
+
+    # A new prefill enters: the running loop schedules req_a's first decode
+    # (which needs a second block at the boundary), then the waiting loop
+    # schedules req_b and evicts req_a.
+    req_b = create_requests(
+        num_requests=1, num_tokens=block_size, block_size=block_size, req_ids=["B"]
+    )[0]
+    scheduler.add_request(req_b)
+    out2 = scheduler.schedule()
+
+    # req_a was kicked; req_b runs.
+    assert req_a.request_id not in out2.num_scheduled_tokens
+    assert req_b.request_id in out2.num_scheduled_tokens
+    # The fix stashed req_a's just-allocated block delta instead of dropping it.
+    assert req_a.request_id in scheduler._stranded_new_blocks
+    stashed_ids = scheduler._stranded_new_blocks[req_a.request_id].get_block_ids()
+    assert any(len(g) > 0 for g in stashed_ids)
+
+    scheduler.update_from_output(out2, create_runner_output(out2, 1))
+
+    # Next step: no waiting prefill, so req_a runs as decode and the stashed
+    # block must be re-emitted in its cached new_block_ids (this step's own
+    # allocate_slots returns nothing — the block is already committed).
+    out3 = scheduler.schedule()
+    assert req_a.request_id in out3.num_scheduled_tokens
+    cached = out3.scheduled_cached_reqs
+    idx = cached.req_ids.index(req_a.request_id)
+    reemitted = cached.new_block_ids[idx]
+    assert reemitted is not None
+    assert any(len(g) > 0 for g in reemitted)
+    # The stash is drained, and the re-emitted ids cover the stashed blocks.
+    assert req_a.request_id not in scheduler._stranded_new_blocks
+    flat_reemitted = [b for g in reemitted for b in g]
+    flat_stashed = [b for g in stashed_ids for b in g]
+    assert flat_stashed
+    assert all(b in flat_reemitted for b in flat_stashed)
+
+
+def test_stranded_blocks_cleaned_up_on_finish():
+    """A block delta stashed for an evicted request must be dropped if the
+    request finishes before it is scheduled again, so the stash never leaks."""
+    block_size = 16
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_num_seqs=4,
+        block_size=block_size,
+        num_blocks=10000,
+    )
+
+    req_a = create_requests(
+        num_requests=1, num_tokens=block_size, block_size=block_size, req_ids=["A"]
+    )[0]
+    scheduler.add_request(req_a)
+    out1 = scheduler.schedule()
+    scheduler.update_from_output(out1, create_runner_output(out1, 1))
+
+    req_b = create_requests(
+        num_requests=1, num_tokens=block_size, block_size=block_size, req_ids=["B"]
+    )[0]
+    scheduler.add_request(req_b)
+    scheduler.schedule()
+    # req_a evicted at the boundary -> its block delta is stashed.
+    assert req_a.request_id in scheduler._stranded_new_blocks
+
+    # Finish req_a before it is rescheduled; the _free_request override must
+    # drop the stash entry.
+    scheduler.finish_requests(req_a.request_id, RequestStatus.FINISHED_ABORTED)
+    assert req_a.request_id not in scheduler._stranded_new_blocks
+
+
 def test_preempt_during_execution():
     # Test copied from https://github.com/vllm-project/vllm/blob/4fd9d6a85c00ac0186aa9abbeff73fc2ac6c721e/tests/v1/core/test_scheduler.py#L672-L728
 

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -50,6 +50,7 @@ refer to query backfill -- not a separate mechanism.
 import itertools
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
@@ -161,6 +162,19 @@ class RBLNScheduler(Scheduler):
                     "sub_block_size=%d.",
                     sub_block_size,
                 )
+
+        # NOTE(RBLN): Blocks allocated for a running (decode) request that is
+        # then evicted by the "disable mixed batching" path (see schedule())
+        # are already committed in the KV-cache coordinator but never reach the
+        # model runner, because the evicted request is dropped from this step's
+        # output. On the next step `allocate_slots` returns an empty delta (the
+        # coordinator already holds the block), so the block id would be lost
+        # to the runner forever — leaving a stale block-id 0 in the request's
+        # block table. This is observable for block-aligned prompts, whose
+        # second block is allocated exactly on the prefill->decode transition
+        # step that the eviction targets. We stash the dropped delta here and
+        # re-emit it on the request's next scheduled step. Keyed by request_id.
+        self._stranded_new_blocks: dict[str, KVCacheBlocks] = {}
 
     def schedule(self) -> RBLNSchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/v1/core/sched/scheduler.py#L338-L927
@@ -884,12 +898,28 @@ class RBLNScheduler(Scheduler):
                 # be scheduled together with the other running requests in the decoding
                 # phase.
                 for req in scheduled_running_reqs:
-                    req_to_new_blocks.pop(req.request_id)
+                    evicted_blocks = req_to_new_blocks.pop(req.request_id)
                     num_scheduled_tokens.pop(req.request_id)
                     req.spec_token_ids = scheduled_spec_decode_tokens.pop(
                         req.request_id, []
                     )
                     scheduled_encoder_inputs.pop(req.request_id, None)
+
+                    # NOTE(RBLN): The block delta allocated for this evicted
+                    # request is already committed in the coordinator but is
+                    # being dropped from this step's output. Stash it (merging
+                    # with any delta stranded on a previous consecutive
+                    # eviction) so it is re-emitted to the runner on the
+                    # request's next scheduled step. Skip empty deltas.
+                    if evicted_blocks is not None and any(
+                        len(g) > 0 for g in evicted_blocks.get_block_ids()
+                    ):
+                        prev = self._stranded_new_blocks.get(req.request_id)
+                        self._stranded_new_blocks[req.request_id] = (
+                            prev + evicted_blocks
+                            if prev is not None
+                            else evicted_blocks
+                        )
 
                 scheduled_running_reqs.clear()
                 token_budget = prefill_token_budget
@@ -970,6 +1000,22 @@ class RBLNScheduler(Scheduler):
                 for req in scheduled_new_reqs
             ]
 
+        # NOTE(RBLN): Re-emit any block delta that was stranded when a running
+        # request was evicted by the "disable mixed batching" path on a prior
+        # step. The coordinator already holds these blocks, so this step's
+        # `allocate_slots` returned an empty delta for them; prepending the
+        # stranded delta (allocated earlier) ahead of this step's delta keeps
+        # the runner's block table in sync (the runner appends deltas in
+        # order). Only requests actually scheduled this step (cached/running)
+        # carry their delta to the runner, so drain on emit.
+        if self._stranded_new_blocks:
+            for req in scheduled_running_reqs:
+                stranded = self._stranded_new_blocks.pop(req.request_id, None)
+                if stranded is not None:
+                    req_to_new_blocks[req.request_id] = (
+                        stranded + req_to_new_blocks[req.request_id]
+                    )
+
         with record_function_or_nullcontext("schedule: make_cached_request_data"):
             cached_reqs_data = self._make_cached_request_data(
                 scheduled_running_reqs,
@@ -1038,6 +1084,14 @@ class RBLNScheduler(Scheduler):
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
+
+    def _free_request(
+        self, request: Request, delay_free_blocks: bool = False
+    ) -> dict[str, Any] | None:
+        # Drop any block delta stashed for re-emit; the request is finishing and
+        # will never be scheduled again, so the stash would otherwise leak.
+        self._stranded_new_blocks.pop(request.request_id, None)
+        return super()._free_request(request, delay_free_blocks)
 
     def update_from_output(
         self,


### PR DESCRIPTION

<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

 #### Summary

  Fix a `RBLNScheduler` bug where a KV block allocated to a decode request is
  permanently lost to the model runner when that request is evicted by the
  "disable mixed batching" path, leaving a stale block-id `0` in its block
  table and corrupting decode output.

  #### Root cause

  When a new prefill request is scheduled, `RBLNScheduler`'s mixed-batching
  eviction kicks out every running (decode) request already scheduled in that
  step, popping their entries from `req_to_new_blocks`. A block that
  `allocate_slots` just granted to an evicted request is already committed in
  the KV-cache coordinator but never reaches the runner. On the next step
  `allocate_slots` returns an empty delta (the coordinator already holds the
  block), so the block id is never communicated — the runner's block table
  keeps a stale `0`.

  This only corrupts **block-aligned prompts** (prompt length an exact
  multiple of `block_size`): their second block is needed on the very first
  decode step — exactly the prefill→decode transition step the eviction
  targets — so it is dropped. Non-aligned prompts allocate the second block
  one step later on a pure decode step and are unaffected.

  #### Impact

  Observed on `gpt-oss-120b` (hybrid Full + SWA), 64 prompts of length 1024
  (= block_size): only **2 of 64** requests kept a correct full-attention
  block table; the other 62 read/wrote generated-token KV at block `0`,
  producing incorrect outputs.

  #### Fix

  - Stash the dropped delta in `self._stranded_new_blocks` and re-emit it
    (prepended, preserving the runner's append order) on the request's next
    scheduled step via `KVCacheBlocks.__add__`.
  - Coordinator state is left untouched — only the runner's view is re-synced.
  - `_free_request` drops any stash entry so an aborted/finished request
    cannot leak.
  - The zeroing path (`new_block_ids_to_zero`) is unaffected: it is gated on
    `needs_kv_cache_zeroing == has_mamba_layers`, which is `False` for
    non-Mamba models.

  #### Verification

  - Added regression tests: stash + re-emit at a block boundary, and on-finish
    cleanup. Both fail without the fix and pass with it.
  - Device rerun (`gpt-oss-120b`, 1024-token prompts): full-attention block
    table now grows to 2 blocks for all 64 requests across the entire decode
    phase (previously only 2/64); zero requests stuck at 1 block during decode.


<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
