### PR TITLE
fix(scheduler): clear stranded KV-block stash on preemption

### DIFF
--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -229,6 +229,47 @@ def test_stranded_blocks_cleaned_up_on_finish():
     assert req_a.request_id not in scheduler._stranded_new_blocks
 
 
+def test_stranded_blocks_cleaned_up_on_preempt():
+    """A stashed block delta must be dropped when the request is preempted.
+
+    Preemption frees ALL of the request's blocks (including the stashed one)
+    and returns the request to the waiting queue. If the stash survived, the
+    request could resume, re-enter the decode batch, and have a now-freed
+    (possibly reused) block id re-emitted into its block table.
+    """
+    block_size = 16
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_num_seqs=4,
+        block_size=block_size,
+        num_blocks=10000,
+    )
+
+    req_a = create_requests(
+        num_requests=1, num_tokens=block_size, block_size=block_size, req_ids=["A"]
+    )[0]
+    scheduler.add_request(req_a)
+    out1 = scheduler.schedule()
+    scheduler.update_from_output(out1, create_runner_output(out1, 1))
+
+    req_b = create_requests(
+        num_requests=1, num_tokens=block_size, block_size=block_size, req_ids=["B"]
+    )[0]
+    scheduler.add_request(req_b)
+    scheduler.schedule()
+    # req_a evicted at the boundary -> its block delta is stashed. It stays in
+    # the running queue (eviction only drops it from this step's output).
+    assert req_a.request_id in scheduler._stranded_new_blocks
+    assert req_a in scheduler.running
+
+    # Preempt req_a (frees its blocks). The override must drop the stash so the
+    # freed block id cannot be re-emitted after the request resumes.
+    scheduler.running.remove(req_a)
+    scheduler._preempt_request(req_a, 0.0)
+    assert req_a.status == RequestStatus.PREEMPTED
+    assert req_a.request_id not in scheduler._stranded_new_blocks
+
+
 def test_preempt_during_execution():
     # Test copied from https://github.com/vllm-project/vllm/blob/4fd9d6a85c00ac0186aa9abbeff73fc2ac6c721e/tests/v1/core/test_scheduler.py#L672-L728
 

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -1093,6 +1093,16 @@ class RBLNScheduler(Scheduler):
         self._stranded_new_blocks.pop(request.request_id, None)
         return super()._free_request(request, delay_free_blocks)
 
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        # Preemption frees ALL of the request's blocks (kv_cache_manager.free),
+        # including any block stashed for re-emit. The request lives on and may
+        # later re-enter the decode batch, where the merge would otherwise
+        # prepend a now-freed (and possibly reused) block id to its block table.
+        # Drop the stash so the resumed request relies solely on the fresh
+        # block ids sent on resume.
+        self._stranded_new_blocks.pop(request.request_id, None)
+        super()._preempt_request(request, timestamp)
+
     def update_from_output(
         self,
         scheduler_output: SchedulerOutput,


### PR DESCRIPTION

<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

#### Summary

  Follow-up to the mixed-batching KV-block fix
  (`fix(scheduler): re-emit KV block dropped by mixed-batching eviction`):
  clear the re-emit stash on **preemption** so a freed block id can never be
  re-emitted into a resumed request's block table.

  #### Background

  `RBLNScheduler` stashes a block delta dropped by the "disable mixed
  batching" eviction in `_stranded_new_blocks` and re-emits it on the
  request's next scheduled step (the prior fix). The stash is keyed by
  request id and drained when the request is next scheduled as running.

  #### Root cause

  `_preempt_request` frees **all** of a request's blocks
  (`kv_cache_manager.free`) and returns it to the waiting queue — but it did
  not drop the request's stash entry. The request can later resume and
  re-enter the decode batch, where the merge would prepend a now-freed (and
  possibly reused) block id to its block table, corrupting decode.

  `_free_request` already clears the stash on finish/abort, but that path is
  hygiene-only: finished requests never re-enter the running batch.
  Preemption — where the request lives on and can come back — was the one
  correctness-critical gap.

  #### Fix

  Override `_preempt_request` to pop the stash entry before delegating to
  the base implementation. A resumed request then relies solely on the fresh
  block ids sent on resume (full `block_ids` via `NewRequestData`), never on
  a stale stashed delta.

  Other block-freeing paths were reviewed and need no change:
  - `_free_request` / `_free_blocks` (finish/abort) — request never re-enters
    running; already cleared for hygiene.
  - remote-KV failure free — operates on `WAITING_FOR_REMOTE_KVS` requests,
    which are never stashed (the stash only holds evicted running decodes).

  #### Verification

  - Added `test_stranded_blocks_cleaned_up_on_preempt`: sets up a stash via
    boundary eviction, preempts the request, asserts the stash is cleared and
    the request is `PREEMPTED`. Fails without the override, passes with it.
  - Full `test_scheduler.py` suite passes (17 tests).

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
