### PR TITLE
fix(rejection-sampler): pad inputs to fixed num_spec_tokens to avoid recompiles

### DIFF
--- a/tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py
+++ b/tests/torch_compile/unit/v1/sample/test_rbln_rejection_sampler.py
@@ -40,7 +40,11 @@ def rejection_sampler(monkeypatch_module):
         compile_context=compile_context,
     )
 
-    return RBLNRejectionSampler(sampler, seed=seed, compile_context=compile_context)
+    # num_spec_tokens is now required by RBLNRejectionSampler (static spec pad);
+    # the tests below use max_spec_len=3, so pad to 3.
+    return RBLNRejectionSampler(
+        sampler, seed=seed, compile_context=compile_context, num_spec_tokens=3
+    )
 
 
 def _one_hot(target_tokens: list[int], vocab_size: int) -> torch.Tensor:

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -66,6 +66,15 @@ class RBLNRejectionSampler(RejectionSampler):
         seed = kwargs.pop("seed", None)
         assert seed is not None, "seed cannot be None."
         compile_context = kwargs.pop("compile_context", None)
+        # NOTE(RBLN): Static spec length used to pad the rejection-sample inputs
+        # to a fixed shape. The compiled `rbln_rejection_sample` is compiled with
+        # dynamic=False, so feeding it the per-step actual `metadata.max_spec_len`
+        # (which varies 1..num_spec_tokens under variable-length methods like
+        # ngram) forces a recompile for every distinct value. Padding to the
+        # config-fixed `num_spec_tokens` instead keeps the op shape static.
+        num_spec_tokens = kwargs.pop("num_spec_tokens", None)
+        assert num_spec_tokens is not None, "num_spec_tokens cannot be None."
+        self.num_spec_tokens = num_spec_tokens
         super().__init__(*args, **kwargs)
         rebel.manual_seed(seed)
         compile_context = resolve_compile_context(compile_context)
@@ -167,7 +176,12 @@ class RBLNRejectionSampler(RejectionSampler):
         output_token_ids = self.rejection_sample(
             metadata.draft_token_ids,
             metadata.num_draft_tokens,
-            metadata.max_spec_len,
+            # NOTE(RBLN): Pad to the fixed config spec length (not the per-step
+            # actual `metadata.max_spec_len`) so the compiled op shape stays
+            # static across steps. Correctness is unchanged: cu_num_draft_tokens
+            # / num_draft_tokens (actual) drive the gather, out_accept clamp and
+            # per-request output composition; the extra columns stay PLACEHOLDER.
+            self.num_spec_tokens,
             metadata.cu_num_draft_tokens,
             draft_probs,
             target_probs,
@@ -197,6 +211,9 @@ class RBLNRejectionSampler(RejectionSampler):
         draft_token_ids: torch.Tensor,
         # [batch_size]
         num_draft_tokens: list[int],
+        # Fixed pad length for the per-batch buffers (= num_spec_tokens), kept
+        # constant so the compiled rejection-sample op shape is static. NOT the
+        # per-step actual max draft count.
         max_spec_len: int,
         # [batch_size]
         cu_num_draft_tokens: torch.Tensor,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -383,6 +383,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     self.sampler,
                     seed=self.vllm_config.model_config.seed,
                     compile_context=self.compile_context,
+                    # Fixed spec length for static rejection-sample op shape.
+                    num_spec_tokens=self.speculative_config.num_speculative_tokens,
                 )
             else:
                 self.rejection_sampler = CPURejectionSampler(self.sampler)


### PR DESCRIPTION


<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

* in RBLN rejection sampler, prevent recompile according to variable number of drafts
instead of dynamic max num drafts, use static, fixed num_spec_tokens
---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
