### PR TITLE
feature(ci): run e2e in PR CI when 'pytest(e2e)' label is present

### DIFF
--- a/.github/workflows/rbln_trigger_fsw_pr_ci.yaml
+++ b/.github/workflows/rbln_trigger_fsw_pr_ci.yaml
@@ -2,7 +2,7 @@ name: Trigger FSW PR CI for vLLM-RBLN
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       ref:
@@ -45,5 +45,6 @@ jobs:
                 "sha": "${{ github.event.pull_request.head.sha }}",
                 "pr_number": "${{ github.event.number }}",
                 "actor": "${{ github.actor }}",
-                "vllm_version": "${{ matrix.vllm_version }}"
+                "vllm_version": "${{ matrix.vllm_version }}",
+                "run_e2e": ${{ contains(github.event.pull_request.labels.*.name, 'pytest(e2e)') }}
               }


### PR DESCRIPTION
## What

vllm-rbln PR에 `pytest(e2e)` 라벨을 붙이면 PR CI에서 e2e 테스트도 실행되도록 한다.

## Changes

`rbln_trigger_fsw_pr_ci.yaml`:
- `pull_request` 트리거에 `labeled` 타입 추가 → 라벨을 붙이면 CI 재트리거
- 디스패치 payload에 `run_e2e` 추가 (`pytest(e2e)` 라벨 존재 여부를 boolean으로 전달)

```yaml
"run_e2e": ${{ contains(github.event.pull_request.labels.*.name, 'pytest(e2e)') }}
```

## Flow

- `pytest(e2e)` 라벨 부착 → `run_e2e: true` 디스패치 → PR CI가 build + unit + **e2e** 실행
- 라벨 없이 커밋 푸시 → `run_e2e: false` → 기존처럼 unit only

## 관련 PR

fsw-integration 쪽 payload 소비 변경과 함께 머지되어야 함: rebellions-sw/fsw-integration#(ci/pr-e2e-on-label)

## Note

- `pytest(e2e)` 라벨이 repo에 존재해야 함 (없으면 생성 필요). `contains`는 대소문자 구분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)