### PR TITLE
fix(test): re-enable device-tensor path in sub-block prefix caching test

### DIFF
--- a/tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
+++ b/tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
@@ -64,12 +64,22 @@ def _generated_token_ids(outputs) -> list[list[int]]:
     return [list(o.outputs[0].token_ids) for o in outputs]
 
 
-# TODO: re-enable True once the device tensor path is stable
-@pytest.mark.parametrize("use_device_tensor", [False])
+@pytest.mark.parametrize("use_device_tensor", [False, True])
 def test_sub_block_prefix_cache_matches_baseline(
     monkeypatch: pytest.MonkeyPatch, use_device_tensor: bool
 ) -> None:
     env = {"VLLM_RBLN_USE_DEVICE_TENSOR": "1" if use_device_tensor else "0"}
+
+    # RblnPlatform freezes device attrs at import; re-sync after env change.
+    from vllm_rbln.platform import RblnPlatform
+
+    dev = "rbln" if use_device_tensor else "cpu"
+    monkeypatch.setattr(RblnPlatform, "_USE_DEVICE_TENSOR", use_device_tensor)
+    monkeypatch.setattr(RblnPlatform, "device_type", dev)
+    monkeypatch.setattr(RblnPlatform, "device_name", dev)
+    monkeypatch.setattr(
+        RblnPlatform, "dist_backend", "rbln-ccl" if use_device_tensor else ""
+    )
 
     # Each engine is shut down before the next is built, so they never coexist.
     with managed_llm(


### PR DESCRIPTION
### 🚀 Summary of Changes

1. **Re-enable device-tensor parametrization:** `test_sub_block_prefix_cache_matches_baseline` now runs both `use_device_tensor=False` and `True` (was `[False]` only), so the device-tensor path is exercised again instead of being skipped.
2. **Work around the import-time freeze:** `RblnPlatform` derives `device_type`/`device_name`/`dist_backend` once at class definition. `conftest.pytest_configure` imports the platform before this test sets `VLLM_RBLN_USE_DEVICE_TENSOR`, so the parent process stays on the cpu values, the KV cache is plumbed as a host input, and compile aborts with `Load op should be a root load`. Re-sync the frozen attrs via `monkeypatch` per parametrization; the spawned worker re-derives them from the inherited env, so parent and worker agree.

---

### 📌 Related Issues / Tickets

* Related to #609 (root cause: device attrs frozen at class-definition time)
* Related to rebellions-sw/vllm-rbln-internal#94

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

```
pytest tests/torch_compile/e2e/v1/test_sub_block_prefix_caching.py
```

Both `use_device_tensor=False` and `True` pass; the `True` case no longer aborts with `Load op should be a root load`.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
