### PR TITLE
fix(worker): unquote CompilationTimes return annotation

### DIFF
--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -472,7 +472,7 @@ class RBLNWorker(WorkerBase):
         )
         self._rbln_cpu_affinity_applied = True
 
-    def compile_or_warm_up_model(self) -> "CompilationTimes":
+    def compile_or_warm_up_model(self) -> CompilationTimes:
         st = time.perf_counter()
         if self.parallel_config.data_parallel_size > 1:
             if envs.VLLM_RBLN_DP_IMPL == "padded_decode":


### PR DESCRIPTION
## Problem

`tests/torch_compile/unit/v1/worker/test_rbln_worker.py::TestInterfaceCompliance::test_compile_or_warm_up_model_returns` fails:

```
AssertionError: assert ('CompilationTimes' is CompilationTimes or 'CompilationTimes' == <class 'inspect._empty'>)
 +  where 'CompilationTimes' = <Signature (self) -> 'CompilationTimes'>.return_annotation
```

The test checks that `RBLNWorker.compile_or_warm_up_model`'s return annotation is the `CompilationTimes` class (or `inspect.Parameter.empty`):

```python
sig = inspect.signature(RBLNWorker.compile_or_warm_up_model)
assert (
    sig.return_annotation is CompilationTimes
    or sig.return_annotation == inspect.Parameter.empty
)
```

## Cause

Commit `8513cf73` ("fix(worker): quote CompilationTimes return annotation") changed the annotation to a string literal:

```python
def compile_or_warm_up_model(self) -> "CompilationTimes":
```

`inspect.signature()` does not resolve string annotations, so `return_annotation` became the string `'CompilationTimes'` rather than the class — failing the `is CompilationTimes` check.

## Fix

`CompilationTimes` is imported unconditionally at module top level (`from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase`), and the module has no `from __future__ import annotations`, so the quoting was unnecessary. Unquote it:

```python
def compile_or_warm_up_model(self) -> CompilationTimes:
```

Now `inspect.signature(...).return_annotation` resolves to the `CompilationTimes` class and the test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)