### PR TITLE
test(lora): remove stale xfail on test_embeddings

### DIFF
--- a/tests/torch_compile/unit/v1/lora/test_layers.py
+++ b/tests/torch_compile/unit/v1/lora/test_layers.py
@@ -289,12 +289,6 @@ def rbln_compile(model):
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("vocab_size", [512, 32000, 64000, 128000])
 @pytest.mark.parametrize("stage", STAGES)
-@pytest.mark.xfail(
-    reason=(
-        "embedding LoRA path produces numerically incorrect outputs "
-        "compared with eager execution."
-    )
-)
 def test_embeddings(dist_init, num_loras, device, vocab_size, stage) -> None:
     torch.set_default_device(device)
     max_loras = 8


### PR DESCRIPTION
## Summary
- `test_embeddings`의 `@pytest.mark.xfail` 마커 제거

vLLM 0.22 환경에서 16개 parametrize 조합이 전부 XPASS — embedding LoRA 수치 불일치가 더 이상 재현되지 않아 마커가 stale 상태였습니다.

## Test
`pytest tests/torch_compile/unit/v1/lora/test_layers.py::test_embeddings` → 16 xpassed (마커 제거 전 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)