### PR TITLE
refactor(multimodal): follow the multimodal interface of upstream vllm

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -137,13 +137,6 @@ class RBLNOptimumBlip2ForConditionalGeneration(
         language_model_inputs = model.language_projection(query_output)
         return list(language_model_inputs)
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
-        image_input = self._parse_and_validate_image_input(**kwargs)
-        if image_input is None:
-            return []
-
-        return self._process_image_input(image_input)
-
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -21,19 +21,20 @@ from vllm.model_executor.models.blip2 import (
     Blip2ImageInputs,
     Blip2ImagePixelInputs,
 )
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 
 from .base import ModelInputForRBLN
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 
 logger = init_logger(__name__)
 
 
 class RBLNOptimumBlip2ForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
+    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -103,9 +104,7 @@ class RBLNOptimumBlip2ForConditionalGeneration(
     def get_language_model(self):
         return self.model.language_model
 
-    def _process_image_input(
-        self, image_input: Blip2ImageInputs
-    ) -> list[torch.Tensor]:
+    def _process_image_input(self, image_input: Blip2ImageInputs) -> list[torch.Tensor]:
         # FIXME new API in optimum-rbln
         if image_input["type"] == "image_embeds":
             return list(image_input["data"])

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -21,7 +21,6 @@ from vllm.model_executor.models.blip2 import (
     Blip2ImageInputs,
     Blip2ImagePixelInputs,
 )
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 
 from .base import ModelInputForRBLN
 from .model_base import (
@@ -136,30 +135,6 @@ class RBLNOptimumBlip2ForConditionalGeneration(
         # (num_images, num_query_tokens, text_hidden_size)
         language_model_inputs = model.language_projection(query_output)
         return list(language_model_inputs)
-
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        # Mirrors optimum-rbln's _preprocess_prefill: scatter the Q-Former
-        # outputs over the image-token positions.
-        config = self.model.config
-        if is_multimodal is None:
-            is_multimodal = input_ids == config.image_token_index
-
-        inputs_embeds = self.model.get_input_embeddings()(input_ids)
-
-        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
-            return inputs_embeds
-
-        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
-            inputs_embeds.device, inputs_embeds.dtype
-        )
-        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
-        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(self, **kwargs: Any) -> Blip2ImageInputs | None:
         pixel_values = kwargs.pop("pixel_values", None)

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -21,7 +21,10 @@ from vllm.model_executor.models.blip2 import (
     Blip2ImageInputs,
     Blip2ImagePixelInputs,
 )
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 
 from .base import ModelInputForRBLN
 from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
@@ -32,6 +35,13 @@ logger = init_logger(__name__)
 class RBLNOptimumBlip2ForConditionalGeneration(
     RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
 ):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return None
+
+        raise ValueError("Only image modality is supported")
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -56,10 +66,6 @@ class RBLNOptimumBlip2ForConditionalGeneration(
 
         is_prompt = model_input.is_prompt
 
-        image_input = None
-        pixel_values = None
-
-        padded_batch_size = self.decoder_batch_size
         request_nums = input_ids.shape[0]
 
         kwargs = self.preprocess_for_decoder(
@@ -67,21 +73,16 @@ class RBLNOptimumBlip2ForConditionalGeneration(
         )
 
         if is_prompt:
-            if model_input.multi_modal_kwargs:
-                image_input = self._parse_and_validate_image_input(
-                    **model_input.multi_modal_kwargs
-                )
-                if image_input is not None:
-                    assert image_input["type"] == "pixel_values"
-                    pixel_values = image_input["data"]
-
             block_tables = kwargs.pop("block_tables")
             input_ids = kwargs.pop("input_ids")
             cache_position = kwargs.pop("cache_position")
 
-            inputs_embeds = self.model._preprocess_prefill(
-                pixel_values=pixel_values,
-                input_ids=input_ids,
+            multimodal_embeddings = self.embed_multimodal(
+                **(model_input.multi_modal_kwargs or {})
+            )
+            inputs_embeds = self.embed_input_ids(
+                input_ids,
+                multimodal_embeddings or None,
             )
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
@@ -98,6 +99,75 @@ class RBLNOptimumBlip2ForConditionalGeneration(
         if not is_prompt:
             logits = logits[:request_nums]
         return logits
+
+    def get_language_model(self):
+        return self.model.language_model
+
+    def _process_image_input(
+        self, image_input: Blip2ImageInputs
+    ) -> list[torch.Tensor]:
+        # FIXME new API in optimum-rbln
+        if image_input["type"] == "image_embeds":
+            return list(image_input["data"])
+
+        # Replicates the vision-encode portion of optimum-rbln's
+        # _preprocess_prefill: vision_model -> Q-Former (query_tokens) ->
+        # language_projection. optimum-rbln does not expose a standalone
+        # get_image_features for BLIP-2.
+        model = self.model
+        pixel_values = image_input["data"]
+
+        vision_outputs = model.vision_model(pixel_values=pixel_values, return_dict=True)
+        image_embeds = vision_outputs[0]
+        image_attention_mask = torch.ones(
+            image_embeds.size()[:-1], dtype=torch.long, device=image_embeds.device
+        )
+
+        query_tokens = model.query_tokens.expand(image_embeds.shape[0], -1, -1)
+        query_outputs = model.qformer(
+            query_embeds=query_tokens,
+            encoder_hidden_states=image_embeds,
+            encoder_attention_mask=image_attention_mask,
+            return_dict=True,
+        )
+        query_output = query_outputs[0]
+        if query_output.dtype != image_embeds.dtype:
+            query_output = query_output.to(image_embeds.dtype)
+
+        # (num_images, num_query_tokens, text_hidden_size)
+        language_model_inputs = model.language_projection(query_output)
+        return list(language_model_inputs)
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors optimum-rbln's _preprocess_prefill: scatter the Q-Former
+        # outputs over the image-token positions.
+        config = self.model.config
+        if is_multimodal is None:
+            is_multimodal = input_ids == config.image_token_index
+
+        inputs_embeds = self.model.get_input_embeddings()(input_ids)
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(self, **kwargs: Any) -> Blip2ImageInputs | None:
         pixel_values = kwargs.pop("pixel_values", None)

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -104,37 +104,15 @@ class RBLNOptimumBlip2ForConditionalGeneration(
         return self.model.language_model
 
     def _process_image_input(self, image_input: Blip2ImageInputs) -> list[torch.Tensor]:
-        # FIXME new API in optimum-rbln
         if image_input["type"] == "image_embeds":
             return list(image_input["data"])
 
-        # Replicates the vision-encode portion of optimum-rbln's
-        # _preprocess_prefill: vision_model -> Q-Former (query_tokens) ->
-        # language_projection. optimum-rbln does not expose a standalone
-        # get_image_features for BLIP-2.
-        model = self.model
+        # Vision model + Q-Former + language projection, compiled by
+        # optimum-rbln.
         pixel_values = image_input["data"]
-
-        vision_outputs = model.vision_model(pixel_values=pixel_values, return_dict=True)
-        image_embeds = vision_outputs[0]
-        image_attention_mask = torch.ones(
-            image_embeds.size()[:-1], dtype=torch.long, device=image_embeds.device
-        )
-
-        query_tokens = model.query_tokens.expand(image_embeds.shape[0], -1, -1)
-        query_outputs = model.qformer(
-            query_embeds=query_tokens,
-            encoder_hidden_states=image_embeds,
-            encoder_attention_mask=image_attention_mask,
-            return_dict=True,
-        )
-        query_output = query_outputs[0]
-        if query_output.dtype != image_embeds.dtype:
-            query_output = query_output.to(image_embeds.dtype)
-
         # (num_images, num_query_tokens, text_hidden_size)
-        language_model_inputs = model.language_projection(query_output)
-        return list(language_model_inputs)
+        image_features = self.model.get_image_features(pixel_values=pixel_values)
+        return list(image_features)
 
     def _parse_and_validate_image_input(self, **kwargs: Any) -> Blip2ImageInputs | None:
         pixel_values = kwargs.pop("pixel_values", None)

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -33,7 +33,7 @@ logger = init_logger(__name__)
 
 
 class RBLNOptimumBlip2ForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
+    RBLNOptimumModelBase, RBLNOptimumMultimodalMixin, RBLNOptimumDecoderMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -236,6 +236,25 @@ class RBLNOptimumGemma3ForConditionalGeneration(
     def get_language_model(self):
         return self.model.language_model
 
+    def build_prefill_inputs(
+        self,
+        input_ids: torch.Tensor,
+        cached_mm_outputs: list,
+        *,
+        cache_position: torch.Tensor | None = None,
+        running_requests_ids: list[str] | None = None,
+    ) -> dict:
+        # EC disaggregation (cached-encoder prefill) is not yet supported for
+        # Gemma3. Its prefill uses hybrid sliding-window attention whose state
+        # (attention_mask / local_block_tables / token_type_ids, tracked by
+        # attention_manager) is not produced by the generic EC consumer path,
+        # so a dedicated implementation is required before EC can be enabled.
+        raise NotImplementedError(
+            "EC disaggregation is not implemented for Gemma3: its hybrid "
+            "sliding-window attention prefill needs attention_manager state "
+            "that build_prefill_inputs does not yet provide."
+        )
+
     def _process_image_input(
         self, image_input: Gemma3ImageInputs
     ) -> list[torch.Tensor]:

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -271,13 +271,6 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             return list(image_embeds)
         return [e.flatten(0, 1) for e in image_embeds.split(num_patches.tolist())]
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
-        image_input = self._parse_and_validate_image_input(**kwargs)
-        if image_input is None:
-            return []
-
-        return self._process_image_input(image_input)
-
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -86,9 +86,9 @@ class RBLNGemma3MultiModalProcessor(Gemma3MultiModalProcessor):
 )
 class RBLNOptimumGemma3ForConditionalGeneration(
     RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
     RBLNOptimumDecoderMixin,
     VllmModelForTextGeneration,
-    RBLNOptimumMultimodalMixin,
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -23,15 +23,16 @@ from vllm.model_executor.models.gemma3_mm import (
     Gemma3MultiModalProcessor,
     Gemma3ProcessingInfo,
 )
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from .base import ModelInputForRBLN, version_error
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 from .optimum_attention import HybridAttentionImageManager, HybridAttentionImageStrategy
 
 logger = init_logger(__name__)
@@ -88,7 +89,7 @@ class RBLNOptimumGemma3ForConditionalGeneration(
     RBLNOptimumModelBase,
     RBLNOptimumDecoderMixin,
     VllmModelForTextGeneration,
-    SupportsMultiModal,
+    RBLNOptimumMultimodalMixin,
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -23,7 +23,6 @@ from vllm.model_executor.models.gemma3_mm import (
     Gemma3MultiModalProcessor,
     Gemma3ProcessingInfo,
 )
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
@@ -271,36 +270,15 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             return list(image_embeds)
         return [e.flatten(0, 1) for e in image_embeds.split(num_patches.tolist())]
 
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
+    def _embed_text_tokens(
+        self, input_ids: torch.Tensor, is_multimodal: torch.Tensor
     ) -> torch.Tensor:
-        # Mirrors the merge semantics of optimum-rbln's _preprocess_prefill:
-        # replace OOV image tokens with PAD for the text embedding lookup,
-        # then scatter the image embeddings over the image-token positions.
+        # Gemma3's image token can be OOV; PAD-mask those positions before the
+        # text embedding lookup (mirrors optimum-rbln's _preprocess_prefill).
         config = self.model.config
-        if is_multimodal is None:
-            is_multimodal = input_ids == config.image_token_index
-
         if config.image_token_index >= self.model.vocab_size:
-            llm_input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
-        else:
-            llm_input_ids = input_ids
-        inputs_embeds = self.model.get_input_embeddings()(llm_input_ids)
-
-        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
-            return inputs_embeds
-
-        # Flatten per-item embeddings into (num_mm_tokens, hidden_size);
-        # works for both a list of 2D tensors and a 3D tensor.
-        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
-            inputs_embeds.device, inputs_embeds.dtype
-        )
-        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
-        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
+            input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
+        return self.model.get_input_embeddings()(input_ids)
 
     def _parse_and_validate_image_input(
         self, **kwargs: Any

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -244,11 +244,9 @@ class RBLNOptimumGemma3ForConditionalGeneration(
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
     ) -> dict:
-        # EC disaggregation (cached-encoder prefill) is not yet supported for
-        # Gemma3. Its prefill uses hybrid sliding-window attention whose state
-        # (attention_mask / local_block_tables / token_type_ids, tracked by
-        # attention_manager) is not produced by the generic EC consumer path,
-        # so a dedicated implementation is required before EC can be enabled.
+        # NOTE: this guard is currently unreachable — init_model() only enables
+        # the EC path for "RBLNQwen3VLForConditionalGeneration", so Gemma3 never
+        # enters here today. It documents the contract for when EC is extended.
         raise NotImplementedError(
             "EC disaggregation is not implemented for Gemma3: its hybrid "
             "sliding-window attention prefill needs attention_manager state "

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -23,7 +23,10 @@ from vllm.model_executor.models.gemma3_mm import (
     Gemma3MultiModalProcessor,
     Gemma3ProcessingInfo,
 )
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
@@ -87,6 +90,13 @@ class RBLNOptimumGemma3ForConditionalGeneration(
     VllmModelForTextGeneration,
     SupportsMultiModal,
 ):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<start_of_image>"
+
+        raise ValueError("Only image modality is supported")
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -148,8 +158,17 @@ class RBLNOptimumGemma3ForConditionalGeneration(
         if is_prompt:
             prefill_batch_idx = sliding_window_table_ids[0]
             local_block_table_id = torch.tensor([prefill_batch_idx], dtype=torch.int16)
-            inputs_embeds, token_type_ids = self._build_prefill_embeds(
-                model_input, input_ids
+            # token_type_ids model_input != token_type_ids of gemma3
+            # https://github.com/huggingface/transformers/blob/d0c9c66d1c09df3cd70bf036e813d88337b20d4c/src/transformers/models/gemma3/processing_gemma3.py#L143
+            token_type_ids = torch.zeros_like(input_ids)
+            token_type_ids[input_ids == self.model.config.image_token_index] = 1
+
+            multimodal_embeddings = self.embed_multimodal(
+                **(model_input.multi_modal_kwargs or {})
+            )
+            inputs_embeds = self.embed_input_ids(
+                input_ids,
+                multimodal_embeddings or None,
             )
             if self.model.language_model.prefill_decoder is None:
                 raise version_error
@@ -214,35 +233,61 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             logits = logits[:request_nums]
         return logits
 
-    def _build_prefill_embeds(
-        self, model_input: ModelInputForRBLN, input_ids: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build ``inputs_embeds`` and ``mm_token_type_ids`` for the prefill pass.
-        Subclasses override to plug in model-specific multimodal handling."""
-        # FIXME It is disappeared in transformers 5.5.4
-        # token_type_ids model_input != token_type_ids of gemma3
-        # https://github.com/huggingface/transformers/blob/d0c9c66d1c09df3cd70bf036e813d88337b20d4c/src/transformers/models/gemma3/processing_gemma3.py#L143
-        mm_token_type_ids = torch.zeros_like(input_ids)
-        mm_token_type_ids[input_ids == self.model.config.image_token_index] = 1
+    def get_language_model(self):
+        return self.model.language_model
 
-        pixel_values = self.get_pixel_values(model_input)
-        inputs_embeds = self.model._preprocess_prefill(input_ids, None, pixel_values)
-        return inputs_embeds, mm_token_type_ids
+    def _process_image_input(
+        self, image_input: Gemma3ImageInputs
+    ) -> list[torch.Tensor]:
+        assert image_input["type"] == "pixel_values"
+        pixel_values = image_input["pixel_values"]
+        num_patches = image_input["num_patches"]
 
-    def get_pixel_values(self, model_input: ModelInputForRBLN):
-        image_input = None
+        # Vision tower + multi-modal projector, compiled by optimum-rbln.
+        # Returns (num_patches_total, mm_tokens_per_image, hidden_size).
+        image_embeds = self.model.get_image_features(pixel_values)
 
-        if model_input.multi_modal_kwargs:
-            image_input = self._parse_and_validate_image_input(
-                **model_input.multi_modal_kwargs
-            )
-            if image_input is not None:
-                assert image_input["type"] == "pixel_values"
-                pixel_values = image_input["pixel_values"]
+        if num_patches is None:
+            return list(image_embeds)
+        return [e.flatten(0, 1) for e in image_embeds.split(num_patches.tolist())]
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors the merge semantics of optimum-rbln's _preprocess_prefill:
+        # replace OOV image tokens with PAD for the text embedding lookup,
+        # then scatter the image embeddings over the image-token positions.
+        config = self.model.config
+        if is_multimodal is None:
+            is_multimodal = input_ids == config.image_token_index
+
+        if config.image_token_index >= self.model.vocab_size:
+            llm_input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
         else:
-            pixel_values = None
+            llm_input_ids = input_ids
+        inputs_embeds = self.model.get_input_embeddings()(llm_input_ids)
 
-        return pixel_values
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        # Flatten per-item embeddings into (num_mm_tokens, hidden_size);
+        # works for both a list of 2D tensors and a 3D tensor.
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(
         self, **kwargs: Any

--- a/vllm_rbln/model_executor/models/optimum/gemma4.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma4.py
@@ -24,7 +24,6 @@ from vllm.model_executor.models.gemma4_mm import (
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
-from .base import ModelInputForRBLN
 from .gemma3 import (
     PAD_TOKEN_ID,
     RBLNOptimumGemma3ForConditionalGeneration,
@@ -166,11 +165,8 @@ class RBLNOptimumGemma4ForConditionalGeneration(
         pixel_values = image_input["pixel_values"]
         pixel_position_ids = image_input["pixel_position_ids"]
 
-        # Vision tower + multi-modal projector, compiled by optimum-rbln.
-        # Returns (num_patches_total, mm_tokens_per_image, hidden_size).
         image_embeds = self.model.get_image_features(
-            pixel_values=pixel_values,
-            pixel_position_ids=pixel_position_ids
+            pixel_values=pixel_values, pixel_position_ids=pixel_position_ids
         )
 
         return image_embeds

--- a/vllm_rbln/model_executor/models/optimum/gemma4.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma4.py
@@ -159,37 +159,21 @@ class RBLNGemma4MultiModalProcessor(Gemma4MultiModalProcessor):
 class RBLNOptimumGemma4ForConditionalGeneration(
     RBLNOptimumGemma3ForConditionalGeneration
 ):
-    def _build_prefill_embeds(
-        self, model_input: ModelInputForRBLN, input_ids: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        # FIXME It should be delivered from runner
-        # FIXME It should allow video_token_ids, audio_token_ids as well.
-        # https://github.com/huggingface/transformers/blob/0588858f54c8c79d28497d3ad6eac3417b716c49/src/transformers/processing_utils.py#L897
-        mm_token_type_ids = torch.zeros_like(input_ids)
-        mm_token_type_ids[input_ids == self.model.config.image_token_id] = 1
-        pixel_values, image_position_ids = self.get_image_values(model_input)
-        inputs_embeds = self.model._preprocess_prefill(
-            input_ids,
-            None,
-            pixel_values,
-            image_position_ids=image_position_ids,
+    def _process_image_input(
+        self, image_input: Gemma4ImageInputs
+    ) -> list[torch.Tensor]:
+        assert image_input["type"] == "pixel_values"
+        pixel_values = image_input["pixel_values"]
+        pixel_position_ids = image_input["pixel_position_ids"]
+
+        # Vision tower + multi-modal projector, compiled by optimum-rbln.
+        # Returns (num_patches_total, mm_tokens_per_image, hidden_size).
+        image_embeds = self.model.get_image_features(
+            pixel_values=pixel_values,
+            pixel_position_ids=pixel_position_ids
         )
-        return inputs_embeds, mm_token_type_ids
 
-    def get_image_values(
-        self, model_input: ModelInputForRBLN
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-        if not model_input.multi_modal_kwargs:
-            return None, None
-
-        multimodal_inputs = self._parse_and_validate_multimodal_inputs(
-            **model_input.multi_modal_kwargs
-        )
-        image_input = multimodal_inputs.get("image")
-        if not isinstance(image_input, Gemma4ImagePixelInputs):
-            return None, None
-
-        return image_input["pixel_values"], image_input["pixel_position_ids"]
+        return image_embeds
 
     def _parse_and_validate_multimodal_inputs(
         self, **kwargs: object

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -160,7 +160,9 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
         return list(connector_outputs)
 
     def _image_token_id(self) -> int:
-        # idefics3's HF config names the placeholder `image_token_id`.
+        # Idefics3Config exposes only `image_token_id` (no `image_token_index`
+        # attribute_map alias, unlike PaliGemma/Gemma3/LLaVA), so the mixin
+        # default would raise AttributeError here.
         return self.model.config.image_token_id
 
     def _validate_pixel_values(self, data: torch.Tensor) -> torch.Tensor:

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -102,62 +102,19 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
         return self.model.text_model
 
     def _process_image_input(self, image_input: ImageInputs) -> list[torch.Tensor]:
-        # FIXME new API in optimum-rbln
         if image_input["type"] == "image_embeds":
             return list(image_input["data"])
 
-        # Replicates the vision-encode portion of optimum-rbln's
-        # _preprocess_prefill (vision_model + connector); optimum-rbln does not
-        # expose a standalone get_image_features for Idefics3.
-        model = self.model
-        config = model.config
+        # Vision model + pixel-shuffle connector, compiled by optimum-rbln.
+        # get_image_features expects a leading batch dim
+        # (batch_size, num_images, num_channels, height, width).
         pixel_values = image_input["pixel_values"].unsqueeze(0)
         pixel_attention_mask = image_input["pixel_attention_mask"].unsqueeze(0)
-
-        batch_size, num_images = pixel_values.shape[:2]
-        pixel_values = pixel_values.to(dtype=model.dtype)
-        pixel_values = pixel_values.view(
-            batch_size * num_images, *pixel_values.shape[2:]
-        )
-
-        # Drop fully-padded (all-zero) images.
-        nb_values_per_image = pixel_values.shape[1:].numel()
-        real_images_inds = (pixel_values == 0.0).sum(
-            dim=(-1, -2, -3)
-        ) != nb_values_per_image
-        pixel_values = pixel_values[real_images_inds].contiguous()
-
-        pixel_attention_mask = pixel_attention_mask.view(
-            batch_size * num_images, *pixel_attention_mask.shape[2:]
-        )
-        pixel_attention_mask = pixel_attention_mask[real_images_inds].contiguous()
-
-        patch_size = config.vision_config.patch_size
-        patches_subgrid = pixel_attention_mask.unfold(1, patch_size, patch_size)
-        patches_subgrid = patches_subgrid.unfold(2, patch_size, patch_size)
-        patch_attention_mask = (patches_subgrid.sum(dim=(-1, -2)) > 0).bool()
-
-        image_hidden_states = model.vision_model(
+        image_features = self.model.get_image_features(
             pixel_values=pixel_values,
-            patch_attention_mask=patch_attention_mask,
-            return_dict=True,
-        ).last_hidden_state
-
-        # Pixel-shuffle connector, run per image.
-        connector_out_size = [
-            image_hidden_states.shape[0],
-            image_hidden_states.shape[1] // config.scale_factor**2,
-            config.text_config.hidden_size,
-        ]
-        connector_outputs = torch.empty(
-            size=connector_out_size, dtype=torch.float32, device="cpu"
+            pixel_attention_mask=pixel_attention_mask,
         )
-        for i in range(image_hidden_states.shape[0]):
-            model.connector(
-                image_hidden_states[i : i + 1], out=connector_outputs[i : i + 1]
-            )
-
-        return list(connector_outputs)
+        return list(image_features)
 
     def _image_token_id(self) -> int:
         # Idefics3Config exposes only `image_token_id` (no `image_token_index`

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -21,7 +21,10 @@ from vllm.model_executor.models.idefics3 import (
     Idefics3ImagePixelInputs,
     ImageInputs,
 )
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 
 from .base import ModelInputForRBLN
 from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
@@ -32,6 +35,13 @@ logger = init_logger(__name__)
 class RBLNOptimumIdefics3ForConditionalGeneration(
     RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
 ):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<image>"
+
+        raise ValueError("Only image modality is supported")
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -62,27 +72,16 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
         )
 
         if is_prompt:
-            if model_input.multi_modal_kwargs:
-                image_input = self._parse_and_validate_image_input(
-                    **model_input.multi_modal_kwargs
-                )
-
-            # Only when image input is given
-            if image_input is not None:
-                pixel_values = image_input["pixel_values"].unsqueeze(0)
-                pixel_attention_mask = image_input["pixel_attention_mask"].unsqueeze(0)
-            else:
-                pixel_values = None
-                pixel_attention_mask = None
-
             block_tables = kwargs.pop("block_tables")
             input_ids = kwargs.pop("input_ids")
             cache_position = kwargs.pop("cache_position")
 
-            inputs_embeds = self.model._preprocess_prefill(
-                input_ids=input_ids,
-                pixel_values=pixel_values,
-                pixel_attention_mask=pixel_attention_mask,
+            multimodal_embeddings = self.embed_multimodal(
+                **(model_input.multi_modal_kwargs or {})
+            )
+            inputs_embeds = self.embed_input_ids(
+                input_ids,
+                multimodal_embeddings or None,
             )
             logits = self.model.text_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
@@ -98,6 +97,96 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
         if not is_prompt:
             logits = logits[:request_nums]
         return logits
+
+    def get_language_model(self):
+        return self.model.text_model
+
+    def _process_image_input(self, image_input: ImageInputs) -> list[torch.Tensor]:
+        # FIXME new API in optimum-rbln
+        if image_input["type"] == "image_embeds":
+            return list(image_input["data"])
+
+        # Replicates the vision-encode portion of optimum-rbln's
+        # _preprocess_prefill (vision_model + connector); optimum-rbln does not
+        # expose a standalone get_image_features for Idefics3.
+        model = self.model
+        config = model.config
+        pixel_values = image_input["pixel_values"].unsqueeze(0)
+        pixel_attention_mask = image_input["pixel_attention_mask"].unsqueeze(0)
+
+        batch_size, num_images = pixel_values.shape[:2]
+        pixel_values = pixel_values.to(dtype=model.dtype)
+        pixel_values = pixel_values.view(batch_size * num_images, *pixel_values.shape[2:])
+
+        # Drop fully-padded (all-zero) images.
+        nb_values_per_image = pixel_values.shape[1:].numel()
+        real_images_inds = (pixel_values == 0.0).sum(
+            dim=(-1, -2, -3)
+        ) != nb_values_per_image
+        pixel_values = pixel_values[real_images_inds].contiguous()
+
+        pixel_attention_mask = pixel_attention_mask.view(
+            batch_size * num_images, *pixel_attention_mask.shape[2:]
+        )
+        pixel_attention_mask = pixel_attention_mask[real_images_inds].contiguous()
+
+        patch_size = config.vision_config.patch_size
+        patches_subgrid = pixel_attention_mask.unfold(1, patch_size, patch_size)
+        patches_subgrid = patches_subgrid.unfold(2, patch_size, patch_size)
+        patch_attention_mask = (patches_subgrid.sum(dim=(-1, -2)) > 0).bool()
+
+        image_hidden_states = model.vision_model(
+            pixel_values=pixel_values,
+            patch_attention_mask=patch_attention_mask,
+            return_dict=True,
+        ).last_hidden_state
+
+        # Pixel-shuffle connector, run per image.
+        connector_out_size = [
+            image_hidden_states.shape[0],
+            image_hidden_states.shape[1] // config.scale_factor**2,
+            config.text_config.hidden_size,
+        ]
+        connector_outputs = torch.empty(
+            size=connector_out_size, dtype=torch.float32, device="cpu"
+        )
+        for i in range(image_hidden_states.shape[0]):
+            model.connector(
+                image_hidden_states[i : i + 1], out=connector_outputs[i : i + 1]
+            )
+
+        return list(connector_outputs)
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors optimum-rbln's inputs_merger: image tokens are in-vocab, so
+        # scatter the connector outputs over the image-token positions.
+        config = self.model.config
+        if is_multimodal is None:
+            is_multimodal = input_ids == config.image_token_id
+
+        inputs_embeds = self.model.get_input_embeddings()(input_ids)
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _validate_pixel_values(self, data: torch.Tensor) -> torch.Tensor:
         h = w = self.model.config.vision_config.image_size

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -21,19 +21,20 @@ from vllm.model_executor.models.idefics3 import (
     Idefics3ImagePixelInputs,
     ImageInputs,
 )
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 
 from .base import ModelInputForRBLN
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 
 logger = init_logger(__name__)
 
 
 class RBLNOptimumIdefics3ForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
+    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -116,7 +117,9 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
 
         batch_size, num_images = pixel_values.shape[:2]
         pixel_values = pixel_values.to(dtype=model.dtype)
-        pixel_values = pixel_values.view(batch_size * num_images, *pixel_values.shape[2:])
+        pixel_values = pixel_values.view(
+            batch_size * num_images, *pixel_values.shape[2:]
+        )
 
         # Drop fully-padded (all-zero) images.
         nb_values_per_image = pixel_values.shape[1:].numel()

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -160,13 +160,6 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
 
         return list(connector_outputs)
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
-        image_input = self._parse_and_validate_image_input(**kwargs)
-        if image_input is None:
-            return []
-
-        return self._process_image_input(image_input)
-
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -21,7 +21,6 @@ from vllm.model_executor.models.idefics3 import (
     Idefics3ImagePixelInputs,
     ImageInputs,
 )
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 
 from .base import ModelInputForRBLN
 from .model_base import (
@@ -160,29 +159,9 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
 
         return list(connector_outputs)
 
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        # Mirrors optimum-rbln's inputs_merger: image tokens are in-vocab, so
-        # scatter the connector outputs over the image-token positions.
-        config = self.model.config
-        if is_multimodal is None:
-            is_multimodal = input_ids == config.image_token_id
-
-        inputs_embeds = self.model.get_input_embeddings()(input_ids)
-
-        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
-            return inputs_embeds
-
-        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
-            inputs_embeds.device, inputs_embeds.dtype
-        )
-        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
-        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
+    def _image_token_id(self) -> int:
+        # idefics3's HF config names the placeholder `image_token_id`.
+        return self.model.config.image_token_id
 
     def _validate_pixel_values(self, data: torch.Tensor) -> torch.Tensor:
         h = w = self.model.config.vision_config.image_size

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -33,7 +33,7 @@ logger = init_logger(__name__)
 
 
 class RBLNOptimumIdefics3ForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
+    RBLNOptimumModelBase, RBLNOptimumMultimodalMixin, RBLNOptimumDecoderMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -33,7 +33,7 @@ logger = init_logger(__name__)
 
 
 class RBLNOptimumLlavaForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
+    RBLNOptimumModelBase, RBLNOptimumMultimodalMixin, RBLNOptimumDecoderMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -16,7 +16,6 @@ from typing import Union
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.llava import (
     LlavaImageInputs,
     LlavaImagePixelInputs,
@@ -154,31 +153,6 @@ class RBLNOptimumLlavaForConditionalGeneration(
             image_sizes=image_sizes,
         )
         return list(image_features)
-
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        # Mirrors optimum-rbln's _preprocess_prefill: image tokens are in-vocab
-        # for LLaVA, so no PAD masking is needed; just scatter the image
-        # features over the image-token positions.
-        config = self.model.config
-        if is_multimodal is None:
-            is_multimodal = input_ids == config.image_token_index
-
-        inputs_embeds = self.model.get_input_embeddings()(input_ids)
-
-        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
-            return inputs_embeds
-
-        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
-            inputs_embeds.device, inputs_embeds.dtype
-        )
-        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
-        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(
         self, **kwargs: object

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -16,10 +16,7 @@ from typing import Union
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.llava import (
     LlavaImageInputs,
     LlavaImagePixelInputs,
@@ -27,13 +24,17 @@ from vllm.model_executor.models.llava import (
 )
 
 from .base import ModelInputForRBLN, version_error
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 
 logger = init_logger(__name__)
 
 
 class RBLNOptimumLlavaForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
+    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -137,9 +138,7 @@ class RBLNOptimumLlavaForConditionalGeneration(
     def get_language_model(self):
         return self.model.language_model
 
-    def _process_image_input(
-        self, image_input: LlavaImageInputs
-    ) -> list[torch.Tensor]:
+    def _process_image_input(self, image_input: LlavaImageInputs) -> list[torch.Tensor]:
         pixel_values = image_input["pixel_values"]
         if image_input["type"] == "pixel_values_pixtral":
             image_sizes = torch.tensor(pixel_values.shape[-2:]).unsqueeze(0)

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -16,7 +16,10 @@ from typing import Union
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 from vllm.model_executor.models.llava import (
     LlavaImageInputs,
     LlavaImagePixelInputs,
@@ -32,6 +35,13 @@ logger = init_logger(__name__)
 class RBLNOptimumLlavaForConditionalGeneration(
     RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
 ):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<image>"
+
+        raise ValueError("Only image modality is supported")
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -54,21 +64,13 @@ class RBLNOptimumLlavaForConditionalGeneration(
         is_prefill: bool,
         block_tables: torch.Tensor,
         input_ids: torch.LongTensor = None,
-        pixel_values: torch.FloatTensor | None = None,
-        image_sizes: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
         cache_position: Union[
             list[torch.Tensor], torch.Tensor
         ] = None,  # vllm keyword argument
         **kwargs,
     ):
         if is_prefill:
-            # NOTE inputs_embeds will be generated inside _preprocess_prefill
-            inputs_embeds = self.model._preprocess_prefill(
-                input_ids=input_ids,
-                pixel_values=pixel_values,
-                image_sizes=image_sizes,
-            )
-
             if self.model.language_model.prefill_decoder is None:
                 raise version_error
 
@@ -97,20 +99,6 @@ class RBLNOptimumLlavaForConditionalGeneration(
         is_prompt = model_input.is_prompt
 
         request_nums = input_ids.shape[0]
-        if model_input.multi_modal_kwargs:
-            image_input = self._parse_and_validate_image_input(
-                **model_input.multi_modal_kwargs
-            )
-            if image_input is not None:
-                if image_input["type"] == "pixel_values":
-                    pixel_values = image_input["pixel_values"]
-                    image_sizes = None
-                elif image_input["type"] == "pixel_values_pixtral":
-                    pixel_values = image_input["pixel_values"]
-                    image_sizes = torch.tensor(pixel_values.shape[-2:]).unsqueeze(0)
-        else:
-            pixel_values = None
-            image_sizes = None
 
         kwargs = self.preprocess_for_decoder(
             is_prompt, block_tables, input_ids, cache_position
@@ -124,18 +112,81 @@ class RBLNOptimumLlavaForConditionalGeneration(
                 padded_batch_size
             ]
 
+        inputs_embeds = None
+        if is_prompt:
+            multimodal_embeddings = self.embed_multimodal(
+                **(model_input.multi_modal_kwargs or {})
+            )
+            inputs_embeds = self.embed_input_ids(
+                input_ids,
+                multimodal_embeddings or None,
+            )
+
         logits = self._forward(
             is_prefill=is_prompt,
             block_tables=block_tables,
             input_ids=input_ids,
-            pixel_values=pixel_values,
-            image_sizes=image_sizes,
+            inputs_embeds=inputs_embeds,
             cache_position=cache_position,
         )
 
         if not is_prompt:
             logits = logits[:request_nums]
         return logits
+
+    def get_language_model(self):
+        return self.model.language_model
+
+    def _process_image_input(
+        self, image_input: LlavaImageInputs
+    ) -> list[torch.Tensor]:
+        pixel_values = image_input["pixel_values"]
+        if image_input["type"] == "pixel_values_pixtral":
+            image_sizes = torch.tensor(pixel_values.shape[-2:]).unsqueeze(0)
+        else:
+            image_sizes = None
+
+        config = self.model.config
+        # Vision tower + multi-modal projector, compiled by optimum-rbln.
+        image_features = self.model.get_image_features(
+            pixel_values=pixel_values,
+            vision_feature_layer=config.vision_feature_layer,
+            vision_feature_select_strategy=config.vision_feature_select_strategy,
+            image_sizes=image_sizes,
+        )
+        return list(image_features)
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors optimum-rbln's _preprocess_prefill: image tokens are in-vocab
+        # for LLaVA, so no PAD masking is needed; just scatter the image
+        # features over the image-token positions.
+        config = self.model.config
+        if is_multimodal is None:
+            is_multimodal = input_ids == config.image_token_index
+
+        inputs_embeds = self.model.get_input_embeddings()(input_ids)
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(
         self, **kwargs: object

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -155,13 +155,6 @@ class RBLNOptimumLlavaForConditionalGeneration(
         )
         return list(image_features)
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
-        image_input = self._parse_and_validate_image_input(**kwargs)
-        if image_input is None:
-            return []
-
-        return self._process_image_input(image_input)
-
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -16,7 +16,10 @@ from typing import Any, Union
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 from vllm.model_executor.models.llava_next import (
     LlavaNextImageInputs,
     LlavaNextImagePixelInputs,
@@ -31,6 +34,13 @@ logger = init_logger(__name__)
 class RBLNOptimumLlavaNextForConditionalGeneration(
     RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
 ):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<image>"
+
+        raise ValueError("Only image modality is supported")
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -48,46 +58,18 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
             num_blocks=self.kv_block_adapter._estimated_num_blocks(),
         )
 
-    def merge_multimodal_embeddings(
-        self,
-        input_ids: torch.Tensor,
-        inputs_embeds: torch.Tensor,
-        multimodal_embeddings: torch.Tensor,
-        placeholder_token_id: int,
-    ) -> torch.Tensor:
-        mask = input_ids == placeholder_token_id
-        num_expected_tokens = mask.sum().item()
-
-        if multimodal_embeddings.shape[0] != num_expected_tokens:
-            raise ValueError(
-                f"Attempted to assign {inputs_embeds[mask].shape}"
-                f" = {multimodal_embeddings.shape} "
-                f"multimodal tokens to {num_expected_tokens} placeholders"
-            )
-
-        inputs_embeds[mask] = multimodal_embeddings
-        return inputs_embeds
-
     def _forward(
         self,
         is_prefill: bool,
         block_tables: torch.Tensor,
         input_ids: torch.LongTensor = None,
-        pixel_values: torch.FloatTensor | None = None,
-        image_sizes: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
         cache_position: Union[
             list[torch.Tensor], torch.Tensor
         ] = None,  # vllm keyword argument
         **kwargs,
     ):
         if is_prefill:
-            # NOTE inputs_embeds will be generated inside _preprocess_prefill
-            inputs_embeds = self.model._preprocess_prefill(
-                input_ids=input_ids,
-                pixel_values=pixel_values,
-                image_sizes=image_sizes,
-            )
-
             if self.model.language_model.prefill_decoder is None:
                 raise version_error
 
@@ -117,18 +99,6 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
 
         request_nums = input_ids.shape[0]
 
-        if model_input.multi_modal_kwargs:
-            image_input = self._parse_and_validate_image_input(
-                **model_input.multi_modal_kwargs
-            )
-            if image_input is not None:
-                assert image_input["type"] == "pixel_values"
-                pixel_values = image_input["pixel_values"]
-                image_sizes = image_input["image_sizes"]
-        else:
-            pixel_values = None
-            image_sizes = None
-
         kwargs = self.preprocess_for_decoder(
             is_prompt, block_tables, input_ids, cache_position
         )
@@ -141,18 +111,87 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
                 padded_batch_size
             ]
 
+        inputs_embeds = None
+        if is_prompt:
+            multimodal_embeddings = self.embed_multimodal(
+                **(model_input.multi_modal_kwargs or {})
+            )
+            inputs_embeds = self.embed_input_ids(
+                input_ids,
+                multimodal_embeddings or None,
+            )
+
         logits = self._forward(
             is_prefill=is_prompt,
             block_tables=block_tables,
             input_ids=input_ids,
-            pixel_values=pixel_values,
-            image_sizes=image_sizes,
+            inputs_embeds=inputs_embeds,
             cache_position=cache_position,
         )
 
         if not is_prompt:
             logits = logits[:request_nums]
         return logits
+
+    def get_language_model(self):
+        return self.model.language_model
+
+    def _process_image_input(
+        self, image_input: LlavaNextImageInputs
+    ) -> list[torch.Tensor]:
+        pixel_values = image_input["pixel_values"]
+        image_sizes = image_input["image_sizes"]
+        config = self.model.config
+
+        # Vision tower + multi-modal projector, compiled by optimum-rbln.
+        # Returns a tuple of per-image features split by num_patches.
+        image_features = self.model.get_image_features(
+            pixel_values,
+            image_sizes,
+            vision_feature_layer=config.vision_feature_layer,
+            vision_feature_select_strategy=config.vision_feature_select_strategy,
+        )
+        # spatial_unpad merge + image_newline insertion. Returns the flattened
+        # features for all images plus the per-image token counts.
+        image_features, feature_lens = self.model.pack_image_features(
+            image_features,
+            image_sizes,
+            vision_feature_select_strategy=config.vision_feature_select_strategy,
+            image_newline=self.model.image_newline,
+        )
+        return list(torch.split(image_features, feature_lens.tolist()))
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors optimum-rbln's _preprocess_prefill: image tokens are in-vocab
+        # for LLaVA-NeXT, so no PAD masking is needed; just scatter the packed
+        # image features over the image-token positions.
+        config = self.model.config
+        if is_multimodal is None:
+            is_multimodal = input_ids == config.image_token_index
+
+        inputs_embeds = self.model.get_input_embeddings()(input_ids)
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(
         self, **kwargs: Any

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -162,13 +162,6 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
         )
         return list(torch.split(image_features, feature_lens.tolist()))
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
-        image_input = self._parse_and_validate_image_input(**kwargs)
-        if image_input is None:
-            return []
-
-        return self._process_image_input(image_input)
-
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -16,23 +16,24 @@ from typing import Any, Union
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.llava_next import (
     LlavaNextImageInputs,
     LlavaNextImagePixelInputs,
 )
 
 from .base import ModelInputForRBLN, version_error
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 
 logger = init_logger(__name__)
 
 
 class RBLNOptimumLlavaNextForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
+    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -16,7 +16,6 @@ from typing import Any, Union
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.llava_next import (
     LlavaNextImageInputs,
     LlavaNextImagePixelInputs,
@@ -161,31 +160,6 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
             image_newline=self.model.image_newline,
         )
         return list(torch.split(image_features, feature_lens.tolist()))
-
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        # Mirrors optimum-rbln's _preprocess_prefill: image tokens are in-vocab
-        # for LLaVA-NeXT, so no PAD masking is needed; just scatter the packed
-        # image features over the image-token positions.
-        config = self.model.config
-        if is_multimodal is None:
-            is_multimodal = input_ids == config.image_token_index
-
-        inputs_embeds = self.model.get_input_embeddings()(input_ids)
-
-        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
-            return inputs_embeds
-
-        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
-            inputs_embeds.device, inputs_embeds.dtype
-        )
-        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
-        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(
         self, **kwargs: Any

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -32,7 +32,7 @@ logger = init_logger(__name__)
 
 
 class RBLNOptimumLlavaNextForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
+    RBLNOptimumModelBase, RBLNOptimumMultimodalMixin, RBLNOptimumDecoderMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -198,6 +198,9 @@ class RBLNOptimumModelBase(nn.Module):
                 # NOTE:
                 # ``sync_vllm_and_optimum`` already narrowed user overrides
                 # down to device-only keys; we forward only those here.
+                rbln_overrides = dict(rbln_overrides)
+                if self._is_ec_consumer_only():
+                    rbln_overrides["_load_visual_runtime"] = False
                 model = model_cls.from_pretrained(
                     valid_path,
                     rbln_config=rbln_overrides,

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -538,10 +538,11 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
     ) -> dict:
-        # EC consumer prefill only, and so far only validated on Qwen-VL.
-        # Gemma3 overrides this because its prefill is incompatible with the
-        # generic path here. The remaining models inherit this default but
-        # have not been validated against the EC consumer path yet.
+        # NOTE: this default is currently unreachable. init_model() gates the EC
+        # producer/consumer path on ec_enabled_model ==
+        # "RBLNQwen3VLForConditionalGeneration", so no non-Qwen model enters the
+        # EC path today. It is kept as the shared interface contract / placeholder
+        # until more models are EC-enabled.
         mm_embeds = [t for out in cached_mm_outputs for t in out]
         inputs_embeds = self.embed_input_ids(input_ids, mm_embeds or None)
         return {"inputs_embeds": inputs_embeds, "cache_position": cache_position}

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.models.interfaces import SupportsMultiModal
 from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
 from vllm.v1.sample.metadata import SamplingMetadata
 
@@ -445,3 +446,32 @@ class RBLNOptimumDecoderMixin(VllmModelForTextGeneration):
         self, hidden_states: torch.Tensor, sampling_metadata: SamplingMetadata
     ) -> torch.Tensor:
         return self.logits_processor(None, hidden_states, sampling_metadata)
+
+
+class RBLNOptimumMultimodalMixin(SupportsMultiModal):
+    """Shared multimodal interface for optimum models.
+
+    Centralizes the default encoder-cache (EC) consumer merge. The producer
+    caches whatever embed_multimodal() returns; on the consumer side this
+    default build_prefill_inputs() flattens those per-item embeddings and
+    merges them via embed_input_ids() — sufficient for models whose
+    prefill_decoder takes (inputs_embeds, cache_position, block_tables).
+
+    Models that need extra prefill state override it: Qwen-VL builds mrope
+    position_embed / deepstack, and Gemma3 raises (its hybrid sliding-window
+    attention prefill is not wired for EC yet).
+    """
+
+    def build_prefill_inputs(
+        self,
+        input_ids: torch.Tensor,
+        cached_mm_outputs: list,
+        *,
+        cache_position: torch.Tensor | None = None,
+        running_requests_ids: list[str] | None = None,
+    ) -> dict:
+        # Each cached output is a list of per-item multimodal token embeddings
+        # (as returned by embed_multimodal()).
+        mm_embeds = [t for out in cached_mm_outputs for t in out]
+        inputs_embeds = self.embed_input_ids(input_ids, mm_embeds or None)
+        return {"inputs_embeds": inputs_embeds, "cache_position": cache_position}

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -187,10 +187,11 @@ class RBLNOptimumModelBase(nn.Module):
         if valid_path is not None:
             # pre-compiled OR cache-hit
             model_cls = getattr(optimum.rbln, model_cls_name)
+            ec_enabled_model = model_cls_name == "RBLNQwen3VLForConditionalGeneration"
             assert model_cls is not None
             # FIXME decouple producer logic from model_base.py
             if self._is_ec_producer_only():
-                if model_cls_name != "RBLNQwen3VLForConditionalGeneration":
+                if not ec_enabled_model:
                     raise ValueError("Disaggregation is not supported for this model.")
                 visual = model_cls.load_visual_encoder(valid_path)
                 model = _ProducerOptimumModelProxy(visual, visual.rbln_config)
@@ -200,6 +201,10 @@ class RBLNOptimumModelBase(nn.Module):
                 # down to device-only keys; we forward only those here.
                 rbln_overrides = dict(rbln_overrides)
                 if self._is_ec_consumer_only():
+                    if not ec_enabled_model:
+                        raise ValueError(
+                            "Disaggregation is not supported for this model."
+                        )
                     rbln_overrides["_load_visual_runtime"] = False
                 model = model_cls.from_pretrained(
                     valid_path,

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -475,6 +475,45 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
 
         return self._process_image_input(image_input)
 
+    def _image_token_id(self) -> int:
+        # Token id of the multimodal placeholder. Default reads the HF config's
+        # `image_token_index`; subclasses whose config names it differently
+        # (e.g. `image_token_id`) override this.
+        return self.model.config.image_token_index
+
+    def _embed_text_tokens(
+        self, input_ids: torch.Tensor, is_multimodal: torch.Tensor
+    ) -> torch.Tensor:
+        # Text-token embedding lookup. Default assumes the placeholder is
+        # in-vocab, so a plain lookup suffices. Models whose placeholder is OOV
+        # override this to PAD-mask the placeholder positions first.
+        return self.model.get_input_embeddings()(input_ids)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors optimum-rbln's _preprocess_prefill: embed the text tokens,
+        # then scatter the per-item multimodal embeddings over the placeholder
+        # positions.
+        if is_multimodal is None:
+            is_multimodal = input_ids == self._image_token_id()
+
+        inputs_embeds = self._embed_text_tokens(input_ids, is_multimodal)
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        # Flatten per-item embeddings into (num_mm_tokens, hidden_size).
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
+
     def build_prefill_inputs(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -20,7 +20,10 @@ import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
 from vllm.v1.sample.metadata import SamplingMetadata
 
@@ -460,6 +463,17 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
     """
     Shared multimodal interface for optimum models.
     """
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        # Default vision-only encode path shared by the simple MM models: parse
+        # the image input and return per-image token embeddings. Models with a
+        # richer cacheable unit (e.g. Qwen-VL, which also handles video) override
+        # this.
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
 
     def build_prefill_inputs(
         self,

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -457,17 +457,8 @@ class RBLNOptimumDecoderMixin(VllmModelForTextGeneration):
 
 
 class RBLNOptimumMultimodalMixin(SupportsMultiModal):
-    """Shared multimodal interface for optimum models.
-
-    Centralizes the default encoder-cache (EC) consumer merge. The producer
-    caches whatever embed_multimodal() returns; on the consumer side this
-    default build_prefill_inputs() flattens those per-item embeddings and
-    merges them via embed_input_ids() — sufficient for models whose
-    prefill_decoder takes (inputs_embeds, cache_position, block_tables).
-
-    Models that need extra prefill state override it: Qwen-VL builds mrope
-    position_embed / deepstack, and Gemma3 raises (its hybrid sliding-window
-    attention prefill is not wired for EC yet).
+    """
+    Shared multimodal interface for optimum models.
     """
 
     def build_prefill_inputs(
@@ -478,8 +469,10 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
     ) -> dict:
-        # Each cached output is a list of per-item multimodal token embeddings
-        # (as returned by embed_multimodal()).
+        # EC consumer prefill only, and so far only validated on Qwen-VL.
+        # Gemma3 overrides this because its prefill is incompatible with the
+        # generic path here. The remaining models inherit this default but
+        # have not been validated against the EC consumer path yet.
         mm_embeds = [t for out in cached_mm_outputs for t in out]
         inputs_embeds = self.embed_input_ids(input_ids, mm_embeds or None)
         return {"inputs_embeds": inputs_embeds, "cache_position": cache_position}

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -464,16 +464,32 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
     Shared multimodal interface for optimum models.
     """
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | dict:
         # Default vision-only encode path shared by the simple MM models: parse
         # the image input and return per-image token embeddings. Models with a
         # richer cacheable unit (e.g. Qwen-VL, which also handles video) override
         # this.
+        #
+        # NOTE: Upstream vLLM's MultiModalEmbeddings is only
+        # list[Tensor] | Tensor | tuple[Tensor, ...] and does not admit a dict.
+        # Models whose cacheable unit is richer than per-item embeddings (e.g.
+        # Qwen-VL: image/video embeds + grid_thw + optional deepstack) return
+        # that unit as a dict, so vLLM-RBLN widens the contract to also allow
+        # dict instead of forcing it into a positional tuple.
         image_input = self._parse_and_validate_image_input(**kwargs)
         if image_input is None:
             return []
 
         return self._process_image_input(image_input)
+
+    def _process_image_input(self, image_input: object) -> list[torch.Tensor] | dict:
+        # Encode a validated image input into the model's cacheable multimodal
+        # unit: per-image token embeddings (list[torch.Tensor]) for the simple
+        # models, or a richer dict (e.g. Qwen-VL). Consumed by the default
+        # embed_multimodal() above.
+        raise NotImplementedError(
+            "`_process_image_input` must be implemented for each model."
+        )
 
     def _image_token_id(self) -> int:
         # Token id of the multimodal placeholder. Default reads the HF config's

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -15,7 +15,10 @@ from typing import Any
 
 import torch
 from vllm.config import VllmConfig
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 from vllm.model_executor.models.paligemma import (
     PaliGemmaImageEmbeddingInputs,
     PaliGemmaImageInputs,
@@ -27,10 +30,19 @@ from vllm_rbln.model_executor.models.optimum.base import ModelInputForRBLN
 
 from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
 
+PAD_TOKEN_ID = 0
+
 
 class RBLNOptimumPaliGemmaForConditionalGeneration(
     RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
 ):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return None
+
+        raise ValueError("Only image modality is supported")
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -61,18 +73,16 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
         )
 
         if is_prompt:
-            if model_input.multi_modal_kwargs:
-                pixel_values = self.get_pixel_values(model_input)
-            else:
-                pixel_values = None
-
             block_tables = kwargs.pop("block_tables")
             input_ids = kwargs.pop("input_ids")
             cache_position = kwargs.pop("cache_position")
 
-            inputs_embeds = self.model._preprocess_prefill(
-                input_ids=input_ids,
-                pixel_values=pixel_values,
+            multimodal_embeddings = self.embed_multimodal(
+                **(model_input.multi_modal_kwargs or {})
+            )
+            inputs_embeds = self.embed_input_ids(
+                input_ids,
+                multimodal_embeddings or None,
             )
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
@@ -99,20 +109,56 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
             logits = logits[:request_nums]
         return logits
 
-    def get_pixel_values(self, model_input: ModelInputForRBLN):
-        image_input = None
+    def get_language_model(self):
+        return self.model.language_model
 
-        if model_input.multi_modal_kwargs:
-            image_input = self._parse_and_validate_image_input(
-                **model_input.multi_modal_kwargs
-            )
-            if image_input is not None:
-                assert image_input["type"] == "pixel_values"
-                pixel_values = image_input["data"]
+    def _process_image_input(
+        self, image_input: PaliGemmaImageInputs
+    ) -> list[torch.Tensor]:
+        if image_input["type"] == "image_embeds":
+            return list(image_input["data"])
+
+        # Vision tower + multi-modal projector, compiled by optimum-rbln.
+        # Returns (num_images, num_image_tokens, hidden_size).
+        image_features = self.model.get_image_features(image_input["data"])
+        return list(image_features)
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        if image_input is None:
+            return []
+
+        return self._process_image_input(image_input)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirrors the merge semantics of optimum-rbln's _preprocess_prefill:
+        # replace OOV image tokens with PAD for the text embedding lookup,
+        # then scatter the image features over the image-token positions.
+        config = self.model.config
+        if is_multimodal is None:
+            is_multimodal = input_ids == config.image_token_id
+
+        if config.image_token_id >= config.text_config.vocab_size:
+            llm_input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
         else:
-            pixel_values = None
+            llm_input_ids = input_ids
+        inputs_embeds = self.model.get_input_embeddings()(llm_input_ids)
 
-        return pixel_values
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        # Flatten per-image embeddings into (num_mm_tokens, hidden_size).
+        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
+            inputs_embeds.device, inputs_embeds.dtype
+        )
+        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
+        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
     def _parse_and_validate_image_input(
         self, **kwargs: Any

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import torch
 from vllm.config import VllmConfig
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.paligemma import (
     PaliGemmaImageEmbeddingInputs,
     PaliGemmaImageInputs,
@@ -124,35 +123,19 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
         image_features = self.model.get_image_features(image_input["data"])
         return list(image_features)
 
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
+    def _image_token_id(self) -> int:
+        # PaliGemma's HF config names the placeholder `image_token_id`.
+        return self.model.config.image_token_id
+
+    def _embed_text_tokens(
+        self, input_ids: torch.Tensor, is_multimodal: torch.Tensor
     ) -> torch.Tensor:
-        # Mirrors the merge semantics of optimum-rbln's _preprocess_prefill:
-        # replace OOV image tokens with PAD for the text embedding lookup,
-        # then scatter the image features over the image-token positions.
+        # PaliGemma's image token can be OOV; PAD-mask those positions before
+        # the text embedding lookup (mirrors optimum-rbln's _preprocess_prefill).
         config = self.model.config
-        if is_multimodal is None:
-            is_multimodal = input_ids == config.image_token_id
-
         if config.image_token_id >= config.text_config.vocab_size:
-            llm_input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
-        else:
-            llm_input_ids = input_ids
-        inputs_embeds = self.model.get_input_embeddings()(llm_input_ids)
-
-        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
-            return inputs_embeds
-
-        # Flatten per-image embeddings into (num_mm_tokens, hidden_size).
-        mm_embeds = torch.cat(list(multimodal_embeddings)).to(
-            inputs_embeds.device, inputs_embeds.dtype
-        )
-        scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
-        return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
+            input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
+        return self.model.get_input_embeddings()(input_ids)
 
     def _parse_and_validate_image_input(
         self, **kwargs: Any

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -124,13 +124,6 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
         image_features = self.model.get_image_features(image_input["data"])
         return list(image_features)
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
-        image_input = self._parse_and_validate_image_input(**kwargs)
-        if image_input is None:
-            return []
-
-        return self._process_image_input(image_input)
-
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -15,10 +15,7 @@ from typing import Any
 
 import torch
 from vllm.config import VllmConfig
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.paligemma import (
     PaliGemmaImageEmbeddingInputs,
     PaliGemmaImageInputs,
@@ -28,13 +25,17 @@ from vllm.model_executor.models.paligemma import (
 from optimum.rbln.configuration_utils import RBLNModelConfig
 from vllm_rbln.model_executor.models.optimum.base import ModelInputForRBLN
 
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 
 PAD_TOKEN_ID = 0
 
 
 class RBLNOptimumPaliGemmaForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal
+    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -123,17 +123,13 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
         image_features = self.model.get_image_features(image_input["data"])
         return list(image_features)
 
-    def _image_token_id(self) -> int:
-        # PaliGemma's HF config names the placeholder `image_token_id`.
-        return self.model.config.image_token_id
-
     def _embed_text_tokens(
         self, input_ids: torch.Tensor, is_multimodal: torch.Tensor
     ) -> torch.Tensor:
         # PaliGemma's image token can be OOV; PAD-mask those positions before
         # the text embedding lookup (mirrors optimum-rbln's _preprocess_prefill).
         config = self.model.config
-        if config.image_token_id >= config.text_config.vocab_size:
+        if config.image_token_index >= config.text_config.vocab_size:
             input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
         return self.model.get_input_embeddings()(input_ids)
 

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -34,7 +34,7 @@ PAD_TOKEN_ID = 0
 
 
 class RBLNOptimumPaliGemmaForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin
+    RBLNOptimumModelBase, RBLNOptimumMultimodalMixin, RBLNOptimumDecoderMixin
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -384,7 +384,7 @@ class RBLNOptimumQwenVLForConditionalGeneration(
     def get_language_model(self):
         return self.model
 
-    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | dict:
         """Vision-only encode entry point (SupportsMultiModal / EC producer).
 
         Unlike the simple MM models (which return a list of per-image token

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -42,7 +42,7 @@ logger = init_logger(__name__)
 
 
 class RBLNOptimumQwenVLForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin, ABC
+    RBLNOptimumModelBase, RBLNOptimumMultimodalMixin, RBLNOptimumDecoderMixin, ABC
 ):
     """
     Unified class for both Qwen2-VL and Qwen2.5-VL models.

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -316,6 +316,7 @@ class RBLNOptimumQwenVLForConditionalGeneration(
             )
 
         # NOTE: preprocess_prefill also use dtype casting.
+        # eunji.lee): dtype casting is required
         inputs_embeds = self.model.embed_tokens(input_ids).to(self.dtype)
         position_embeds = []
         for b_id, request_id in enumerate(running_requests_ids):

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -17,7 +17,10 @@ from typing import Any
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+)
 from vllm.model_executor.models.qwen2_5_vl import (
     Qwen2_5_VLImageEmbeddingInputs,
     Qwen2_5_VLImagePixelInputs,
@@ -44,6 +47,15 @@ class RBLNOptimumQwenVLForConditionalGeneration(
     Unified class for both Qwen2-VL and Qwen2.5-VL models.
     Automatically detects model type based on the model configuration.
     """
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<|vision_start|><|image_pad|><|vision_end|>"
+        if modality.startswith("video"):
+            return "<|vision_start|><|video_pad|><|vision_end|>"
+
+        raise ValueError("Only image or video modality is supported")
 
     def __init__(
         self,
@@ -363,6 +375,107 @@ class RBLNOptimumQwenVLForConditionalGeneration(
 
         # fallback return if both are None
         return None
+
+    def get_language_model(self):
+        return self.model
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        """Vision-only encode entry point (SupportsMultiModal / EC producer).
+
+        Unlike the simple MM models (which return a list of per-image token
+        embeddings), Qwen's cacheable unit is the dict returned by encode():
+        image/video embeds + grid_thw (+ deepstack for Qwen3-VL). It is consumed
+        on the decode side by build_prefill_inputs().
+        """
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        video_input = self._parse_and_validate_video_input(**kwargs)
+        if image_input is None and video_input is None:
+            return []
+
+        return self.encode(image_input, video_input)
+
+    def build_prefill_inputs(
+        self,
+        input_ids: torch.Tensor,
+        cached_mm_outputs: list[dict],
+        *,
+        cache_position: torch.Tensor | None = None,
+        running_requests_ids: list[str] | None = None,
+    ) -> dict:
+        """Build prefill_decoder kwargs from cached encoder outputs (EC consumer).
+
+        Reconstructs image/video embeds + grid_thw (+ deepstack) from the
+        per-feature dicts produced by embed_multimodal(), runs the merge via
+        preprocess_prefill, and stashes rope_deltas for the decode phase.
+        cache_position is unused (Qwen feeds positions via position_embed).
+        """
+        model_dtype = self.dtype
+
+        image_caches = [c for c in cached_mm_outputs if "image_embeds" in c]
+        video_caches = [c for c in cached_mm_outputs if "video_embeds" in c]
+
+        def _concat_deepstack(caches: list[dict], key: str):
+            present = [c for c in caches if c.get(key) is not None]
+            if not present:
+                return None
+            num_layers = len(present[0][key])
+            return [
+                torch.cat([c[key][layer].to(model_dtype) for c in present], dim=0)
+                for layer in range(num_layers)
+            ]
+
+        image_input = None
+        video_input = None
+        deepstack_image_embeds = None
+        deepstack_video_embeds = None
+
+        if image_caches:
+            image_embeds = torch.cat(
+                [c["image_embeds"].to(model_dtype) for c in image_caches], dim=0
+            )
+            image_grid_thw = torch.cat(
+                [c["image_grid_thw"].to(torch.int64) for c in image_caches], dim=0
+            )
+            image_input = self._create_image_embedding_inputs(
+                image_embeds=image_embeds, image_grid_thw=image_grid_thw
+            )
+            deepstack_image_embeds = _concat_deepstack(
+                image_caches, "deepstack_image_embeds"
+            )
+
+        if video_caches:
+            video_embeds = torch.cat(
+                [c["video_embeds"].to(model_dtype) for c in video_caches], dim=0
+            )
+            video_grid_thw = torch.cat(
+                [c["video_grid_thw"].to(torch.int64) for c in video_caches], dim=0
+            )
+            video_input = self._create_video_embedding_inputs(
+                video_embeds=video_embeds, video_grid_thw=video_grid_thw
+            )
+            # Qwen2.5-VL: second_per_grid_ts is per-video metadata; carry the
+            # first feature's value as a best-effort for mixed batches.
+            if "second_per_grid_ts" in video_caches[0]:
+                video_input["second_per_grid_ts"] = video_caches[0]["second_per_grid_ts"]
+            deepstack_video_embeds = _concat_deepstack(
+                video_caches, "deepstack_video_embeds"
+            )
+
+        attention_mask = torch.ones_like(input_ids)
+        prefill_params = self.preprocess_prefill(
+            input_ids,
+            attention_mask,
+            image_input,
+            video_input,
+            deepstack_image_embeds=deepstack_image_embeds,
+            deepstack_video_embeds=deepstack_video_embeds,
+        )
+
+        rope_deltas = prefill_params.pop("rope_deltas", None)
+        if rope_deltas is not None and running_requests_ids:
+            self.rope_deltas[running_requests_ids[0]] = rope_deltas.item()
+
+        return prefill_params
 
 
 class RBLNOptimumQwen2_5_VLForConditionalGeneration(

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -17,10 +17,7 @@ from typing import Any
 import torch
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import (
-    MultiModalEmbeddings,
-    SupportsMultiModal,
-)
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.qwen2_5_vl import (
     Qwen2_5_VLImageEmbeddingInputs,
     Qwen2_5_VLImagePixelInputs,
@@ -35,13 +32,17 @@ from vllm.model_executor.models.qwen2_vl import (
 )
 
 from .base import ModelInputForRBLN
-from .model_base import RBLNOptimumDecoderMixin, RBLNOptimumModelBase
+from .model_base import (
+    RBLNOptimumDecoderMixin,
+    RBLNOptimumModelBase,
+    RBLNOptimumMultimodalMixin,
+)
 
 logger = init_logger(__name__)
 
 
 class RBLNOptimumQwenVLForConditionalGeneration(
-    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, SupportsMultiModal, ABC
+    RBLNOptimumModelBase, RBLNOptimumDecoderMixin, RBLNOptimumMultimodalMixin, ABC
 ):
     """
     Unified class for both Qwen2-VL and Qwen2.5-VL models.
@@ -456,7 +457,9 @@ class RBLNOptimumQwenVLForConditionalGeneration(
             # Qwen2.5-VL: second_per_grid_ts is per-video metadata; carry the
             # first feature's value as a best-effort for mixed batches.
             if "second_per_grid_ts" in video_caches[0]:
-                video_input["second_per_grid_ts"] = video_caches[0]["second_per_grid_ts"]
+                video_input["second_per_grid_ts"] = video_caches[0][
+                    "second_per_grid_ts"
+                ]
             deepstack_video_embeds = _concat_deepstack(
                 video_caches, "deepstack_video_embeds"
             )

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -85,8 +85,7 @@ class RBLNOptimumQwenVLForConditionalGeneration(
             "rope_deltas": preprocess_outputs[2],
         }
 
-    def encode(self, image_input, video_input) -> dict:
-        # sync with optimum encode()
+    def _process_image_input(self, image_input) -> dict:
         result = {}
         if image_input is not None and image_input.get("type") == "pixel_values":
             visual_out = self.model.visual(
@@ -101,6 +100,10 @@ class RBLNOptimumQwenVLForConditionalGeneration(
             else:
                 result["image_embeds"] = visual_out
             result["image_grid_thw"] = image_input["image_grid_thw"]
+        return result
+
+    def _process_video_input(self, video_input) -> dict:
+        result = {}
         if video_input is not None and video_input.get("type") == "pixel_values_videos":
             visual_out = self.model.visual(
                 video_input["pixel_values_videos"],
@@ -394,7 +397,12 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         if image_input is None and video_input is None:
             return []
 
-        return self.encode(image_input, video_input)
+        # Merge the per-modality encoder outputs into a single cacheable dict
+        # (consumed on the decode side by build_prefill_inputs()).
+        result = {}
+        result.update(self._process_image_input(image_input))
+        result.update(self._process_video_input(video_input))
+        return result
 
     def build_prefill_inputs(
         self,

--- a/vllm_rbln/v1/worker/ec_disagg_helpers.py
+++ b/vllm_rbln/v1/worker/ec_disagg_helpers.py
@@ -94,15 +94,8 @@ class ECDisaggHelpersMixin:
         model_input: ModelInputForRBLN,
         scheduler_output: "SchedulerOutput",
     ) -> None:
-        """Run the vision encoder only and save results to the EC connector
-        (producer-only path).
-
-        Model-agnostic: delegates to the model's embed_multimodal() so any
-        SupportsMultiModal model can act as a producer. The cached payload is
-        whatever embed_multimodal() returns (a list of per-item embeddings for
-        the simple models, or an encode dict with grid_thw/deepstack for
-        Qwen-VL); the matching consumer side knows how to merge it back.
-        """
+        """Producer path: run the vision encoder (model.embed_multimodal) and
+        cache the result for the consumer to merge back."""
         mm_kwargs = model_input.multi_modal_kwargs or {}
         encode_output = self.model.embed_multimodal(**mm_kwargs)
 
@@ -116,16 +109,8 @@ class ECDisaggHelpersMixin:
         model_input: ModelInputForRBLN,
         scheduler_output: "SchedulerOutput",
     ) -> torch.Tensor:
-        """Consumer path: gather cached encoder outputs for the request's
-        mm_features and run the prefill decoder.
-
-        The text+vision merge is delegated to the model. Models exposing
-        build_prefill_inputs() (e.g. Qwen-VL, which needs mrope position_embed
-        and deepstack) build their own prefill kwargs; otherwise the generic
-        path flattens the cached per-item embeddings and merges them with
-        embed_input_ids() into inputs_embeds. get_language_model().prefill_decoder
-        is used for both so the path is model-agnostic.
-        """
+        """Consumer path: gather the cached encoder outputs, let the model
+        merge them (model.build_prefill_inputs), and run the prefill decoder."""
         if not scheduler_output.scheduled_new_reqs:
             raise RuntimeError("EC consumer: no scheduled_new_reqs on prefill step.")
         req = scheduler_output.scheduled_new_reqs[0]
@@ -153,22 +138,12 @@ class ECDisaggHelpersMixin:
         cache_position = kwargs.pop("cache_position")
         block_tables = kwargs.pop("block_tables")
 
-        if hasattr(self.model, "build_prefill_inputs"):
-            prefill_params = self.model.build_prefill_inputs(
-                input_ids,
-                cached_mm_outputs,
-                cache_position=cache_position,
-                running_requests_ids=model_input.running_requests_ids,
-            )
-        else:
-            # Generic merge: each cached output is a list of per-item
-            # multimodal token embeddings.
-            mm_embeds = [t for out in cached_mm_outputs for t in out]
-            inputs_embeds = self.model.embed_input_ids(input_ids, mm_embeds or None)
-            prefill_params = {
-                "inputs_embeds": inputs_embeds,
-                "cache_position": cache_position,
-            }
+        prefill_params = self.model.build_prefill_inputs(
+            input_ids,
+            cached_mm_outputs,
+            cache_position=cache_position,
+            running_requests_ids=model_input.running_requests_ids,
+        )
 
         language_model = self.model.get_language_model()
         logits = language_model.prefill_decoder(

--- a/vllm_rbln/v1/worker/ec_disagg_helpers.py
+++ b/vllm_rbln/v1/worker/ec_disagg_helpers.py
@@ -94,21 +94,17 @@ class ECDisaggHelpersMixin:
         model_input: ModelInputForRBLN,
         scheduler_output: "SchedulerOutput",
     ) -> None:
-        """Run the vision encoder only and save results to the EC
-        connector.  Producer-only path — sends encode() output
-        (image_embeds/video_embeds + grid_thw) instead of the full
-        preprocess_prefill result."""
-        image_input = None
-        video_input = None
-        if model_input.multi_modal_kwargs:
-            image_input = self.model._parse_and_validate_image_input(
-                **model_input.multi_modal_kwargs
-            )
-            video_input = self.model._parse_and_validate_video_input(
-                **model_input.multi_modal_kwargs
-            )
+        """Run the vision encoder only and save results to the EC connector
+        (producer-only path).
 
-        encode_output = self.model.encode(image_input, video_input)
+        Model-agnostic: delegates to the model's embed_multimodal() so any
+        SupportsMultiModal model can act as a producer. The cached payload is
+        whatever embed_multimodal() returns (a list of per-item embeddings for
+        the simple models, or an encode dict with grid_thw/deepstack for
+        Qwen-VL); the matching consumer side knows how to merge it back.
+        """
+        mm_kwargs = model_input.multi_modal_kwargs or {}
+        encode_output = self.model.embed_multimodal(**mm_kwargs)
 
         mm_hash = self._get_mm_hash_for_request(scheduler_output)
         if mm_hash is not None:
@@ -120,15 +116,15 @@ class ECDisaggHelpersMixin:
         model_input: ModelInputForRBLN,
         scheduler_output: "SchedulerOutput",
     ) -> torch.Tensor:
-        """Consumer path: reconstruct embedding inputs from all cached
-        per-mm_feature encode() outputs and run preprocess_prefill +
-        prefill_decoder.
+        """Consumer path: gather cached encoder outputs for the request's
+        mm_features and run the prefill decoder.
 
-        Each image/video in the request is a separate mm_feature with its
-        own identifier; the producer caches one encode() result per
-        mm_feature. This walks every mm_feature of the new request in
-        order, fetches its cached embeddings, and concatenates them so
-        the LLM sees the full embedding sequence for the whole request.
+        The text+vision merge is delegated to the model. Models exposing
+        build_prefill_inputs() (e.g. Qwen-VL, which needs mrope position_embed
+        and deepstack) build their own prefill kwargs; otherwise the generic
+        path flattens the cached per-item embeddings and merges them with
+        embed_input_ids() into inputs_embeds. get_language_model().prefill_decoder
+        is used for both so the path is model-agnostic.
         """
         if not scheduler_output.scheduled_new_reqs:
             raise RuntimeError("EC consumer: no scheduled_new_reqs on prefill step.")
@@ -136,10 +132,7 @@ class ECDisaggHelpersMixin:
         if not req.mm_features:
             raise RuntimeError("EC consumer: request has no mm_features.")
 
-        model_dtype = self.model.dtype
-
-        image_caches: list[dict] = []
-        video_caches: list[dict] = []
+        cached_mm_outputs: list = []
         for feat in req.mm_features:
             mm_hash = feat.identifier
             if mm_hash not in self.encoder_cache:
@@ -148,99 +141,37 @@ class ECDisaggHelpersMixin:
                     f"encoder_cache_keys={list(self.encoder_cache.keys())[:5]}, "
                     f"mm_features={[f.identifier for f in req.mm_features]}"
                 )
-            cached = self.encoder_cache[mm_hash]
-            modality = getattr(feat, "modality", None)
-            if modality == "image" or (modality is None and "image_embeds" in cached):
-                image_caches.append(cached)
-            elif modality == "video" or (modality is None and "video_embeds" in cached):
-                video_caches.append(cached)
-            else:
-                # Fallback: include into whichever modality is populated.
-                if "image_embeds" in cached:
-                    image_caches.append(cached)
-                if "video_embeds" in cached:
-                    video_caches.append(cached)
-
-        def _concat_deepstack(
-            caches: list[dict], key: str
-        ) -> list[torch.Tensor] | None:
-            """Concat per-layer deepstack tensors across features along dim=0."""
-            present = [c for c in caches if c.get(key) is not None]
-            if not present:
-                return None
-            num_layers = len(present[0][key])
-            out: list[torch.Tensor] = []
-            for layer in range(num_layers):
-                out.append(
-                    torch.cat([c[key][layer].to(model_dtype) for c in present], dim=0)
-                )
-            return out
-
-        image_input = None
-        video_input = None
-        deepstack_image_embeds = None
-        deepstack_video_embeds = None
-
-        if image_caches:
-            image_embeds = torch.cat(
-                [c["image_embeds"].to(model_dtype) for c in image_caches], dim=0
-            )
-            image_grid_thw = torch.cat(
-                [c["image_grid_thw"].to(torch.int64) for c in image_caches], dim=0
-            )
-            image_input = self.model._create_image_embedding_inputs(
-                image_embeds=image_embeds,
-                image_grid_thw=image_grid_thw,
-            )
-            deepstack_image_embeds = _concat_deepstack(
-                image_caches, "deepstack_image_embeds"
-            )
-
-        if video_caches:
-            video_embeds = torch.cat(
-                [c["video_embeds"].to(model_dtype) for c in video_caches], dim=0
-            )
-            video_grid_thw = torch.cat(
-                [c["video_grid_thw"].to(torch.int64) for c in video_caches], dim=0
-            )
-            video_input = self.model._create_video_embedding_inputs(
-                video_embeds=video_embeds,
-                video_grid_thw=video_grid_thw,
-            )
-            # Qwen2.5-VL: second_per_grid_ts is per-video metadata; carry
-            # the first feature's value as a best-effort for mixed batches.
-            if "second_per_grid_ts" in video_caches[0]:
-                video_input["second_per_grid_ts"] = video_caches[0][
-                    "second_per_grid_ts"
-                ]
-            deepstack_video_embeds = _concat_deepstack(
-                video_caches, "deepstack_video_embeds"
-            )
+            cached_mm_outputs.append(self.encoder_cache[mm_hash])
 
         input_ids = model_input.input_tokens
-        attention_mask = torch.ones_like(input_ids)
-        prefill_params = self.model.preprocess_prefill(
-            input_ids,
-            attention_mask,
-            image_input,
-            video_input,
-            deepstack_image_embeds=deepstack_image_embeds,
-            deepstack_video_embeds=deepstack_video_embeds,
-        )
-
-        rope_deltas = prefill_params.pop("rope_deltas", None)
-        if rope_deltas is not None:
-            cur_request_id = model_input.running_requests_ids[0]
-            self.model.rope_deltas[cur_request_id] = rope_deltas.item()
-
         kwargs = self.model.preprocess_for_decoder(
             True,
             model_input.block_tables,
-            model_input.input_tokens,
+            input_ids,
             model_input.input_positions,
         )
+        cache_position = kwargs.pop("cache_position")
         block_tables = kwargs.pop("block_tables")
-        logits = self.model.model.prefill_decoder(
+
+        if hasattr(self.model, "build_prefill_inputs"):
+            prefill_params = self.model.build_prefill_inputs(
+                input_ids,
+                cached_mm_outputs,
+                cache_position=cache_position,
+                running_requests_ids=model_input.running_requests_ids,
+            )
+        else:
+            # Generic merge: each cached output is a list of per-item
+            # multimodal token embeddings.
+            mm_embeds = [t for out in cached_mm_outputs for t in out]
+            inputs_embeds = self.model.embed_input_ids(input_ids, mm_embeds or None)
+            prefill_params = {
+                "inputs_embeds": inputs_embeds,
+                "cache_position": cache_position,
+            }
+
+        language_model = self.model.get_language_model()
+        logits = language_model.prefill_decoder(
             **prefill_params,
             block_tables=block_tables,
         ).logits


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

**Interface refactor**
- Adopt upstream `SupportsMultiModal` and introduce `RBLNOptimumMultimodalMixin`, replacing the previous `hasattr`-based dispatch.
- Migrate paligemma, llava/llava_next, idefics3/blip2, qwen_vl, gemma3 onto the shared embed interface. https://github.com/vllm-project/vllm/blob/e2f993dc4116ba96ea10ec40b7bd2ee45b27b2b8/docs/contributing/model/multimodal.md

**Encoder-cache (EC) disaggregation flow**
- Producer: runs the vision encoder only (`embed_multimodal`) and caches the result; never touches the LLM.
- Consumer: on a multimodal prefill step, gathers cached encoder outputs and calls `model.build_prefill_inputs(...)` to merge them with `input_ids`, then runs the language-model `prefill_decoder` (skips the vision encoder runtime). All other paths (non-EC inference, producer side, decode steps, text-only requests) don't touch `build_prefill_inputs`.

**Per-model coverage of `build_prefill_inputs`**
- Default (`RBLNOptimumMultimodalMixin`): flattens cached per-item embeds and merges via `embed_input_ids` — for simple MM models whose `prefill_decoder` only needs `inputs_embeds`.
- Qwen-VL override: reconstructs image/video embeds + grid_thw (+ deepstack), runs mrope/`preprocess_prefill`, stashes `rope_deltas`. Currently the only validated model.
- Gemma3 override: raises `NotImplementedError` — its hybrid sliding-window attention prefill needs `attention_manager` state the generic path doesn't provide.

### TODO
a. call `embed_input_ids` and generate mm_token_type_ids in model_runner,
b. make `_process_image_input` API separately in blip2, idefics3 in optimum-rbln level @rebel-kblee 
c. decouple the logic of encoder cache and model code



---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [x] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [x] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---

