### PR TITLE
other(merge): resolve dev-0.22.0 ↔ dev conflict in fused_moe layer

### DIFF
--- a/tests/torch_compile/unit/test_rbln_envs.py
+++ b/tests/torch_compile/unit/test_rbln_envs.py
@@ -67,11 +67,6 @@ def test_rbln_envs():
         got {rbln_envs.VLLM_RBLN_ENFORCE_MODEL_FP32}"
     )
 
-    assert rbln_envs.VLLM_RBLN_MOE_CUSTOM_KERNEL, (
-        f"Expected VLLM_RBLN_MOE_CUSTOM_KERNEL to be True, \
-        got {rbln_envs.VLLM_RBLN_MOE_CUSTOM_KERNEL}"
-    )
-
     assert rbln_envs.VLLM_RBLN_DP_INPUT_ALL_GATHER, (
         f"Expected VLLM_RBLN_DP_INPUT_ALL_GATHER to be True, \
         got {rbln_envs.VLLM_RBLN_DP_INPUT_ALL_GATHER}"

--- a/vllm_rbln/model_executor/layers/fused_moe/all2all.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/all2all.py
@@ -1,0 +1,322 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""All2All dispatch helpers for MoE expert parallelism.
+
+This module implements the naive P2P all2all communication pattern
+used to dispatch tokens across data-parallel ranks in MoE layers. It contains:
+
+- Expert mask generation utilities
+- CCL custom ops for dispatch_send, all2all_x, and dispatch_receive kernels
+- The CCL group ID constant
+"""
+
+import numpy as np
+import torch
+from torch import Tensor
+
+# ---------------------------------------------------------------------------
+# Mask generation helpers
+# ---------------------------------------------------------------------------
+
+
+def generate_expert_mask(R: int, E: int) -> np.ndarray:
+    """Expert ownership mask (R, E). Local expert index or -1."""
+    mask = np.ones((R, E), dtype=int) * -1
+    local_cnt = E // R
+    for i in range(R):
+        for j in range(local_cnt):
+            mask[i, j + i * local_cnt] = j
+    return mask
+
+
+def prepare_send_mask_matrix(R: int, E: int) -> np.ndarray:
+    """(R, E) send mask — rank-independent expert-to-rank mapping.
+
+    send_mask[dst, e] = 1 if expert e belongs to rank dst.
+    """
+    expert_binary = np.where(generate_expert_mask(R, E) >= 0, 1, 0)
+    return expert_binary
+
+
+# ---------------------------------------------------------------------------
+# Custom op: ccl_dispatch_send
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op(
+    "rbln_custom_ops::ccl_dispatch_send",
+    mutates_args=(),
+)
+def ccl_dispatch_send(
+    hidden_states: Tensor,
+    router_logits: Tensor,
+    send_mask: Tensor,
+    rank_id: int,
+) -> tuple[Tensor, Tensor]:
+    t_dim = hidden_states.shape[0]
+    H_dim = hidden_states.shape[1]
+    R_dim = send_mask.shape[0]
+
+    send_logit = torch.matmul(send_mask, router_logits)  # (R, t)
+
+    send_buffer = torch.zeros(R_dim, t_dim, H_dim, dtype=hidden_states.dtype)
+    send_sizes = torch.zeros(R_dim, 64, dtype=torch.uint16)
+    for r in range(R_dim):
+        valid_idx = send_logit[r].nonzero(as_tuple=True)[0]
+        send_buffer[r, : valid_idx.shape[0]] = hidden_states[valid_idx]
+        send_sizes[r, 0] = valid_idx.shape[0]
+
+    return send_buffer, send_sizes
+
+
+@ccl_dispatch_send.register_fake
+def _ccl_dispatch_send_fake(
+    hidden_states: Tensor,
+    router_logits: Tensor,
+    send_mask: Tensor,
+    rank_id: int,
+) -> tuple[Tensor, Tensor]:
+    t_dim = hidden_states.shape[0]
+    H_dim = hidden_states.shape[1]
+    R_dim = send_mask.shape[0]
+    return (
+        torch.empty(R_dim, t_dim, H_dim, dtype=hidden_states.dtype),
+        torch.empty(R_dim, 64, dtype=torch.uint16),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Custom op: ccl_all2all_x_kernel  (naive P2P — no recv_sizes)
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op(
+    "rbln_custom_ops::ccl_all2all_x_kernel",
+    mutates_args=(),
+)
+def ccl_all2all_x_kernel(
+    send_buffer: Tensor,
+    send_sizes: Tensor,
+    ccl_world_size: int,
+    group_name: str,
+) -> Tensor:
+    # CPU stub — returns zeros of correct shape.
+    # Real communication happens on device via CCL runtime (rcclAllToAllX).
+    R = ccl_world_size
+    t = send_buffer.shape[1]
+    H = send_buffer.shape[2]
+    return torch.zeros(R, t, H, dtype=send_buffer.dtype)
+
+
+@ccl_all2all_x_kernel.register_fake
+def _ccl_all2all_x_kernel_fake(
+    send_buffer: Tensor,
+    send_sizes: Tensor,
+    ccl_world_size: int,
+    group_name: str,
+) -> Tensor:
+    R_dim = ccl_world_size
+    t_dim = send_buffer.shape[1]
+    H_dim = send_buffer.shape[2]
+    return torch.empty(R_dim, t_dim, H_dim, dtype=send_buffer.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Custom op: ccl_dispatch_receive
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op(
+    "rbln_custom_ops::ccl_dispatch_receive",
+    mutates_args=(),
+)
+def ccl_dispatch_receive(
+    recv_buffer: Tensor,
+    router_logits: Tensor,
+    hidden_states: Tensor,
+    rank_id: int,
+) -> Tensor:
+    R_dim = recv_buffer.shape[0]
+    t_dim = recv_buffer.shape[1]
+    H_dim = recv_buffer.shape[2]
+
+    # e-reduction: (e, T) → (T,) → (R, t)
+    recv_logit = router_logits.sum(dim=0).reshape(R_dim, t_dim)
+
+    # nonzero
+    t_padded = (t_dim + 63) // 64 * 64
+    recv_indices = torch.full((R_dim, t_padded), 65535, dtype=torch.uint16)
+    recv_sizes = torch.zeros(R_dim, 64, dtype=torch.uint16)
+    for r in range(R_dim):
+        valid_idx = recv_logit[r].nonzero(as_tuple=True)[0].to(torch.uint16)
+        recv_indices[r, : valid_idx.shape[0]] = valid_idx
+        recv_sizes[r, 0] = valid_idx.shape[0]
+
+    # scatter + replace rank_id slot
+    unpacked = torch.zeros(R_dim, t_dim, H_dim, dtype=recv_buffer.dtype)
+    for r in range(R_dim):
+        if r == rank_id:
+            unpacked[r] = hidden_states
+        else:
+            num_valid = int(recv_sizes[r, 0])
+            valid_idx = recv_indices[r, :num_valid].long()
+            unpacked[r, valid_idx] = recv_buffer[r, :num_valid]
+
+    return unpacked
+
+
+@ccl_dispatch_receive.register_fake
+def _ccl_dispatch_receive_fake(
+    recv_buffer: Tensor,
+    router_logits: Tensor,
+    hidden_states: Tensor,
+    rank_id: int,
+) -> Tensor:
+    R_dim = recv_buffer.shape[0]
+    t_dim = recv_buffer.shape[1]
+    H_dim = recv_buffer.shape[2]
+    return torch.empty(R_dim, t_dim, H_dim, dtype=recv_buffer.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Custom op: ccl_combine_send
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op(
+    "rbln_custom_ops::ccl_combine_send",
+    mutates_args=(),
+)
+def ccl_combine_send(
+    hidden_states: Tensor,
+    router_logits: Tensor,
+    rank_id: int,
+) -> tuple[Tensor, Tensor]:
+    """Combine send: pack per-rank expert outputs for all2all exchange.
+
+    Reverse of dispatch_receive — uses sum-reduction over local experts.
+
+    Args:
+        hidden_states: (R, t, H) — per-rank token embeddings after expert processing
+        router_logits: (e, T) — local expert routing logits, e=E/R, T=R*t
+        rank_id: this rank's ID
+
+    Returns:
+        send_buffer: (R, t, H) — packed hidden states per dest rank
+        send_sizes: (R, 64) — uint16 valid count per dest rank
+    """
+    R_dim = hidden_states.shape[0]
+    t_dim = hidden_states.shape[1]
+    H_dim = hidden_states.shape[2]
+
+    # e-reduction via sum: (e, T) -> (T,) -> (R, t)
+    send_logit = router_logits.sum(dim=0).reshape(R_dim, t_dim)
+
+    send_buffer = torch.zeros(R_dim, t_dim, H_dim, dtype=hidden_states.dtype)
+    send_sizes = torch.zeros(R_dim, 64, dtype=torch.uint16)
+    for r in range(R_dim):
+        valid_idx = send_logit[r].nonzero(as_tuple=True)[0]
+        send_buffer[r, : valid_idx.shape[0]] = hidden_states[r, valid_idx]
+        send_sizes[r, 0] = valid_idx.shape[0]
+
+    return send_buffer, send_sizes
+
+
+@ccl_combine_send.register_fake
+def _ccl_combine_send_fake(
+    hidden_states: Tensor,
+    router_logits: Tensor,
+    rank_id: int,
+) -> tuple[Tensor, Tensor]:
+    R_dim = hidden_states.shape[0]
+    t_dim = hidden_states.shape[1]
+    H_dim = hidden_states.shape[2]
+    return (
+        torch.empty(R_dim, t_dim, H_dim, dtype=hidden_states.dtype),
+        torch.empty(R_dim, 64, dtype=torch.uint16),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Custom op: ccl_combine_receive
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op(
+    "rbln_custom_ops::ccl_combine_receive",
+    mutates_args=(),
+)
+def ccl_combine_receive(
+    recv_buffer: Tensor,
+    router_logits: Tensor,
+    expert_map: Tensor,
+    hidden_states: Tensor,
+    rank_id: int,
+) -> Tensor:
+    """Combine receive: unpack recv_buffer and sum-reduce over R ranks.
+
+    Reverse of dispatch_send — uses expert_map @ router_logits matmul.
+
+    Args:
+        recv_buffer: (R, t, H) — packed received data per source rank
+        router_logits: (E, t) — this rank's routing logits (full experts)
+        expert_map: (R, E) — per-rank expert map (identity-based)
+        hidden_states: (t, H) — local rank's hidden states
+        rank_id: this rank's ID
+
+    Returns:
+        output: (t, H) — sum-reduced over R ranks
+    """
+    R_dim = recv_buffer.shape[0]
+    t_dim = recv_buffer.shape[1]
+    H_dim = recv_buffer.shape[2]
+
+    # recv_logit = expert_map @ router_logits -> (R, t)
+    recv_logit = torch.matmul(expert_map, router_logits)  # (R, t)
+
+    # nonzero -> recv_indices
+    t_padded = (t_dim + 63) // 64 * 64
+    recv_indices = torch.full((R_dim, t_padded), 65535, dtype=torch.uint16)
+    recv_sizes = torch.zeros(R_dim, 64, dtype=torch.uint16)
+    for r in range(R_dim):
+        valid_idx = recv_logit[r].nonzero(as_tuple=True)[0].to(torch.uint16)
+        recv_indices[r, : valid_idx.shape[0]] = valid_idx
+        recv_sizes[r, 0] = valid_idx.shape[0]
+
+    # scatter + replace rank_id slot
+    unpacked = torch.zeros(R_dim, t_dim, H_dim, dtype=recv_buffer.dtype)
+    for r in range(R_dim):
+        if r == rank_id:
+            unpacked[r] = hidden_states
+        else:
+            num_valid = int(recv_sizes[r, 0])
+            valid_idx = recv_indices[r, :num_valid].long()
+            unpacked[r, valid_idx] = recv_buffer[r, :num_valid]
+
+    # sum-reduce over R ranks
+    return unpacked.sum(dim=0)
+
+
+@ccl_combine_receive.register_fake
+def _ccl_combine_receive_fake(
+    recv_buffer: Tensor,
+    router_logits: Tensor,
+    expert_map: Tensor,
+    hidden_states: Tensor,
+    rank_id: int,
+) -> Tensor:
+    t_dim = recv_buffer.shape[1]
+    H_dim = recv_buffer.shape[2]
+    return torch.empty(t_dim, H_dim, dtype=recv_buffer.dtype)

--- a/vllm_rbln/model_executor/layers/fused_moe/layer.py
+++ b/vllm_rbln/model_executor/layers/fused_moe/layer.py
@@ -23,6 +23,11 @@ from vllm.model_executor.layers.fused_moe.layer import (
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
+from vllm_rbln.model_executor.layers.fused_moe.all2all import (  # noqa: F401 — registers custom ops on import
+    ccl_combine_receive,  # noqa: F811
+    ccl_combine_send,  # noqa: F811
+    prepare_send_mask_matrix,
+)
 
 logger = init_logger(__name__)
 
@@ -38,209 +43,68 @@ def fused_moe_custom__init__(self, *args, **kwargs):
     )
 
 
-# Define custom_moe_glu op based on environment variable
-# VLLM_RBLN_MOE_USE_OPT_KERNEL: uses topk, post_norm, expert_map parameters
-# VLLM_RBLN_MOE_CUSTOM_KERNEL: uses expert_select_count parameter
-if envs.VLLM_RBLN_MOE_USE_OPT_KERNEL:
+# Define custom_moe_glu op. The body below is the PyTorch reference
+# implementation; on device it is replaced by the RBLN custom kernel.
+@torch.library.custom_op(
+    "rbln_custom_ops::custom_moe_glu",
+    mutates_args=(),
+)
+def custom_moe_glu(
+    hidden_states: torch.Tensor,
+    gate_proj_weight: torch.Tensor,
+    up_proj_weight: torch.Tensor,
+    down_proj_weight: torch.Tensor,
+    masked_routing_weight: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+    gate_proj_bias: torch.Tensor | None = None,
+    up_proj_bias: torch.Tensor | None = None,
+    down_proj_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """
+    Customized MoE GLU operation (custom kernel version).
 
-    @torch.library.custom_op(
-        "rbln_custom_ops::custom_moe_glu",
-        mutates_args=(),
+    Expected tensor shapes:
+    - hidden_states: [batch * seq_len, hidden_size]
+    - gate_proj_weight: [num_experts, intermediate_size, hidden_size]
+    - up_proj_weight: [num_experts, intermediate_size, hidden_size]
+    - down_proj_weight: [num_experts, hidden_size, intermediate_size]
+    - masked_routing_weight: [num_experts, batch * seq_len]
+      (token dim may be padded to 64-align)
+
+    Returns:
+        torch.Tensor: [batch * seq_len, hidden_size]
+    """
+    assert hidden_states.dtype == masked_routing_weight.dtype, (
+        "hidden_states and masked_routing_weight must have the same dtype"
     )
-    def custom_moe_glu(
-        hidden_states: torch.Tensor,
-        gate_proj_weight: torch.Tensor,
-        up_proj_weight: torch.Tensor,
-        down_proj_weight: torch.Tensor,
-        masked_routing_weight: torch.Tensor,
-        scoring_func: str,
-        topk: int,
-        post_norm: bool,
-        expert_map: torch.Tensor | None = None,
-        gate_proj_bias: torch.Tensor | None = None,
-        up_proj_bias: torch.Tensor | None = None,
-        down_proj_bias: torch.Tensor | None = None,
-        dp_mask: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        """
-        Customized MoE GLU operation (optimized kernel version).
 
-        Expected tensor shapes:
-        - hidden_states: [batch * seq_len, hidden_size]
-        - gate_proj_weight: [num_experts, intermediate_size, hidden_size]
-        - up_proj_weight: [num_experts, intermediate_size, hidden_size]
-        - down_proj_weight: [num_experts, hidden_size, intermediate_size]
-        - masked_routing_weight: [batch * seq_len, num_experts]
-
-        Returns:
-            torch.Tensor: [batch * seq_len, hidden_size]
-        """
-        out = torch.zeros_like(hidden_states)
-        expert_cnt = gate_proj_weight.shape[0]
-        for i in range(expert_cnt):
-            gate = torch.nn.functional.linear(hidden_states, gate_proj_weight[i])
-            up = torch.nn.functional.linear(hidden_states, up_proj_weight[i])
-            mul = torch.nn.functional.silu(gate) * up
-            down = torch.nn.functional.linear(mul, down_proj_weight[i])
-            out += down * masked_routing_weight[:, i : i + 1]
-        return out
-
-    @custom_moe_glu.register_fake
-    def custom_moe_glu_fake(
-        hidden_states: torch.Tensor,
-        gate_proj_weight: torch.Tensor,
-        up_proj_weight: torch.Tensor,
-        down_proj_weight: torch.Tensor,
-        masked_routing_weight: torch.Tensor,
-        scoring_func: str,
-        topk: int,
-        post_norm: bool,
-        expert_map: torch.Tensor | None = None,
-        gate_proj_bias: torch.Tensor | None = None,
-        up_proj_bias: torch.Tensor | None = None,
-        down_proj_bias: torch.Tensor | None = None,
-        dp_mask: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        return torch.empty_like(hidden_states)
-
-else:
-
-    @torch.library.custom_op(
-        "rbln_custom_ops::custom_moe_glu",
-        mutates_args=(),
-    )
-    def custom_moe_glu(
-        hidden_states: torch.Tensor,
-        gate_proj_weight: torch.Tensor,
-        up_proj_weight: torch.Tensor,
-        down_proj_weight: torch.Tensor,
-        masked_routing_weight: torch.Tensor,
-        expert_select_count: torch.Tensor,
-        gate_proj_bias: torch.Tensor | None = None,
-        up_proj_bias: torch.Tensor | None = None,
-        down_proj_bias: torch.Tensor | None = None,
-        dp_mask: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        """
-        Customized MoE GLU operation (custom kernel version).
-
-        Expected tensor shapes:
-        - hidden_states: [batch * seq_len, hidden_size]
-        - gate_proj_weight: [num_experts, intermediate_size, hidden_size]
-        - up_proj_weight: [num_experts, intermediate_size, hidden_size]
-        - down_proj_weight: [num_experts, hidden_size, intermediate_size]
-        - masked_routing_weight: [batch * seq_len, num_experts]
-        - expert_select_count: [num_experts]
-
-        Returns:
-            torch.Tensor: [batch * seq_len, hidden_size]
-        """
-        out = torch.zeros_like(hidden_states)
-        expert_cnt = gate_proj_weight.shape[0]
-        for i in range(expert_cnt):
-            gate = torch.nn.functional.linear(hidden_states, gate_proj_weight[i])
-            up = torch.nn.functional.linear(hidden_states, up_proj_weight[i])
-            mul = torch.nn.functional.silu(gate) * up
-            down = torch.nn.functional.linear(mul, down_proj_weight[i])
-            out += down * masked_routing_weight[:, i : i + 1]
-        return out
-
-    @custom_moe_glu.register_fake
-    def custom_moe_glu_fake(
-        hidden_states: torch.Tensor,
-        gate_proj_weight: torch.Tensor,
-        up_proj_weight: torch.Tensor,
-        down_proj_weight: torch.Tensor,
-        masked_routing_weight: torch.Tensor,
-        expert_select_count: torch.Tensor,
-        gate_proj_bias: torch.Tensor | None = None,
-        up_proj_bias: torch.Tensor | None = None,
-        down_proj_bias: torch.Tensor | None = None,
-        dp_mask: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        return torch.empty_like(hidden_states)
+    num_tokens = hidden_states.shape[0]
+    out = torch.zeros_like(hidden_states)
+    expert_cnt = gate_proj_weight.shape[0]
+    # routing weight token dim may be padded to 64-align; slice to actual num_tokens
+    routing_t = masked_routing_weight.transpose(0, 1)[:num_tokens, :]  # [num_tokens, E]
+    for i in range(expert_cnt):
+        gate = torch.nn.functional.linear(hidden_states, gate_proj_weight[i])
+        up = torch.nn.functional.linear(hidden_states, up_proj_weight[i])
+        mul = torch.nn.functional.silu(gate) * up
+        down = torch.nn.functional.linear(mul, down_proj_weight[i])
+        out += down * routing_t[:, i : i + 1]
+    return out
 
 
-def unquantized_fused_moe_method_rbln(
-    self: UnquantizedFusedMoEMethod,
-    layer: FusedMoE,
-    x: torch.Tensor,
-    router_logits: torch.Tensor,
-):
-    # selected_experts
-    w1 = layer.w13_weight
-    w2 = layer.w2_weight
-
-    orig_shape = x.shape  # noqa: F841
-    hidden_size = x.shape[-1]
-    num_tokens = x.shape[:-1].numel()  # noqa: F841
-    num_experts = w1.shape[0]
-    intermediate_size = w2.shape[-1]
-    dtype = x.dtype
-    top_k = layer.top_k
-
-    hidden_states = x
-    gating_output = router_logits
-    topk_weights = gating_output.softmax(dim=-1, dtype=torch.float)
-    topk_weights = topk_weights.to(torch.float)
-    topk_weights, selected_experts = topk_weights.topk(top_k, dim=-1)
-    if layer.renormalize:
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
-
-    if layer.expert_map is not None:
-        selected_experts = layer.expert_map[selected_experts]
-
-    final_hidden_states = None
-
-    # 1. build expert_mask & expert_weights
-    # 2. FFN
-    # topk_weights, expert_weights, expert_mask.shape = [b, seq, top_k]
-    # NOTE - convert for loop scalar operation into tensor compare
-
-    # [1,num_tokens,hidden_size]
-    hidden_states = hidden_states.reshape(1, num_tokens, -1)
-    # [num_experts,1,1,1]
-    expert_idx_array = torch.arange(0, num_experts).reshape(num_experts, 1, 1, 1)
-    # [1,1,num_tokens,topk]
-    selected_experts_array = selected_experts.reshape(-1, 1, num_tokens, top_k)
-    # [num_experts,1,num_tokens,topk]
-    expert_mask_array = selected_experts_array == expert_idx_array
-    # [num_experts,1,num_tokens,topk]
-    topk_weights_array = topk_weights.reshape(-1, 1, num_tokens, top_k)
-    # [num_experts,1,num_tokens,1]
-    expert_weights_array = (topk_weights_array * expert_mask_array).sum(
-        dim=-1, keepdim=True
-    )
-    # [1,num_tokens,1]
-    temp_expert_weights = expert_weights_array[0]
-    # NOTE - make explicit dependence between hidden_states and expert_weights
-    # [1,num_tokens,hidden_size]
-    # [1,num_tokens,1] <- broadcast add
-    hidden_states = hidden_states + temp_expert_weights - temp_expert_weights
-    # [num_experts,1,num_tokens,1] -> [num_experts,1,num_tokens,hidden_size]
-    hidden_states = hidden_states.to(dtype)
-    expert_weights_array = expert_weights_array.broadcast_to(
-        (num_experts, 1, num_tokens, hidden_size)
-    ).to(dtype)
-    # solution1. make custom operation for expert loop
-    # solution2. add dummy use of expert_weights_array
-    for expert_idx in range(num_experts):
-        expert_w1 = w1[expert_idx]
-        expert_w2 = w2[expert_idx]
-        expert_weights = expert_weights_array[expert_idx]
-        x = F.linear(hidden_states, expert_w1)
-        gate = F.silu(x[..., :intermediate_size])
-        x = x[..., intermediate_size:] * gate
-        x = F.linear(x, expert_w2)
-
-        current_hidden_states = x * expert_weights
-        if final_hidden_states is None:
-            final_hidden_states = current_hidden_states
-        else:
-            final_hidden_states = final_hidden_states + current_hidden_states
-
-    assert final_hidden_states is not None
-    return final_hidden_states.reshape(orig_shape)
+@custom_moe_glu.register_fake
+def custom_moe_glu_fake(
+    hidden_states: torch.Tensor,
+    gate_proj_weight: torch.Tensor,
+    up_proj_weight: torch.Tensor,
+    down_proj_weight: torch.Tensor,
+    masked_routing_weight: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+    gate_proj_bias: torch.Tensor | None = None,
+    up_proj_bias: torch.Tensor | None = None,
+    down_proj_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states)
 
 
 def get_tokens_mask(num_tokens: int, left=1.0, right=0.0, device=None):
@@ -260,57 +124,108 @@ def get_tokens_mask(num_tokens: int, left=1.0, right=0.0, device=None):
     return tokens_mask
 
 
-# based on custom fused moe expert kernel
-def get_masked_routing_weights(router_logits, top_k, renormalize, expert_map):
-    # routing_weights: (batch * sequence_length, n_experts)
-    # selected_experts: (batch * sequence_length, top_k)
-    if renormalize:
-        router_logits = router_logits.to(torch.float)
-        selected_weights, selected_experts = torch.topk(router_logits, k=top_k, dim=-1)
-        selected_weights = torch.nn.functional.softmax(selected_weights, dim=1)
-    else:
-        routing_weights = torch.nn.functional.softmax(router_logits, dim=1)
-        routing_weights = routing_weights.to(torch.float)
-        selected_weights, selected_experts = torch.topk(
-            routing_weights, k=top_k, dim=-1
+def _apply_grouped_topk_torch(
+    router_logits_2d,  # [T, E] - raw logits (not transposed)
+    top_k,
+    num_expert_group,
+    topk_group,
+    scoring_func=None,
+    renormalize=True,
+    e_score_correction_bias=None,
+):
+    """Apply grouped topk routing in PyTorch.
+
+    Args:
+        router_logits_2d: [T, E] raw router logits.
+        top_k: Number of experts to select per token.
+        num_expert_group: Number of expert groups (G).
+        topk_group: Number of top groups to select per token.
+        scoring_func: "softmax", "sigmoid", or None.
+        renormalize: Whether to renormalize routing weights after topk.
+        e_score_correction_bias: Optional [E] bias tensor (used with sigmoid).
+
+    Returns:
+        masked_routing_weights: [E, T] tensor with topk routing weights.
+    """
+    T, E = router_logits_2d.shape
+    G = num_expert_group
+    epg = E // G  # experts per group
+
+    # Step 1: Apply scoring function & reshape to groups [T, G, E/G]
+    if scoring_func == "sigmoid":
+        router_logits_2d = torch.sigmoid(router_logits_2d)
+    grouped = router_logits_2d.reshape(T, G, epg)
+
+    # Step 2: Score each group by sum of top-2 expert values
+    group_top2_values, _ = torch.topk(grouped, 2, dim=2)  # [T, G, 2]
+    group_scores = group_top2_values.sum(dim=2)  # [T, G]
+
+    # Step 3: Select top topk_group groups per token
+    _, selected_group_idx = torch.topk(
+        group_scores, topk_group, dim=1
+    )  # [T, topk_group]
+
+    # Step 4: Gather selected groups [T, topk_group, epg]
+    idx_expanded = selected_group_idx.unsqueeze(-1).expand(-1, -1, epg)
+    gathered = torch.gather(grouped, 1, idx_expanded)  # [T, topk_group, epg]
+
+    if e_score_correction_bias is not None:
+        # --- with-bias branch ---
+        # Scatter into [T, G, epg] filled with -inf, then flatten to [E, T] so
+        # bias indices line up with expert IDs.
+        minus_inf = torch.full(
+            (T, G, epg),
+            float("-inf"),
+            dtype=gathered.dtype,
+            device=gathered.device,
         )
+        grouped_masked = minus_inf.scatter(1, idx_expanded, gathered)  # [T, G, epg]
+        # [T, G, epg] -> [G, epg, T] -> [E, T]
+        scores_t = grouped_masked.permute(1, 2, 0).reshape(E, T)
 
-    use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
-    if use_moe_tokens_mask:
-        tokens_mask = get_tokens_mask(
-            router_logits.shape[0], 1.0, 0.0, device=selected_weights.device
-        )
-        selected_weights = selected_weights * tokens_mask
+        scores_for_topk = scores_t + e_score_correction_bias.unsqueeze(1)
+        _, selected_experts = torch.topk(scores_for_topk, k=top_k, dim=0)
+        topk_weights = scores_t.gather(0, selected_experts)
+        if scoring_func == "softmax":
+            topk_weights = F.softmax(topk_weights, dim=0)
+        if renormalize:
+            topk_weights = topk_weights / topk_weights.sum(
+                dim=0, keepdim=True
+            ).clamp_min(1e-20)
 
-    n_expert = router_logits.shape[1]
-    if expert_map is not None:
-        expert_map_within_bounds = torch.where(
-            expert_map < 0, n_expert - 1, expert_map
-        ).to(torch.int64)
-        selected_experts = expert_map_within_bounds[selected_experts]
+        result = torch.zeros_like(scores_t)  # [E, T]
+        result.scatter_(0, selected_experts, topk_weights)
+        return result  # [E, T]
 
-    # masked_routing_weights=selected_weights w/ non selected indicies zeros
-    # selected_weights      = [..., top_k]
-    # masked_routing_weights= [..., n_experts], selected_experts has only value
-    masked_routing_weights = torch.zeros_like(router_logits, dtype=torch.float32)
-    masked_routing_weights.scatter_(1, selected_experts, selected_weights)
+    # --- no-bias branch ---
+    # Flatten gathered groups to [topk_group*epg, T] and run topk routing there.
+    gathered_flat = gathered.permute(1, 2, 0).reshape(-1, T)  # [topk_group*epg, T]
 
-    ## count selected tokens for each expert index from selected_experts
-    zeros = torch.zeros(n_expert, dtype=torch.int32)
-
-    if use_moe_tokens_mask:
-        ones = torch.ones_like(selected_experts, dtype=torch.int32)
-        tokens_mask = tokens_mask.to(torch.int32)
-        ones = ones * tokens_mask
-        ones = ones.view(-1)
+    if scoring_func == "softmax":
+        if renormalize:
+            # post_norm: topk first, then softmax on selected values
+            topk_weights, selected_experts = torch.topk(gathered_flat, k=top_k, dim=0)
+            topk_weights = F.softmax(topk_weights, dim=0)
+        else:
+            # pre_norm: softmax first, then topk
+            sw = F.softmax(gathered_flat, dim=0)
+            topk_weights, selected_experts = torch.topk(sw, k=top_k, dim=0)
     else:
-        ones = torch.ones_like(selected_experts.view(-1), dtype=torch.int32)
+        topk_weights, selected_experts = torch.topk(gathered_flat, k=top_k, dim=0)
+        if renormalize:
+            topk_weights = topk_weights / topk_weights.sum(
+                dim=0, keepdim=True
+            ).clamp_min(1e-20)
 
-    expert_select_count = torch.scatter_add(
-        zeros, dim=0, index=selected_experts.view(-1), src=ones
-    )
-
-    return masked_routing_weights, expert_select_count
+    routed_flat = torch.zeros_like(gathered_flat)  # [topk_group*epg, T]
+    routed_flat.scatter_(0, selected_experts, topk_weights)
+    # [topk_group*epg, T] -> [topk_group, epg, T] -> [T, topk_group, epg]
+    routed_t = routed_flat.reshape(topk_group, epg, T).permute(2, 0, 1)
+    # Scatter back to full expert space: [T, G, epg]
+    zeros = torch.zeros(T, G, epg, dtype=routed_t.dtype, device=routed_t.device)
+    result_t = zeros.scatter(1, idx_expanded, routed_t)
+    # [T, G, epg] -> [G, epg, T] -> [E, T]
+    return result_t.permute(1, 2, 0).reshape(E, T)
 
 
 def unquantized_fused_moe_method_custom(
@@ -319,83 +234,23 @@ def unquantized_fused_moe_method_custom(
     x: torch.Tensor,
     router_logits: torch.Tensor,
 ):
-    # selected_experts
+    # router_logits is now pre-computed masked_routing_weights
+    # (topk + softmax already done in fused_moe_forward_rbln)
     # w1 : gate_proj, w2 : down_proj, w3 : up_proj
     orig_shape = x.shape  # noqa: F841
     num_tokens = orig_shape[:-1].numel()  # noqa: F841
     intermediate_size = layer.w2_weight.shape[-1]
 
-    # w13_weight- merged weight for gate_proj(w1_weight) and up_proj (w3_weight)
-    # w2_weight - down_proj
-    # gate_proj_weight - first half, layer.w13_weight[:intermediate_size]
-    # up_proj_weight - second half, layer.w13_weight[intermediate_size:]
-    # down_proj_weights = layer.w2_weight
     gate_proj_weight = layer.w13_weight[:, :intermediate_size, :]
     up_proj_weight = layer.w13_weight[:, intermediate_size:, :]
     down_proj_weight = layer.w2_weight
 
     # expected tensor shape - [num_tokens, -1]
     hidden_states = x.reshape(num_tokens, -1)
-    router_logits = router_logits.reshape(num_tokens, -1)
+    masked_routing_weights = router_logits.reshape(num_tokens, -1)
 
-    masked_routing_weights, expert_select_count = get_masked_routing_weights(
-        router_logits, layer.top_k, layer.renormalize, layer.expert_map
-    )
-
-    tokens_mask = None
-    use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
-    if use_moe_tokens_mask:
-        tokens_mask = get_tokens_mask(num_tokens, device=router_logits.device)
-
-    final_hidden_states = torch.ops.rbln_custom_ops.custom_moe_glu(
-        hidden_states,
-        gate_proj_weight,
-        up_proj_weight,
-        down_proj_weight,
-        masked_routing_weights,
-        expert_select_count,
-        None,
-        None,
-        None,
-        tokens_mask,
-    )
-    return final_hidden_states.reshape(orig_shape)
-
-
-def unquantized_fused_optimize_moe_method_custom(
-    self: UnquantizedFusedMoEMethod,
-    layer: FusedMoE,
-    x: torch.Tensor,
-    router_logits: torch.Tensor,
-):
-    # selected_experts
-    # w1 : gate_proj, w2 : down_proj, w3 : up_proj
-    orig_shape = x.shape  # noqa: F841
-    num_tokens = orig_shape[:-1].numel()  # noqa: F841
-    intermediate_size = layer.w2_weight.shape[-1]
-
-    # w13_weight- merged weight for gate_proj(w1_weight) and up_proj (w3_weight)
-    # w2_weight - down_proj
-    # gate_proj_weight - first half, layer.w13_weight[:intermediate_size]
-    # up_proj_weight - second half, layer.w13_weight[intermediate_size:]
-    # down_proj_weights = layer.w2_weight
-    gate_proj_weight = layer.w13_weight[:, :intermediate_size, :]
-    up_proj_weight = layer.w13_weight[:, intermediate_size:, :]
-    down_proj_weight = layer.w2_weight
-
-    # expected tensor shape - [num_tokens, -1]
-    hidden_states = x.reshape(num_tokens, -1)
-    router_logits = router_logits.reshape(num_tokens, -1)
-
-    # Pre-score routing inputs at caller side; compiler custom op routing
-    # expects already-scored values (no sigmoid applied inside the kernel).
-    scoring_func = getattr(layer, "scoring_func", None)
-    assert scoring_func is not None, "FusedMoE.scoring_func must be set"
-    assert scoring_func in {"softmax", "sigmoid"}
-    if scoring_func == "sigmoid":
-        router_logits = torch.sigmoid(router_logits.to(torch.float32)).to(
-            router_logits.dtype
-        )
+    # transpose to [num_experts, num_tokens] for custom_moe_glu
+    masked_routing_weights_t = masked_routing_weights.transpose(0, 1)
 
     expert_map_const = None
     if layer.expert_map is not None:
@@ -404,29 +259,16 @@ def unquantized_fused_optimize_moe_method_custom(
         # PyTorch 2.10+ Dynamo when capture_scalar_outputs is false (pytorch#163807).
         expert_map_const = torch.tensor(layer.expert_map_const, dtype=torch.int32)
 
-    tokens_mask = None
-    use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
-    if use_moe_tokens_mask:
-        tokens_mask = get_tokens_mask(num_tokens, device=router_logits.device)
-
-    # optimum-rbln/src/optimum/rbln/transformers/models/qwen3_moe/
-    # qwen3_moe_architecture.py
-    # Keep argument order aligned with rebel custom_op schema:
-    # (..., router_logits, scoring_func, topk, post_norm, ...)
     final_hidden_states = torch.ops.rbln_custom_ops.custom_moe_glu(
         hidden_states,
         gate_proj_weight,
         up_proj_weight,
         down_proj_weight,
-        router_logits,
-        scoring_func,
-        layer.top_k,
-        layer.renormalize,
+        masked_routing_weights_t,
         expert_map_const,
         None,
         None,
         None,
-        tokens_mask,
     )
     return final_hidden_states.reshape(orig_shape)
 
@@ -438,103 +280,427 @@ def fused_moe_forward_rbln(
 
     if self.moe_parallel_config.dp_size > 1:
         org_hidden_shape = hidden_states.shape
+        R = self.moe_parallel_config.dp_size
+        num_tokens = org_hidden_shape[:-1].numel()
+        t = num_tokens
+        max_pad = get_forward_context().dp_metadata.max_pads_across_dp.shape[0]
+        H_dim = hidden_states.shape[-1]
 
-        # input broadcast - all DPs broadcast hidden_states & router_logits
-        # example) DP2, TP/EP2
-        # dp_group = {{0, 2}, {1, 3}}
-        # tp_group = {{0, 1}, {2, 3}}
-        # 1. initially, each DP hidden_states = [1, 128, 1024]
-        # 2. after multicast, all DPs hidden_states = [dp_size, 128, 1024]
-        # - all DP ranks broadcast inputs to process group
-        # 3. DP x TP/EP expert parallel
-        # ex) 0, 1, 2, 3 has its own hidden_states = [dp_size, 128, 1024]
-        # 4. dp_group all reduce - {0+2}, {1+3}, {0+2}, {1+3}
-        # 5. select each DP rank output
-        # 6. to_group all reduce - {0+2+1+3}, {0+2+1+3}, {0+2+1+3}, {0+2+1+3}
-        hidden_states = self.naive_multicast(hidden_states)
+        # Pad hidden_states to max_pad so all DP ranks have the same tensor size
+        hidden_flat = hidden_states.reshape(t, -1)  # [t, H]
+        if t < max_pad:
+            hidden_flat = F.pad(
+                hidden_flat, (0, 0, 0, max_pad - t), value=0.0
+            )  # [max_pad, H]
+
+        if envs.VLLM_RBLN_DISPATCH_ALL2ALL:
+            # --- Router DP path: local routing → all_gather logits ---
+            router_logits = router(hidden_states)
+            router_logits_2d = router_logits.reshape(t, -1)  # [t, E]
+            E = router_logits_2d.shape[-1]
+
+            if t < max_pad:
+                router_logits_2d = F.pad(
+                    router_logits_2d, (0, 0, 0, max_pad - t), value=0.0
+                )  # [max_pad, E]
+
+            # all_gather router_logits across DP ranks
+            rl_flat = router_logits_2d.reshape(1, -1)
+            all_rl_flat = get_dp_group().all_gather(rl_flat, dim=0)  # [R, max_pad*E]
+            all_router_logits = all_rl_flat.reshape(R * max_pad, E)  # [R*max_pad, E]
+        else:
+            # --- origin/dev path: all-gather hidden first → router on full tokens ---
+            # all-gather hidden_states across DP ranks (also serves as dispatch)
+            hidden_for_gather = hidden_flat.unsqueeze(0)  # [1, max_pad, H]
+            all_hidden = get_dp_group().all_gather(
+                hidden_for_gather, dim=0
+            )  # [R, max_pad, H]
+            gathered_hidden = all_hidden.reshape(R * max_pad, H_dim)
+
+            # Router on all gathered tokens (no Router DP)
+            all_router_logits = router(gathered_hidden)  # [R*max_pad, E]
+            all_router_logits = all_router_logits.reshape(R * max_pad, -1)
+            E = all_router_logits.shape[-1]
+
+        # --- topk + softmax on all gathered tokens ---
+        # [E, R*max_pad] for dim=0 topk (select top_k experts per token)
+        all_router_logits_t = all_router_logits.transpose(0, 1)  # [E, R*max_pad]
+
+        scoring_func = getattr(self, "scoring_func", "softmax")
+        e_score_correction_bias = getattr(self, "e_score_correction_bias", None)
+        use_grouped_topk = getattr(self, "use_grouped_topk", False)
+
+        if scoring_func == "sigmoid":
+            if use_grouped_topk:
+                masked_routing_weights = _apply_grouped_topk_torch(
+                    all_router_logits,
+                    self.top_k,
+                    self.num_expert_group,
+                    self.topk_group,
+                    scoring_func=scoring_func,
+                    renormalize=self.renormalize,
+                    e_score_correction_bias=e_score_correction_bias,
+                )  # [E, R*max_pad]
+            else:
+                # deepseekv3 style: minimax m2.5 (?)
+                # sigmoid scoring with optional e_score_correction_bias
+                scores = torch.sigmoid(all_router_logits)  # [R*max_pad, E]
+                scores_t = scores.transpose(0, 1)  # [E, R*max_pad]
+                scores_for_topk = scores_t
+                if e_score_correction_bias is not None:
+                    scores_for_topk = scores_t + e_score_correction_bias.unsqueeze(
+                        1
+                    )  # [E, 1]
+                _, selected_experts = torch.topk(scores_for_topk, k=self.top_k, dim=0)
+                topk_weights = scores_t.gather(
+                    0, selected_experts
+                )  # weights from original scores
+                if self.renormalize:
+                    topk_weights = topk_weights / topk_weights.sum(
+                        dim=0, keepdim=True
+                    ).clamp_min(1e-20)
+                masked_routing_weights = torch.zeros_like(
+                    all_router_logits_t
+                )  # [E, R*max_pad]
+                masked_routing_weights.scatter_(0, selected_experts, topk_weights)
+        elif scoring_func == "softmax":
+            if use_grouped_topk:
+                masked_routing_weights = _apply_grouped_topk_torch(
+                    all_router_logits,
+                    self.top_k,
+                    self.num_expert_group,
+                    self.topk_group,
+                    scoring_func=scoring_func,
+                    renormalize=self.renormalize,
+                    e_score_correction_bias=e_score_correction_bias,
+                )  # [E, R*max_pad]
+            else:
+                if self.renormalize:
+                    # post_norm: topk first, then softmax on selected values
+                    topk_weights, selected_experts = torch.topk(
+                        all_router_logits_t, k=self.top_k, dim=0
+                    )
+                    topk_weights = F.softmax(topk_weights, dim=0)
+                else:
+                    # pre_norm: softmax first, then topk
+                    routing_weights = F.softmax(all_router_logits_t, dim=0)
+                    topk_weights, selected_experts = torch.topk(
+                        routing_weights, k=self.top_k, dim=0
+                    )
+                masked_routing_weights = torch.zeros_like(
+                    all_router_logits_t
+                )  # [E, R*max_pad]
+                masked_routing_weights.scatter_(0, selected_experts, topk_weights)
+        else:
+            if use_grouped_topk:
+                masked_routing_weights = _apply_grouped_topk_torch(
+                    all_router_logits,
+                    self.top_k,
+                    self.num_expert_group,
+                    self.topk_group,
+                    scoring_func=scoring_func,
+                    renormalize=self.renormalize,
+                    e_score_correction_bias=e_score_correction_bias,
+                )  # [E, R*max_pad]
+            else:
+                topk_weights, selected_experts = torch.topk(
+                    all_router_logits_t, k=self.top_k, dim=0
+                )
+                if self.renormalize:
+                    topk_weights = topk_weights / topk_weights.sum(
+                        dim=0, keepdim=True
+                    ).clamp_min(1e-20)
+                masked_routing_weights = torch.zeros_like(
+                    all_router_logits_t
+                )  # [E, R*max_pad]
+                masked_routing_weights.scatter_(0, selected_experts, topk_weights)
+
+        # Apply token mask to zero out padded positions per DP rank
+        use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
+        if use_moe_tokens_mask:
+            tokens_mask = get_tokens_mask(
+                max_pad, device=masked_routing_weights.device
+            ).transpose(1, 0)  # [1, R*max_pad]
+            masked_routing_weights = masked_routing_weights * tokens_mask
+
+        # --- Pre-compute routing logit slices (used by all2all) ---
+        if envs.VLLM_RBLN_DISPATCH_ALL2ALL or envs.VLLM_RBLN_COMBINE_ALL2ALL:
+            # all_routing_3d: [E, R, max_pad] for CCL send/receive kernels
+            all_routing_3d = masked_routing_weights.reshape(E, R, max_pad)
+
+            # Prepare per-rank router_logits slices
+            e = E // R  # local experts per rank
+            # send_rl: [E, max_pad] — this rank's routing for all experts
+            send_rl = all_routing_3d[
+                :, self.moe_parallel_config.dp_rank, :
+            ]  # (E, max_pad)
+            # recv_rl: [e, R*max_pad] — local experts' routing across all ranks
+            e_start = self.moe_parallel_config.dp_rank * e
+            recv_rl = all_routing_3d[e_start : e_start + e].reshape(
+                e, R * max_pad
+            )  # (e, T)
+
+        # --- Step 4: Dispatch tokens across DP ranks ---
+        if envs.VLLM_RBLN_DISPATCH_ALL2ALL:
+            # --- all2all dispatch path ---
+            # hidden_flat: [max_pad, H] (already padded above)
+
+            # ccl_dispatch_send
+            send_buffer, send_sizes = torch.ops.rbln_custom_ops.ccl_dispatch_send(
+                hidden_flat,
+                send_rl,
+                self.send_mask,
+                self.moe_parallel_config.dp_rank,
+            )
+
+            # ccl_all2all_x (naive P2P)
+            recv_buffer = torch.ops.rbln_custom_ops.ccl_all2all_x_kernel(
+                send_buffer,
+                send_sizes,
+                self.moe_parallel_config.dp_size,
+                get_dp_group().unique_name,
+            )
+
+            # ccl_dispatch_receive → unpacked: [R, max_pad, H]
+            unpacked = torch.ops.rbln_custom_ops.ccl_dispatch_receive(
+                recv_buffer,
+                recv_rl,
+                hidden_flat,
+                self.moe_parallel_config.dp_rank,
+            )
+
+            # unpacked: [R, max_pad, H] → flatten to [R*max_pad, H] for MoE
+            gathered_hidden = unpacked.reshape(R * max_pad, H_dim)
+        # else: gathered_hidden was already computed via all-gather before router
+
+        # --- Step 5: MoE FFN computation ---
+        final_hidden_states = self.quant_method.apply(
+            layer=self,
+            x=gathered_hidden,
+            router_logits=masked_routing_weights,  # [E*max_pad, T_padded]
+        )
+
+        # --- Step 6: Combine partial results and extract this rank's output ---
+        if envs.VLLM_RBLN_COMBINE_ALL2ALL:
+            # --- all2all combine path ---
+            # MoE output: [R*max_pad, H] → [R, max_pad, H]
+            combine_3d = final_hidden_states.reshape(R, max_pad, H_dim)
+
+            # ccl_combine_send: pack expert outputs per destination rank
+            # recv_rl (e, T): local experts' routing → sum-reduction for dest indices
+            combine_send_buf, combine_send_sizes = (
+                torch.ops.rbln_custom_ops.ccl_combine_send(
+                    combine_3d,
+                    recv_rl,
+                    self.moe_parallel_config.dp_rank,
+                )
+            )
+
+            # ccl_all2all_x: all2all transfer of combined buffers
+            combine_recv_buf = torch.ops.rbln_custom_ops.ccl_all2all_x_kernel(
+                combine_send_buf,
+                combine_send_sizes,
+                self.moe_parallel_config.dp_size,
+                get_dp_group().unique_name,
+            )
+
+            # ccl_combine_receive: unpack + sum-reduce → (max_pad, H)
+            # send_rl (E, max_pad): this rank's full expert routing
+            # self.send_mask: reused as expert_map (same matrix)
+            final_hidden_states = torch.ops.rbln_custom_ops.ccl_combine_receive(
+                combine_recv_buf,
+                send_rl,
+                self.send_mask,
+                combine_3d[
+                    self.moe_parallel_config.dp_rank
+                ],  # local rank's own contribution
+                self.moe_parallel_config.dp_rank,
+            )
+            # final_hidden_states: (max_pad, H)
+        else:
+            # --- reduce_scatter / all_reduce combine path ---
+            if envs.VLLM_RBLN_MOE_REDUCE_SCATTER:
+                # reduce_scatter: each rank receives only its own summed portion
+                hidden_shape_dp = (-1, 1, H_dim)
+                all_hidden_states = final_hidden_states.reshape(hidden_shape_dp)
+                assert (
+                    all_hidden_states.shape[0] % self.moe_parallel_config.dp_size == 0
+                )
+
+                final_hidden_states = get_dp_group().reduce_scatter(
+                    all_hidden_states, dim=0
+                )
+                assert final_hidden_states.shape[0] == max_pad
+            else:
+                all_hidden_states = get_dp_group().all_reduce(final_hidden_states)
+                hidden_shape_dp = (-1, 1, H_dim)
+                final_hidden_states = all_hidden_states.reshape(hidden_shape_dp)
+
+                start = self.moe_parallel_config.dp_rank * max_pad
+                end = start + t
+                final_hidden_states = final_hidden_states[start:end]
+
+        final_hidden_states = final_hidden_states[:t]
+        final_hidden_states = final_hidden_states.reshape(org_hidden_shape)
+
+        return final_hidden_states
+
+    # --- DP == 1 path ---
     router_logits = router(hidden_states)
 
-    # Matrix multiply.
+    # topk + softmax → masked_routing_weights
+    orig_shape = hidden_states.shape
+    num_tokens = orig_shape[:-1].numel()
+    router_logits_2d = router_logits.reshape(num_tokens, -1)
+
+    # transpose to [E, t] for dim=0 topk (matching detach_topk branch)
+    scoring_func = getattr(self, "scoring_func", "softmax")
+    e_score_correction_bias = getattr(self, "e_score_correction_bias", None)
+    use_grouped_topk = getattr(self, "use_grouped_topk", False)
+
+    if scoring_func == "sigmoid":
+        if use_grouped_topk:
+            masked_routing_weights = _apply_grouped_topk_torch(
+                router_logits_2d,
+                self.top_k,
+                self.num_expert_group,
+                self.topk_group,
+                scoring_func=scoring_func,
+                renormalize=self.renormalize,
+                e_score_correction_bias=e_score_correction_bias,
+            )  # [E, t]
+        else:
+            router_logits_t = router_logits_2d.transpose(0, 1)  # [E, t]
+            # DeepSeek-V3 style: sigmoid scoring with optional e_score_correction_bias
+            scores_t = torch.sigmoid(router_logits_t)  # [E, t]
+            scores_for_topk = scores_t
+            if e_score_correction_bias is not None:
+                scores_for_topk = scores_t + e_score_correction_bias.unsqueeze(
+                    1
+                )  # [E, 1]
+            _, selected_experts = torch.topk(scores_for_topk, k=self.top_k, dim=0)
+            topk_weights = scores_t.gather(
+                0, selected_experts
+            )  # weights from original scores
+            if self.renormalize:
+                topk_weights = topk_weights / topk_weights.sum(
+                    dim=0, keepdim=True
+                ).clamp_min(1e-20)
+            masked_routing_weights = torch.zeros_like(router_logits_t)  # [E, t]
+            masked_routing_weights.scatter_(0, selected_experts, topk_weights)
+    elif scoring_func == "softmax":
+        if use_grouped_topk:
+            masked_routing_weights = _apply_grouped_topk_torch(
+                router_logits_2d,
+                self.top_k,
+                self.num_expert_group,
+                self.topk_group,
+                scoring_func=scoring_func,
+                renormalize=self.renormalize,
+                e_score_correction_bias=e_score_correction_bias,
+            )  # [E, t]
+        else:
+            router_logits_t = router_logits_2d.transpose(0, 1)  # [E, t]
+            if self.renormalize:
+                # post_norm: topk first, then softmax on selected values
+                topk_weights, selected_experts = torch.topk(
+                    router_logits_t, k=self.top_k, dim=0
+                )
+                topk_weights = F.softmax(topk_weights, dim=0)
+            else:
+                # pre_norm: softmax first, then topk
+                routing_weights = F.softmax(router_logits_t, dim=0)
+                topk_weights, selected_experts = torch.topk(
+                    routing_weights, k=self.top_k, dim=0
+                )
+            masked_routing_weights = torch.zeros_like(router_logits_t)  # [E, t]
+            masked_routing_weights.scatter_(0, selected_experts, topk_weights)
+    else:
+        if use_grouped_topk:
+            masked_routing_weights = _apply_grouped_topk_torch(
+                router_logits_2d,
+                self.top_k,
+                self.num_expert_group,
+                self.topk_group,
+                scoring_func=scoring_func,
+                renormalize=self.renormalize,
+                e_score_correction_bias=e_score_correction_bias,
+            )  # [E, t]
+        else:
+            router_logits_t = router_logits_2d.transpose(0, 1)  # [E, t]
+            topk_weights, selected_experts = torch.topk(
+                router_logits_t, k=self.top_k, dim=0
+            )
+            if self.renormalize:
+                topk_weights = topk_weights / topk_weights.sum(
+                    dim=0, keepdim=True
+                ).clamp_min(1e-20)
+            masked_routing_weights = torch.zeros_like(router_logits_t)  # [E, t]
+            masked_routing_weights.scatter_(0, selected_experts, topk_weights)
+
+    use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
+    if use_moe_tokens_mask:
+        tokens_mask = get_tokens_mask(
+            num_tokens, device=masked_routing_weights.device
+        ).transpose(1, 0)  # [1, t]
+
+        # [t, E] * [t, 1] (broadcast)
+        masked_routing_weights = masked_routing_weights * tokens_mask
+
+    # pass as [t, E] to quant_method.apply (it will be reshaped inside)
     final_hidden_states = self.quant_method.apply(
         layer=self,
         x=hidden_states,
-        router_logits=router_logits,
+        router_logits=masked_routing_weights,
     )
-
-    if self.moe_parallel_config.dp_size > 1:
-        # output all_reduce == dp all_reduce + tp all_reduce
-        if envs.VLLM_RBLN_MOE_REDUCE_SCATTER:
-            hidden_shape_dp = (-1, 1, org_hidden_shape[-1])
-            all_hidden_states = final_hidden_states.reshape(hidden_shape_dp)
-            assert all_hidden_states.shape[0] % self.moe_parallel_config.dp_size == 0
-
-            hidden_states = get_dp_group().reduce_scatter(all_hidden_states, dim=0)
-            max_pad = get_forward_context().dp_metadata.max_pads_across_dp.shape[0]
-            assert hidden_states.shape[0] == max_pad
-
-            num_tokens = org_hidden_shape[:-1].numel()  # noqa: F841
-            final_hidden_states = hidden_states[:num_tokens]
-        else:
-            all_hidden_states = get_dp_group().all_reduce(final_hidden_states)
-            hidden_shape_dp = (-1, 1, org_hidden_shape[-1])
-            final_hidden_states = all_hidden_states.reshape(hidden_shape_dp)
-
-            max_pad = get_forward_context().dp_metadata.max_pads_across_dp.shape[0]
-            num_tokens = org_hidden_shape[:-1].numel()  # noqa: F841
-            start = self.moe_parallel_config.dp_rank * max_pad
-            end = start + num_tokens
-            final_hidden_states = final_hidden_states[start:end]
-
-        final_hidden_states = final_hidden_states.reshape(org_hidden_shape)
 
     return final_hidden_states
 
 
-def fused_moe_naive_multicast_rbln(self: FusedMoE, x: torch.Tensor):
-    # as-is : [num_tokens, hidden_size]
-    # to-be : buffer = [data_parallel_size*batch, seq, hidden_size], broadcast
-    #         hidden = [batch, seq, hidden_size]
-    # x.shape = [1, seq, hidden_size]
-    # assert len(x.shape) == 3
-
-    x = x.reshape(1, -1, x.size(-1))
-    max_pad = get_forward_context().dp_metadata.max_pads_across_dp.shape[0]
-    num_tokens = x.size(1)
-    num_repeat = max_pad // num_tokens
-    # TODO: evaluate various padding approaches
-    x = x.repeat(num_repeat, 1, 1)
-    x = x.reshape(1, max_pad, -1)
-
-    if not envs.VLLM_RBLN_DP_INPUT_ALL_GATHER:
-        # each DP rank gather all inputs via torch.distributed.all_reduce
-        # broadcast(value) == all_reduce(value for me or zeros for others)
-        all_buffer = None
-        zeros = x - x
-        for rank in range(get_dp_group().world_size):
-            rank_tensor = x if rank == self.moe_parallel_config.dp_rank else zeros
-            all_buffer = (
-                torch.cat((all_buffer, rank_tensor), dim=0)
-                if all_buffer is not None
-                else rank_tensor
-            )
-        output = get_dp_group().all_reduce(all_buffer)
-        return output
-    else:
-        # gather all inputs via torch.distributed.all_gather
-        all_gather_buffer = get_dp_group().all_gather(x, dim=0)
-        return all_gather_buffer
+# ---------------------------------------------------------------------------
+# Monkeypatch: FusedMoE.__init__ — register all2all masks when DP > 1
+# ---------------------------------------------------------------------------
 
 
-FusedMoE.__init__ = fused_moe_custom__init__
+def _fused_moe_init_with_all2all(self, *args, **kwargs):
+    fused_moe_custom__init__(self, *args, **kwargs)
+    use_dispatch_all2all = envs.VLLM_RBLN_DISPATCH_ALL2ALL
+    use_combine_all2all = envs.VLLM_RBLN_COMBINE_ALL2ALL
+
+    if self.moe_parallel_config.dp_size > 1 and (
+        use_dispatch_all2all or use_combine_all2all
+    ):
+        R = self.moe_parallel_config.dp_size
+        E = self.global_num_experts
+        # send_mask doubles as expert_map for combine_receive (same matrix)
+        self.register_buffer(
+            "send_mask",
+            torch.tensor(
+                prepare_send_mask_matrix(R, E),
+                dtype=torch.float32,
+            ),
+        )
+        logger.info(
+            "[RBLN] FusedMoE all2all masks registered "
+            "(dispatch=%s, combine=%s): "
+            "R=%s, E=%s, "
+            "send_mask=%s",
+            use_dispatch_all2all,
+            use_combine_all2all,
+            R,
+            E,
+            self.send_mask.shape,
+        )
+    elif self.moe_parallel_config.dp_size > 1:
+        logger.info(
+            "[RBLN] FusedMoE using all-gather dispatch: R=%s, E=%s",
+            self.moe_parallel_config.dp_size,
+            self.global_num_experts,
+        )
+
+
+FusedMoE.__init__ = _fused_moe_init_with_all2all
 FusedMoE.forward_oot = fused_moe_forward_rbln
 
-if envs.VLLM_RBLN_MOE_USE_OPT_KERNEL:
-    logger.info("[RBLN] fused moe, RBLN optimize moe custom kernel")
-    UnquantizedFusedMoEMethod.apply = unquantized_fused_optimize_moe_method_custom
-elif envs.VLLM_RBLN_MOE_CUSTOM_KERNEL:
-    logger.info("[RBLN] fused moe, RBLN moe custom kernel")
-    UnquantizedFusedMoEMethod.apply = unquantized_fused_moe_method_custom
-else:
-    logger.info("[RBLN] fused moe, pytorch native kernel")
-    UnquantizedFusedMoEMethod.apply = unquantized_fused_moe_method_rbln
-FusedMoE.naive_multicast = fused_moe_naive_multicast_rbln
+logger.info("[RBLN] fused moe, RBLN moe custom kernel")
+UnquantizedFusedMoEMethod.apply = unquantized_fused_moe_method_custom

--- a/vllm_rbln/model_executor/layers/quantization/fp8.py
+++ b/vllm_rbln/model_executor/layers/quantization/fp8.py
@@ -53,9 +53,7 @@ from vllm.model_executor.parameter import (
 )
 from vllm.model_executor.utils import set_weight_attrs
 
-import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
-from vllm_rbln.model_executor.layers.fused_moe.layer import get_tokens_mask
 
 logger = init_logger(__name__)
 
@@ -402,20 +400,15 @@ def custom_moe_swiglu_group_dequantize(
     up_proj_scale: torch.Tensor,
     down_proj_weight: torch.Tensor,
     down_proj_scale: torch.Tensor,
-    router_logits: torch.Tensor,
-    scoring_func: str,
+    masked_routing_weights: torch.Tensor,
     group_size: torch.Tensor,
-    topk: int,
-    post_norm: bool = True,
-    e_score_correction_bias: torch.Tensor | None = None,
     gate_proj_bias: torch.Tensor | None = None,
     up_proj_bias: torch.Tensor | None = None,
     down_proj_bias: torch.Tensor | None = None,
     expert_map: torch.Tensor | None = None,
-    dp_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
-    Customized MoE SwiGLU operation.
+    Customized MoE SwiGLU operation with pre-computed routing weights.
 
     Expected tensor shapes:
     - hidden_states: [batch*seq_len, hidden_size]
@@ -425,13 +418,13 @@ def custom_moe_swiglu_group_dequantize(
     - up_proj_scale: [num_experts, intermediate_size, hidden_size // 128]
     - down_proj_weight: [num_experts, intermediate_size, hidden_size]
     - down_proj_scale: [num_experts, hidden_size, intermediate_size // 128]
-    - router_logits: [batch*seq_len, num_experts]
+    - masked_routing_weights: [num_experts, num_tokens]
+      (token dim may be padded to 64-align)
     - group_size: group size for weight scale
-    - topk: top k experts to select
-    - e_score_correction_bias:
     - gate_proj_bias: [num_experts, intermediate_size]
     - up_proj_bias: [num_experts, intermediate_size]
     - down_proj_bias: [num_experts, hidden_size]
+    - expert_map: [num_experts] mapping global -> local expert index (-1 for non-local)
 
     Returns:
         Tensor: [batch * seq_len, hidden_size]
@@ -476,57 +469,24 @@ def custom_moe_swiglu_group_dequantize(
         down_proj_weight, down_proj_scale, in_block_size, down_out_block
     )
 
-    routing_scores = router_logits.float()
-    # Match rebel router behavior:
-    # - softmax: select topk on logits (post_norm) or on softmax weights (pre_norm)
-    # - sigmoid: select topk on sigmoid(+optional bias), optional post topk renorm
-    if scoring_func == "softmax":
-        if post_norm:
-            _, topk_ids = torch.topk(routing_scores, topk, dim=-1, sorted=False)
-            topk_values = routing_scores.gather(1, topk_ids)
-            topk_weights = torch.softmax(topk_values, dim=-1)
-        else:
-            all_weights = torch.softmax(routing_scores, dim=-1)
-            _, topk_ids = torch.topk(all_weights, topk, dim=-1, sorted=False)
-            topk_weights = all_weights.gather(1, topk_ids)
-    else:
-        # Sigmoid mode expects pre-scored inputs from caller.
-        routing_weights = routing_scores
-        scores_for_choice = routing_weights
-        if e_score_correction_bias is not None:
-            scores_for_choice = scores_for_choice + e_score_correction_bias
-        _, topk_ids = torch.topk(scores_for_choice, topk, dim=-1, sorted=False)
-        topk_weights = routing_weights.gather(1, topk_ids)
-        if post_norm:
-            topk_weights = topk_weights / topk_weights.sum(
-                dim=-1, keepdim=True
-            ).clamp_min(1e-20)
-
-    topk_weights = topk_weights.to(hidden_states.dtype)
-
-    if dp_mask is not None:
-        topk_weights = topk_weights * dp_mask.to(topk_weights.dtype)
-
+    num_tokens, hidden_size = hidden_states.shape
     num_experts = gate_proj_weight_dq.shape[0]
-    if expert_map is not None:
-        safe_expert_map = torch.where(expert_map < 0, num_experts - 1, expert_map).to(
-            topk_ids.dtype
-        )
-        topk_ids = safe_expert_map[topk_ids]
+    dtype = hidden_states.dtype
 
-    final_hidden_states = torch.zeros_like(hidden_states)
-    expert_mask = torch.nn.functional.one_hot(
-        topk_ids, num_classes=num_experts
-    ).permute(2, 1, 0)
-    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero(as_tuple=False)
+    # masked_routing_weights: [E, T_padded]
+    routing_t = masked_routing_weights[:, :num_tokens]
 
-    for expert_idx_tensor in expert_hit:
-        expert_idx = int(expert_idx_tensor.item())
-        topk_slot, token_idx = torch.where(expert_mask[expert_idx])
-        if token_idx.numel() == 0:
+    final_hidden_states = torch.zeros(num_tokens, hidden_size, dtype=dtype)
+
+    for expert_idx in range(num_experts):
+        expert_weights = routing_t[expert_idx]  # [T]
+        token_indices = expert_weights.nonzero(as_tuple=True)[0]
+        if token_indices.numel() == 0:
             continue
 
-        current_state = hidden_states[token_idx]
+        weights = expert_weights[token_indices]  # [num_selected]
+        current_state = hidden_states[token_indices]  # [num_selected, hidden_size]
+
         gate = torch.nn.functional.linear(
             current_state,
             gate_proj_weight_dq[expert_idx],
@@ -543,9 +503,9 @@ def custom_moe_swiglu_group_dequantize(
             down_proj_weight_dq[expert_idx],
             down_proj_bias[expert_idx] if down_proj_bias is not None else None,
         )
-        current_hidden_states = down * topk_weights[token_idx, topk_slot, None]
+        current_hidden_states = down * weights.unsqueeze(-1)
         final_hidden_states.index_add_(
-            0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
+            0, token_indices, current_hidden_states.to(dtype)
         )
 
     return final_hidden_states
@@ -560,17 +520,12 @@ def custom_moe_swiglu_group_dequantize_fake(
     up_proj_scale: torch.Tensor,
     down_proj_weight: torch.Tensor,
     down_proj_scale: torch.Tensor,
-    router_logits: torch.Tensor,
-    scoring_func: str,
+    masked_routing_weights: torch.Tensor,
     group_size: torch.Tensor,
-    topk: int,
-    post_norm: bool = True,
-    e_score_correction_bias: torch.Tensor | None = None,
     gate_proj_bias: torch.Tensor | None = None,
     up_proj_bias: torch.Tensor | None = None,
     down_proj_bias: torch.Tensor | None = None,
     expert_map: torch.Tensor | None = None,
-    dp_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 
@@ -853,21 +808,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         **kwargs: object,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         # NOTE(RBLN): fp8 MoE implementation uses custom op
+        # router_logits is now pre-computed masked_routing_weights
+        # (topk + softmax already done in fused_moe_forward_rbln)
         orig_shape = x.shape  # noqa: F841
         num_tokens = orig_shape[:-1].numel()  # noqa: F841
         hidden_states = x.reshape(num_tokens, -1)
-        router_logits = router_logits.reshape(num_tokens, -1)
-
-        # Pre-score routing inputs at caller side; compiler custom op routing
-        # expects already-scored values (no sigmoid applied inside the kernel).
-        scoring_func = getattr(layer, "scoring_func", None)
-        assert scoring_func is not None, "FusedMoE.scoring_func must be set"
-        assert scoring_func in {"softmax", "sigmoid"}
-        if scoring_func == "sigmoid":
-            router_logits = torch.sigmoid(router_logits.to(torch.float32)).to(
-                router_logits.dtype
-            )
-
+        masked_routing_weights = router_logits
         intermediate_size = layer.w2_weight.shape[-1]
 
         # w13_weight: merged gate(up) weights, w2_weight: down weights
@@ -886,19 +832,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             :, scale_intermediate_size:, :
         ]
 
-        e_score_correction_bias = kwargs.get("e_score_correction_bias")
-        if e_score_correction_bias is None:
-            e_score_correction_bias = getattr(layer, "e_score_correction_bias", None)
-
         expert_map_const = None
         if layer.expert_map is not None:
             assert getattr(layer, "expert_map_const", None) is not None
             expert_map_const = torch.tensor(layer.expert_map_const, dtype=torch.int32)
-
-        tokens_mask = None
-        use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
-        if use_moe_tokens_mask:
-            tokens_mask = get_tokens_mask(num_tokens, device=router_logits.device)
 
         final_hidden_states = (
             torch.ops.rbln_custom_ops.custom_moe_swiglu_group_dequantize(
@@ -909,19 +846,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 up_proj_weight_scale,
                 down_proj_weight,
                 down_proj_weight_scale,
-                router_logits,
-                # Keep arg order aligned with rebel custom_op schema:
-                # (..., router_logits, scoring_func, group_size, topk, post_norm, ...)
-                scoring_func,
+                masked_routing_weights,
                 torch.tensor(self.weight_block_size[1], dtype=torch.int32),
-                layer.top_k,
-                layer.renormalize,
-                e_score_correction_bias,
                 None,  # gate_proj_bias
                 None,  # up_proj_bias
                 None,  # down_proj_bias
                 expert_map_const,
-                tokens_mask,
             )
         )
 

--- a/vllm_rbln/model_executor/layers/quantization/mxfp4.py
+++ b/vllm_rbln/model_executor/layers/quantization/mxfp4.py
@@ -26,7 +26,6 @@ from vllm.model_executor.utils import set_weight_attrs
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
-from vllm_rbln.model_executor.layers.fused_moe.layer import get_tokens_mask
 
 logger = init_logger(__name__)
 
@@ -105,14 +104,10 @@ def custom_moe_glu_mxfp4(
     down_proj_blocks: torch.Tensor,
     down_proj_scales: torch.Tensor,
     down_proj_bias: torch.Tensor,
-    router_logits: torch.Tensor,
-    scoring_func: str,
+    masked_routing_weights: torch.Tensor,
     alpha: torch.Tensor,
     limit: torch.Tensor,
-    k: int,
-    post_norm: bool = True,
     expert_map: torch.Tensor | None = None,
-    dp_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     MoE GLU operation for GPT-OSS with mxfp4 quantization and swigluoai activation.
@@ -128,7 +123,8 @@ def custom_moe_glu_mxfp4(
     - down_proj_blocks: uint8 [num_experts, hidden_size, intermediate_size // 2]
     - down_proj_scales: [num_experts, hidden_size, intermediate_size // 32]
     - down_proj_bias: [num_experts, hidden_size]
-    - router_logits: [num_tokens, num_experts]
+    - masked_routing_weights: [num_experts, num_tokens]
+      (token dim may be padded to 64-align)
     - alpha: [], constant
     - limit: [], constant
     - expert_map: [num_experts],
@@ -138,7 +134,6 @@ def custom_moe_glu_mxfp4(
     Returns:
         torch.Tensor: [num_tokens, hidden_size]
     """
-
     if envs.VLLM_RBLN_COMPILE_MODEL:
         return torch.empty_like(hidden_states)
 
@@ -152,30 +147,11 @@ def custom_moe_glu_mxfp4(
     alpha_val = alpha.item()
     limit_val = limit.item()
 
-    routing_scores = router_logits.float()
-    # Match rebel router behavior:
-    # - softmax: score->topk, with optional pre/post normalization
-    # - sigmoid: sigmoid(score)->topk, optional renormalization on selected topk
-    if scoring_func == "sigmoid":
-        # Sigmoid mode expects pre-scored inputs from caller.
-        routing_weights_full = routing_scores
-        _, top_k_indices = torch.topk(routing_weights_full, k, dim=-1)
-        routing_weights = torch.gather(
-            routing_weights_full, dim=-1, index=top_k_indices
-        )
-        if post_norm:
-            routing_weights = routing_weights / routing_weights.sum(
-                dim=-1, keepdim=True
-            ).clamp_min(1e-20)
-    else:
-        top_k_values, top_k_indices = torch.topk(routing_scores, k, dim=-1)
-        if post_norm:
-            routing_weights = torch.softmax(top_k_values, dim=-1)
-        else:
-            all_weights = torch.softmax(routing_scores, dim=-1)
-            routing_weights = torch.gather(all_weights, dim=-1, index=top_k_indices)
-
-    # Initialize output
+    # routing weight token dim may be padded to 64-align; slice to actual num_tokens
+    # masked_routing_weights: [E, num_tokens(+pad)] → [num_tokens, E]
+    routing_t = masked_routing_weights.transpose(0, 1)[
+        :num_tokens, :
+    ]  # [num_tokens, E]
     output = torch.zeros(num_tokens, hidden_size, dtype=dtype)
 
     # Dequantize all expert weights once
@@ -203,15 +179,14 @@ def custom_moe_glu_mxfp4(
             global_expert_idx = local_expert_idx
 
         # Find tokens routed to this expert
-        # top_k_indices: [num_tokens, k]
-        expert_mask = top_k_indices == global_expert_idx  # [num_tokens, k]
-        token_indices, k_indices = expert_mask.nonzero(as_tuple=True)
+        expert_weights = routing_t[:, global_expert_idx]  # [num_tokens]
+        token_indices = expert_weights.nonzero(as_tuple=True)[0]
 
         if len(token_indices) == 0:
             continue
 
         # Get routing weights for these tokens
-        weights = routing_weights[token_indices, k_indices]  # [num_selected_tokens]
+        weights = expert_weights[token_indices]  # [num_selected_tokens]
 
         # Get hidden states for selected tokens
         selected_hidden = hidden_states[token_indices]  # [num_selected, hidden_size]
@@ -249,14 +224,10 @@ def custom_moe_glu_mxfp4_fake(
     down_proj_blocks: torch.Tensor,
     down_proj_scales: torch.Tensor,
     down_proj_bias: torch.Tensor,
-    router_logits: torch.Tensor,
-    scoring_func: str,
+    masked_routing_weights: torch.Tensor,
     alpha: torch.Tensor,
     limit: torch.Tensor,
-    k: int,
-    post_norm: bool = True,
     expert_map: torch.Tensor | None = None,
-    dp_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 
@@ -408,39 +379,20 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         x: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        # refer to custom_moe_glu
+        # router_logits is now pre-computed masked_routing_weights
+        # (topk + softmax already done in fused_moe_forward_rbln)
         orig_shape = x.shape  # noqa: F841
         num_tokens = orig_shape[:-1].numel()  # noqa: F841
         hidden_states = x.reshape(num_tokens, -1)
-        router_logits = router_logits.reshape(num_tokens, -1)
-        # x = x.view(-1, self.hidden_size)
-        # router_logits = router_logits.view(-1, self.num_experts)
-        # router_logits = router_logits.view(-1, self.moe.num_experts)
-
-        # Pre-score routing inputs at caller side; compiler custom op routing
-        # expects already-scored values (no sigmoid applied inside the kernel).
-        scoring_func = getattr(layer, "scoring_func", None)
-        assert scoring_func is not None, "FusedMoE.scoring_func must be set"
-        assert scoring_func in {"softmax", "sigmoid"}
-        if scoring_func == "sigmoid":
-            router_logits = torch.sigmoid(router_logits.to(torch.float32)).to(
-                router_logits.dtype
-            )
+        masked_routing_weights = router_logits
 
         if layer.activation == MoEActivation.SWIGLUOAI:
             expert_map_const = None
             if layer.expert_map is not None:
                 assert getattr(layer, "expert_map_const", None) is not None
                 expert_map_const = torch.tensor(
-                    layer.expert_map_const,
-                    dtype=torch.int32,
-                    device=router_logits.device,
+                    layer.expert_map_const, dtype=torch.int32
                 )
-
-            tokens_mask = None
-            use_moe_tokens_mask = envs.VLLM_RBLN_USE_MOE_TOKENS_MASK
-            if use_moe_tokens_mask:
-                tokens_mask = get_tokens_mask(num_tokens, device=router_logits.device)
 
             final_hidden_states = torch.ops.rbln_custom_ops.custom_moe_glu_mxfp4(
                 hidden_states,
@@ -453,14 +405,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 layer.down_proj_blocks,
                 layer.down_proj_scales,
                 layer.down_proj_bias,
-                router_logits,
-                scoring_func,
+                masked_routing_weights,
                 self.swiglu_alpha,
                 self.swiglu_limit,
-                layer.top_k,
-                layer.renormalize,
                 expert_map_const,
-                tokens_mask,
             )
         else:
             raise NotImplementedError(layer.activation)

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
     VLLM_RBLN_DP_IMPL: str = "padded_decode"
     VLLM_RBLN_USE_MOE_TOKENS_MASK: bool = True
     VLLM_RBLN_ENFORCE_MODEL_FP32: bool = False
-    VLLM_RBLN_MOE_CUSTOM_KERNEL: bool = True
-    VLLM_RBLN_MOE_USE_OPT_KERNEL: bool = True
     VLLM_RBLN_DP_INPUT_ALL_GATHER: bool = True
     VLLM_RBLN_LOGITS_ALL_GATHER: bool = True
     VLLM_RBLN_NUM_RAY_NODES: int = 1
@@ -47,6 +45,8 @@ if TYPE_CHECKING:
     VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS: list[int] = []
     VLLM_RBLN_USE_CUSTOM_KERNEL: bool = False
     VLLM_RBLN_AUTO_PORT: bool = True
+    VLLM_RBLN_DISPATCH_ALL2ALL: bool = False
+    VLLM_RBLN_COMBINE_ALL2ALL: bool = False
     VLLM_RBLN_MOE_REDUCE_SCATTER: bool = False
     VLLM_RBLN_SUB_BLOCK_CACHE: bool = True
     VLLM_RBLN_USE_DEVICE_TENSOR: bool = False
@@ -204,20 +204,6 @@ environment_variables = {
             in ("true", "1")
         )
     ),
-    # use moe custom kernel, by default disabled
-    "VLLM_RBLN_MOE_CUSTOM_KERNEL": (
-        lambda: (
-            os.environ.get("VLLM_RBLN_MOE_CUSTOM_KERNEL", "True").lower()
-            in ("true", "1")
-        )
-    ),
-    # enable moe optimization if RBLN_MoE_OPT is set to 1
-    "VLLM_RBLN_MOE_USE_OPT_KERNEL": (
-        lambda: (
-            os.environ.get("VLLM_RBLN_MOE_USE_OPT_KERNEL", "True").lower()
-            in ("true", "1")
-        )
-    ),
     # DP_INPUT_ALL_GATHER, use DP input all_gather
     "VLLM_RBLN_DP_INPUT_ALL_GATHER": (
         lambda: (
@@ -282,6 +268,20 @@ environment_variables = {
     ),
     "VLLM_RBLN_PROFILER": (
         lambda: os.environ.get("RBLN_PROFILER", "False").lower() in ("true", "1")
+    ),
+    # Use all2all dispatch instead of all-gather for MoE DP dispatch
+    "VLLM_RBLN_DISPATCH_ALL2ALL": (
+        lambda: (
+            os.environ.get("VLLM_RBLN_DISPATCH_ALL2ALL", "False").lower()
+            in ("true", "1")
+        )
+    ),
+    # Use all2all combine instead of reduce-scatter for MoE DP combine
+    "VLLM_RBLN_COMBINE_ALL2ALL": (
+        lambda: (
+            os.environ.get("VLLM_RBLN_COMBINE_ALL2ALL", "False").lower()
+            in ("true", "1")
+        )
     ),
     # Enable sub-block prefix caching.
     # Sub-block size equals max_num_batched_tokens (prefill chunk size).


### PR DESCRIPTION
## Why

PR #669 (`dev-0.22.0` → `dev`) is `CONFLICTING` because `dev` advanced with #605 (`feature: enable all2all communication for MoE model`) which is not yet in `dev-0.22.0`. The only conflicting file is `vllm_rbln/model_executor/layers/fused_moe/layer.py`.

This PR merges `origin/dev` into `dev-0.22.0`, resolving the conflict so #669 can merge cleanly.

## The conflict

Both sides changed the bottom monkeypatch block that wires `FusedMoE`:

- **`dev` (#605)** wrapped `__init__` with `_fused_moe_init_with_all2all` to register the `send_mask` buffer when `dp_size > 1`, and dispatched via `FusedMoE.forward_oot = fused_moe_forward_rbln`.
- **`dev-0.22.0`** kept `FusedMoE.__init__ = fused_moe_custom__init__` but switched to `FusedMoE.forward = fused_moe_forward_rbln`, because in vLLM 0.22 `FusedMoE` is a `PluggableLayer` and no longer dispatches through `CustomOp.forward_oot`.

## Resolution

Combine both: keep `dev`'s `_fused_moe_init_with_all2all` wrapper (the all2all forward path at lines ~296–513 calls `self.send_mask`, so the buffer registration must stay), and keep `dev-0.22.0`'s vLLM 0.22 `FusedMoE.forward` override instead of `forward_oot`.

```python
FusedMoE.__init__ = _fused_moe_init_with_all2all
FusedMoE.forward = fused_moe_forward_rbln   # vLLM 0.22 PluggableLayer
```

All other hunks (the all2all imports and forward-path code) auto-merged cleanly. `py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)