### PR TITLE
perf(reorder): copy only the valid token range in InputBatch.swap_states

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -155,6 +155,45 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+# [OPT] Monkey-patch InputBatch.swap_states to copy only the valid token range.
+# token_ids_cpu/is_token_ids are [max_num_reqs, max_model_len]; a full-row swap
+# copies max_model_len(=131072) int32 ≈ 512KB/row. Under PDD decode request
+# turnover, _may_reorder_batch issues many swaps/step → ~0.85ms. We wrap the
+# upstream swap_states with NARROWED VIEWS of those two arrays (sharing memory),
+# so the original logic copies only :n columns (n = max valid token count of the
+# two rows) — all other field swaps run unchanged. No base-vLLM edit, robust to
+# upstream changes (delegates to the original method). num_tokens_no_spec is the
+# exact valid length without speculative decode.
+_RBLN_ORIG_SWAP_STATES = InputBatch.swap_states
+
+
+def _rbln_fast_swap_states(self, i1: int, i2: int) -> None:
+    n1 = int(self.num_tokens_no_spec[i1])
+    n2 = int(self.num_tokens_no_spec[i2])
+    n = n1 if n1 >= n2 else n2
+    full_tok = self.token_ids_cpu
+    full_is = self.is_token_ids
+    if n >= full_tok.shape[1]:
+        _RBLN_ORIG_SWAP_STATES(self, i1, i2)
+        return
+    try:
+        self.token_ids_cpu = full_tok[:, :n]
+        self.is_token_ids = full_is[:, :n]
+        _RBLN_ORIG_SWAP_STATES(self, i1, i2)
+    finally:
+        self.token_ids_cpu = full_tok
+        self.is_token_ids = full_is
+
+
+# Toggle with VLLM_RBLN_FAST_SWAP=0 to restore the original full-row swap (baseline).
+if (
+    os.environ.get("VLLM_RBLN_FAST_SWAP", "1") == "1"
+    and getattr(InputBatch.swap_states, "__name__", "") != "_rbln_fast_swap_states"
+):
+    InputBatch.swap_states = _rbln_fast_swap_states
+    logger.info("[vllm-rbln] patched InputBatch.swap_states (valid-range copy)")
+
+
 # Wrapper for ModelRunnerOutput to support overlapped execution.
 class AsyncRBLNModelRunnerOutput(AsyncModelRunnerOutput):
     def __init__(


### PR DESCRIPTION
## Summary
Reduce the per-swap copy cost of `_may_reorder_batch` (the `VLLM_RBLN_SORT_BATCH` length-sort) by copying only the **valid token range** of `token_ids_cpu` / `is_token_ids` instead of the full `max_model_len`-wide row.

## Context — why the sort can't just be turned off
`VLLM_RBLN_SORT_BATCH` (coupled with `VLLM_RBLN_BATCH_ATTN_OPT`) is **required** by rebel's batched decode attention kernel: per KV partition `p` the kernel attends only the first `valid_batch[p]` sequences (count of seqs with `len > p*partition_len`) as the dynamic batch size, which selects the correct sequences **only if the batch is sorted by descending length**. On gpt-oss-120b the alternative configs don't work (`opt=0/sort=0` fails to compile; `opt=1/sort=0` is silently wrong on multi-partition decode). So the sort is mandatory and the right optimization is to make each swap cheaper.

## Change
Monkey-patch `InputBatch.swap_states` (no base-vLLM edit, gated by `VLLM_RBLN_FAST_SWAP`, default on): wrap the upstream method with **narrowed views** of `token_ids_cpu`/`is_token_ids` (`[:, :n]`, `n` = max valid length of the two rows via `num_tokens_no_spec`), so the original logic copies only `:n` columns (~1k) instead of `max_model_len` (131072 int32 ≈ 512KB/row). All other field swaps run unchanged; the full arrays are restored in `finally`. Robust to upstream changes (delegates to the original).

## Validation (gpt-oss-120b PDD, rebel 0.10.5.dev269)
Reduces the decode **overhead** component (E2E − d32 − sample) consistently with `VLLM_RBLN_FAST_SWAP=1` vs `0`: 1k/144 3.42→4.02 (−0.60ms), 1k/192 3.09→3.72 (−0.63ms), 8k/1k 2.83→2.88 (−0.05, less turnover). Correctness preserved (0 failed requests across MIX/PDD × {1k144,1k192,8k1k}). Toggle off with `VLLM_RBLN_FAST_SWAP=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
