### PR TITLE
refactor(mm): build multimodal forward inputs (embeds + MRoPE positions) at the runner level

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/base.py
+++ b/vllm_rbln/model_executor/models/optimum/base.py
@@ -35,13 +35,7 @@ class ModelInputForRBLN:
     cached_lengths: list[int] = field(default_factory=list)  # for prefix caching
     multi_modal_kwargs: BatchedTensorInputs | None = None
     dummy_block: int | None = None  # for prefix caching
-    # Prefill input embeddings, computed at the runner level for multimodal
-    # models (embed_multimodal + embed_input_ids) and consumed by the model
-    # forward. Mirrors upstream vLLM where the runner produces inputs_embeds.
     inputs_embeds: torch.Tensor | None = None
-    # MRoPE position embeddings (cos/sin), computed at the runner level for
-    # models that use multimodal rotary positions (e.g. Qwen-VL) and consumed
-    # by the model forward. None for models without MRoPE.
     position_embed: torch.Tensor | None = None
 
 

--- a/vllm_rbln/model_executor/models/optimum/base.py
+++ b/vllm_rbln/model_executor/models/optimum/base.py
@@ -35,6 +35,10 @@ class ModelInputForRBLN:
     cached_lengths: list[int] = field(default_factory=list)  # for prefix caching
     multi_modal_kwargs: BatchedTensorInputs | None = None
     dummy_block: int | None = None  # for prefix caching
+    # Prefill input embeddings, computed at the runner level for multimodal
+    # models (embed_multimodal + embed_input_ids) and consumed by the model
+    # forward. Mirrors upstream vLLM where the runner produces inputs_embeds.
+    inputs_embeds: torch.Tensor | None = None
 
 
 version_error = RuntimeError(

--- a/vllm_rbln/model_executor/models/optimum/base.py
+++ b/vllm_rbln/model_executor/models/optimum/base.py
@@ -39,6 +39,10 @@ class ModelInputForRBLN:
     # models (embed_multimodal + embed_input_ids) and consumed by the model
     # forward. Mirrors upstream vLLM where the runner produces inputs_embeds.
     inputs_embeds: torch.Tensor | None = None
+    # MRoPE position embeddings (cos/sin), computed at the runner level for
+    # models that use multimodal rotary positions (e.g. Qwen-VL) and consumed
+    # by the model forward. None for models without MRoPE.
+    position_embed: torch.Tensor | None = None
 
 
 version_error = RuntimeError(

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -74,16 +74,11 @@ class RBLNOptimumBlip2ForConditionalGeneration(
 
         if is_prompt:
             block_tables = kwargs.pop("block_tables")
-            input_ids = kwargs.pop("input_ids")
             cache_position = kwargs.pop("cache_position")
 
-            multimodal_embeddings = self.embed_multimodal(
-                **(model_input.multi_modal_kwargs or {})
-            )
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings or None,
-            )
+            # inputs_embeds are computed at the runner level (embed_multimodal
+            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            inputs_embeds = model_input.inputs_embeds
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
                 cache_position=cache_position,

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -76,8 +76,6 @@ class RBLNOptimumBlip2ForConditionalGeneration(
             block_tables = kwargs.pop("block_tables")
             cache_position = kwargs.pop("cache_position")
 
-            # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/blip2.py
+++ b/vllm_rbln/model_executor/models/optimum/blip2.py
@@ -77,7 +77,7 @@ class RBLNOptimumBlip2ForConditionalGeneration(
             cache_position = kwargs.pop("cache_position")
 
             # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -193,6 +193,7 @@ class RBLNOptimumGemma3ForConditionalGeneration(
         *,
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
+        mrope_position_deltas: dict[str, float] | None = None,
     ) -> dict:
         # NOTE: this guard is currently unreachable — init_model() only enables
         # the EC path for "RBLNQwen3VLForConditionalGeneration", so Gemma3 never

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -115,8 +115,6 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             # `image_token_id`. Subclasses override `_image_token_id()` accordingly.
             token_type_ids[input_ids == self._image_token_id()] = 1
 
-            # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             if self.model.language_model.prefill_decoder is None:
                 raise version_error

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -118,7 +118,7 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             token_type_ids[input_ids == self._image_token_id()] = 1
 
             # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             if self.model.language_model.prefill_decoder is None:
                 raise version_error

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -184,7 +184,7 @@ class RBLNOptimumGemma3ForConditionalGeneration(
     def get_language_model(self):
         return self.model.language_model
 
-    def build_prefill_inputs(
+    def build_prefill_inputs_from_cache(
         self,
         input_ids: torch.Tensor,
         cached_mm_outputs: list,
@@ -199,7 +199,7 @@ class RBLNOptimumGemma3ForConditionalGeneration(
         raise NotImplementedError(
             "EC disaggregation is not implemented for Gemma3: its hybrid "
             "sliding-window attention prefill needs attention_manager state "
-            "that build_prefill_inputs does not yet provide."
+            "that build_prefill_inputs_from_cache does not yet provide."
         )
 
     def _process_image_input(

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -117,16 +117,9 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             # `image_token_id`. Subclasses override `_image_token_id()` accordingly.
             token_type_ids[input_ids == self._image_token_id()] = 1
 
-            multimodal_embeddings = self.embed_multimodal(
-                **(model_input.multi_modal_kwargs or {})
-            )
-            # Pass through as-is: `embed_input_ids` already treats None / len()==0 as
-            # "text only". A bare `... or None` raises on Gemma4, whose multimodal
-            # embeddings are a Tensor ("Boolean value of Tensor ... is ambiguous").
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings,
-            )
+            # inputs_embeds are computed at the runner level (embed_multimodal
+            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            inputs_embeds = model_input.inputs_embeds
             if self.model.language_model.prefill_decoder is None:
                 raise version_error
             assert attention_masks is not None

--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -20,7 +20,6 @@ from vllm.model_executor.models.gemma3_mm import (
     Gemma3ImageInputs,
     Gemma3ImagePixelInputs,
 )
-from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
 
 from .base import ModelInputForRBLN, version_error
 from .model_base import (
@@ -39,7 +38,6 @@ class RBLNOptimumGemma3ForConditionalGeneration(
     RBLNOptimumModelBase,
     RBLNOptimumMultimodalMixin,
     RBLNOptimumDecoderMixin,
-    VllmModelForTextGeneration,
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -73,16 +73,11 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
 
         if is_prompt:
             block_tables = kwargs.pop("block_tables")
-            input_ids = kwargs.pop("input_ids")
             cache_position = kwargs.pop("cache_position")
 
-            multimodal_embeddings = self.embed_multimodal(
-                **(model_input.multi_modal_kwargs or {})
-            )
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings or None,
-            )
+            # inputs_embeds are computed at the runner level (embed_multimodal
+            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            inputs_embeds = model_input.inputs_embeds
             logits = self.model.text_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
                 cache_position=cache_position,

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -75,8 +75,6 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
             block_tables = kwargs.pop("block_tables")
             cache_position = kwargs.pop("cache_position")
 
-            # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             logits = self.model.text_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/idefics3.py
+++ b/vllm_rbln/model_executor/models/optimum/idefics3.py
@@ -76,7 +76,7 @@ class RBLNOptimumIdefics3ForConditionalGeneration(
             cache_position = kwargs.pop("cache_position")
 
             # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             logits = self.model.text_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -114,7 +114,7 @@ class RBLNOptimumLlavaForConditionalGeneration(
 
         # For prefill, inputs_embeds are computed at the runner level
         # (embed_multimodal + embed_input_ids); see
-        # RBLNOptimumModelRunner._maybe_embed_inputs. Decode embeds from
+        # RBLNOptimumModelRunner._build_forward_inputs. Decode embeds from
         # input_ids inside _forward.
         inputs_embeds = model_input.inputs_embeds if is_prompt else None
 

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -112,15 +112,11 @@ class RBLNOptimumLlavaForConditionalGeneration(
                 padded_batch_size
             ]
 
-        inputs_embeds = None
-        if is_prompt:
-            multimodal_embeddings = self.embed_multimodal(
-                **(model_input.multi_modal_kwargs or {})
-            )
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings or None,
-            )
+        # For prefill, inputs_embeds are computed at the runner level
+        # (embed_multimodal + embed_input_ids); see
+        # RBLNOptimumModelRunner._maybe_embed_inputs. Decode embeds from
+        # input_ids inside _forward.
+        inputs_embeds = model_input.inputs_embeds if is_prompt else None
 
         logits = self._forward(
             is_prefill=is_prompt,

--- a/vllm_rbln/model_executor/models/optimum/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/llava.py
@@ -112,10 +112,6 @@ class RBLNOptimumLlavaForConditionalGeneration(
                 padded_batch_size
             ]
 
-        # For prefill, inputs_embeds are computed at the runner level
-        # (embed_multimodal + embed_input_ids); see
-        # RBLNOptimumModelRunner._build_forward_inputs. Decode embeds from
-        # input_ids inside _forward.
         inputs_embeds = model_input.inputs_embeds if is_prompt else None
 
         logits = self._forward(

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -111,15 +111,11 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
                 padded_batch_size
             ]
 
-        inputs_embeds = None
-        if is_prompt:
-            multimodal_embeddings = self.embed_multimodal(
-                **(model_input.multi_modal_kwargs or {})
-            )
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings or None,
-            )
+        # For prefill, inputs_embeds are computed at the runner level
+        # (embed_multimodal + embed_input_ids); see
+        # RBLNOptimumModelRunner._maybe_embed_inputs. Decode embeds from
+        # input_ids inside _forward.
+        inputs_embeds = model_input.inputs_embeds if is_prompt else None
 
         logits = self._forward(
             is_prefill=is_prompt,

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -111,10 +111,6 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
                 padded_batch_size
             ]
 
-        # For prefill, inputs_embeds are computed at the runner level
-        # (embed_multimodal + embed_input_ids); see
-        # RBLNOptimumModelRunner._build_forward_inputs. Decode embeds from
-        # input_ids inside _forward.
         inputs_embeds = model_input.inputs_embeds if is_prompt else None
 
         logits = self._forward(

--- a/vllm_rbln/model_executor/models/optimum/llava_next.py
+++ b/vllm_rbln/model_executor/models/optimum/llava_next.py
@@ -113,7 +113,7 @@ class RBLNOptimumLlavaNextForConditionalGeneration(
 
         # For prefill, inputs_embeds are computed at the runner level
         # (embed_multimodal + embed_input_ids); see
-        # RBLNOptimumModelRunner._maybe_embed_inputs. Decode embeds from
+        # RBLNOptimumModelRunner._build_forward_inputs. Decode embeds from
         # input_ids inside _forward.
         inputs_embeds = model_input.inputs_embeds if is_prompt else None
 

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -14,6 +14,7 @@
 import json
 import math
 import os
+from dataclasses import replace
 from typing import Any
 
 import torch
@@ -37,6 +38,7 @@ from vllm_rbln.utils.optimum.block_size import get_attn_block_size
 from vllm_rbln.utils.optimum.bucket import select_bucket_size
 from vllm_rbln.utils.optimum.registry import get_rbln_model_info
 
+from .base import ModelInputForRBLN
 from .compilation import RBLNCompileSpec
 
 logger = init_logger(__name__)
@@ -470,6 +472,33 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
     Shared multimodal interface for optimum models.
     """
 
+    def build_forward_inputs(
+        self,
+        model_input: ModelInputForRBLN,
+        mrope_position_deltas: dict[str, float],
+    ) -> ModelInputForRBLN:
+        """Compute the model-specific forward inputs at the runner level and
+        return an updated ``model_input``. Mirrors upstream vLLM, where the
+        runner produces ``inputs_embeds`` (and, for MRoPE models, positions).
+
+        Default: simple multimodal models embed at prefill
+        (``embed_multimodal`` + ``embed_input_ids``) and pass ``input_ids``
+        through at decode. ``mrope_position_deltas`` (runner-owned per-request
+        MRoPE state) is unused here; MRoPE models (e.g. Qwen-VL) override this.
+        """
+        if not model_input.is_prompt:
+            return model_input
+        multimodal_embeddings = self.embed_multimodal(
+            **(model_input.multi_modal_kwargs or {})
+        )
+        # int64 mirrors the dtype the model forward used to embed with
+        # (previously cast in preprocess_for_decoder before embed_input_ids).
+        inputs_embeds = self.embed_input_ids(
+            model_input.input_tokens.to(torch.int64),
+            multimodal_embeddings or None,
+        )
+        return replace(model_input, inputs_embeds=inputs_embeds)
+
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | dict:
         # Default vision-only encode path shared by the simple MM models: parse
         # the image input and return per-image token embeddings. Models with a
@@ -543,6 +572,7 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         *,
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
+        mrope_position_deltas: dict[str, float] | None = None,
     ) -> dict:
         # NOTE: this default is currently unreachable. init_model() gates the EC
         # producer/consumer path on ec_enabled_model ==

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -14,7 +14,6 @@
 import json
 import math
 import os
-from dataclasses import replace
 from typing import Any
 
 import torch
@@ -472,22 +471,22 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
     Shared multimodal interface for optimum models.
     """
 
-    def build_forward_inputs(
+    def build_prefill_forward_inputs(
         self,
         model_input: ModelInputForRBLN,
-        mrope_position_deltas: dict[str, float],
-    ) -> ModelInputForRBLN:
-        """Compute the model-specific forward inputs at the runner level and
-        return an updated ``model_input``. Mirrors upstream vLLM, where the
-        runner produces ``inputs_embeds`` (and, for MRoPE models, positions).
+    ) -> tuple[torch.Tensor, torch.Tensor | None, float | None]:
+        """Assemble the prefill forward inputs at the runner level. Mirrors
+        upstream vLLM, where the runner produces ``inputs_embeds`` (and, for
+        MRoPE models, positions).
 
-        Default: simple multimodal models embed at prefill
-        (``embed_multimodal`` + ``embed_input_ids``) and pass ``input_ids``
-        through at decode. ``mrope_position_deltas`` (runner-owned per-request
-        MRoPE state) is unused here; MRoPE models (e.g. Qwen-VL) override this.
+        Returns ``(inputs_embeds, position_embed, rope_delta)``. These hooks are
+        pure: the per-request MRoPE delta is *returned* (the runner owns and
+        stores it), never mutated in place.
+
+        Default: simple multimodal models embed (``embed_multimodal`` +
+        ``embed_input_ids``) and have neither MRoPE positions nor a delta. MRoPE
+        models (e.g. Qwen-VL) override this to also return the two.
         """
-        if not model_input.is_prompt:
-            return model_input
         multimodal_embeddings = self.embed_multimodal(
             **(model_input.multi_modal_kwargs or {})
         )
@@ -497,7 +496,21 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
             model_input.input_tokens.to(torch.int64),
             multimodal_embeddings or None,
         )
-        return replace(model_input, inputs_embeds=inputs_embeds)
+        return inputs_embeds, None, None
+
+    def compute_decode_position_embed(
+        self,
+        model_input: ModelInputForRBLN,
+        mrope_position_deltas: dict[str, float],
+    ) -> torch.Tensor | None:
+        """Decode-step position embeddings, computed at the runner level from
+        the runner-owned ``mrope_position_deltas``.
+
+        Default: ``None`` — simple multimodal models pass ``input_ids`` through
+        at decode and don't use precomputed positions. MRoPE models (e.g.
+        Qwen-VL) override this.
+        """
+        return None
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | dict:
         # Default vision-only encode path shared by the simple MM models: parse

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -475,25 +475,12 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         self,
         model_input: ModelInputForRBLN,
     ) -> tuple[torch.Tensor, torch.Tensor | None, float | None]:
-        """Assemble the prefill forward inputs at the runner level. Mirrors
-        upstream vLLM, where the runner produces ``inputs_embeds`` (and, for
-        MRoPE models, positions).
-
-        Returns ``(inputs_embeds, position_embed, rope_delta)``. These hooks are
-        pure: the per-request MRoPE delta is *returned* (the runner owns and
-        stores it), never mutated in place.
-
-        Default: simple multimodal models embed (``embed_multimodal`` +
-        ``embed_input_ids``) and have neither MRoPE positions nor a delta. MRoPE
-        models (e.g. Qwen-VL) override this to also return the two.
-        """
         multimodal_embeddings = self.embed_multimodal(
             **(model_input.multi_modal_kwargs or {})
         )
-        # int64 mirrors the dtype the model forward used to embed with
-        # (previously cast in preprocess_for_decoder before embed_input_ids).
+        input_ids = model_input.input_tokens.to(torch.int64)
         inputs_embeds = self.embed_input_ids(
-            model_input.input_tokens.to(torch.int64),
+            input_ids,
             multimodal_embeddings or None,
         )
         return inputs_embeds, None, None
@@ -503,13 +490,7 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         model_input: ModelInputForRBLN,
         mrope_position_deltas: dict[str, float],
     ) -> torch.Tensor | None:
-        """Decode-step position embeddings, computed at the runner level from
-        the runner-owned ``mrope_position_deltas``.
-
-        Default: ``None`` — simple multimodal models pass ``input_ids`` through
-        at decode and don't use precomputed positions. MRoPE models (e.g.
-        Qwen-VL) override this.
-        """
+        # MRoPE models (e.g. Qwen-VL) override this
         return None
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | dict:

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -481,7 +481,7 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         input_ids = model_input.input_tokens.to(torch.int64)
         inputs_embeds = self.embed_input_ids(
             input_ids,
-            multimodal_embeddings or None,
+            multimodal_embeddings,
         )
         return inputs_embeds, None, None
 
@@ -574,5 +574,5 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         # EC path today. It is kept as the shared interface contract / placeholder
         # until more models are EC-enabled.
         mm_embeds = [t for out in cached_mm_outputs for t in out]
-        inputs_embeds = self.embed_input_ids(input_ids, mm_embeds or None)
+        inputs_embeds = self.embed_input_ids(input_ids, mm_embeds)
         return {"inputs_embeds": inputs_embeds, "cache_position": cache_position}

--- a/vllm_rbln/model_executor/models/optimum/model_base.py
+++ b/vllm_rbln/model_executor/models/optimum/model_base.py
@@ -578,7 +578,7 @@ class RBLNOptimumMultimodalMixin(SupportsMultiModal):
         scatter_mask = is_multimodal.unsqueeze(-1).expand_as(inputs_embeds)
         return inputs_embeds.masked_scatter(scatter_mask, mm_embeds)
 
-    def build_prefill_inputs(
+    def build_prefill_inputs_from_cache(
         self,
         input_ids: torch.Tensor,
         cached_mm_outputs: list,

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -77,7 +77,7 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
             cache_position = kwargs.pop("cache_position")
 
             # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -74,16 +74,11 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
 
         if is_prompt:
             block_tables = kwargs.pop("block_tables")
-            input_ids = kwargs.pop("input_ids")
             cache_position = kwargs.pop("cache_position")
 
-            multimodal_embeddings = self.embed_multimodal(
-                **(model_input.multi_modal_kwargs or {})
-            )
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings or None,
-            )
+            # inputs_embeds are computed at the runner level (embed_multimodal
+            # + embed_input_ids); see RBLNOptimumModelRunner._maybe_embed_inputs.
+            inputs_embeds = model_input.inputs_embeds
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,
                 cache_position=cache_position,

--- a/vllm_rbln/model_executor/models/optimum/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/paligemma.py
@@ -76,8 +76,6 @@ class RBLNOptimumPaliGemmaForConditionalGeneration(
             block_tables = kwargs.pop("block_tables")
             cache_position = kwargs.pop("cache_position")
 
-            # inputs_embeds are computed at the runner level (embed_multimodal
-            # + embed_input_ids); see RBLNOptimumModelRunner._build_forward_inputs.
             inputs_embeds = model_input.inputs_embeds
             logits = self.model.language_model.prefill_decoder(
                 inputs_embeds=inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -313,6 +313,12 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         request_nums = input_ids.shape[0]
         is_prompt = model_input.is_prompt
 
+        # FIXME This should be removed in the future
+        # by moving the padding logic into model runner.
+        assert len(model_input.running_requests_ids) == request_nums, (
+            f"The number of running requests is {len(model_input.running_requests_ids)}, "
+            f"but the shape of input_ids is {input_ids.shape}")
+        
         kwargs = self.preprocess_for_decoder(
             is_prompt, block_tables, input_ids, cache_position
         )

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
+from dataclasses import replace
 from typing import Any
 
 import torch
@@ -31,6 +32,8 @@ from vllm.model_executor.models.qwen2_vl import (
     Qwen2VLVideoPixelInputs,
 )
 
+from vllm_rbln.utils.optimum.bucket import select_bucket_size
+
 from .base import ModelInputForRBLN
 from .model_base import (
     RBLNOptimumDecoderMixin,
@@ -49,11 +52,6 @@ class RBLNOptimumQwenVLForConditionalGeneration(
     Automatically detects model type based on the model configuration.
     """
 
-    # Qwen-VL prefill uses a custom preprocess_prefill (rope_deltas /
-    # position embeddings) rather than the embed_input_ids merge pattern,
-    # so it embeds inside its own forward instead of at the runner level.
-    merges_embeds_in_runner: bool = False
-
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):
@@ -68,7 +66,6 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         vllm_config: VllmConfig,
     ) -> None:
         super().__init__(vllm_config=vllm_config)
-        self.rope_deltas: dict = dict()
         if self._is_ec_producer_only():
             return
         assert self.kv_block_adapter is not None
@@ -243,18 +240,22 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         """Create video embedding inputs based on model type"""
         pass
 
-    def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
+    def build_forward_inputs(
+        self,
+        model_input: ModelInputForRBLN,
+        mrope_position_deltas: dict[str, float],
+    ) -> ModelInputForRBLN:
+        """Build forward inputs at the runner level (upstream-aligned).
+
+        Prefill: run ``preprocess_prefill`` (embedding merge + MRoPE) and stash
+        the per-request rope delta in the runner-owned
+        ``mrope_position_deltas``; attach inputs_embeds + position_embed.
+        Decode: compute MRoPE ``position_embed`` from the stored delta. Decode
+        ``inputs_embeds`` are still embedded in ``forward`` (they depend on the
+        padded input_ids produced by ``preprocess_for_decoder``).
+        """
         input_ids = model_input.input_tokens
-        cache_position = model_input.input_positions
-        block_tables = model_input.block_tables
-
-        request_nums = input_ids.shape[0]
-        finished_requests_ids = model_input.finished_requests_ids
-        running_requests_ids = model_input.running_requests_ids
-
-        is_prompt = model_input.is_prompt
-
-        if is_prompt:
+        if model_input.is_prompt:
             image_input = None
             video_input = None
             if model_input.multi_modal_kwargs:
@@ -265,70 +266,52 @@ class RBLNOptimumQwenVLForConditionalGeneration(
                     **model_input.multi_modal_kwargs
                 )
 
-            if image_input is None and video_input is None:
-                inputs_embeds = None
-
-            cur_request_id = running_requests_ids[0]
+            cur_request_id = model_input.running_requests_ids[0]
             attention_mask = torch.ones_like(input_ids)
-
             prefill_params = self.preprocess_prefill(
                 input_ids, attention_mask, image_input, video_input
             )
 
-            if finished_requests_ids:
-                for request_id in finished_requests_ids:
-                    self.rope_deltas.pop(request_id, None)
-            self.rope_deltas[cur_request_id] = prefill_params["rope_deltas"].item()
-            prefill_params.pop("rope_deltas")
+            for request_id in model_input.finished_requests_ids:
+                mrope_position_deltas.pop(request_id, None)
+            mrope_position_deltas[cur_request_id] = prefill_params["rope_deltas"].item()
 
-        kwargs = self.preprocess_for_decoder(
-            is_prompt, block_tables, input_ids, cache_position
+            return replace(
+                model_input,
+                inputs_embeds=prefill_params["inputs_embeds"],
+                position_embed=prefill_params["position_embed"],
+            )
+
+        position_embed = self._compute_decode_position_embed(
+            model_input.input_positions,
+            model_input.running_requests_ids,
+            mrope_position_deltas,
         )
-        cache_position = kwargs.pop("cache_position")
-        block_tables = kwargs.pop("block_tables")
+        return replace(model_input, position_embed=position_embed)
 
-        if is_prompt:
-            logits = self.model.prefill_decoder(
-                **prefill_params,
-                block_tables=block_tables,
-            ).logits
-        else:
-            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
-            self.model.decoder = self.model.decoders[padded_batch_size]
-            input_ids = kwargs.pop("input_ids")
-
-            inputs_embeds, position_embed = self._preprocess_embeds(
-                input_ids, cache_position, running_requests_ids, padded_batch_size
-            )
-            logits = self.model.decoder(
-                inputs_embeds=inputs_embeds,
-                cache_position=cache_position,
-                position_embed=position_embed,
-                block_tables=block_tables,
-            ).logits
-        if not is_prompt:
-            logits = logits[:request_nums]
-        return logits
-
-    def _preprocess_embeds(
+    def _compute_decode_position_embed(
         self,
-        input_ids: torch.LongTensor,
-        cache_position: torch.LongTensor,
+        cache_position: torch.Tensor,
         running_requests_ids: list[str],
-        padded_batch_size: int,
-    ):
-        if padded_batch_size != cache_position.shape[0]:
-            raise RuntimeError(
-                f"Cache position size mismatch: got {cache_position.shape[0]},",
-                " expected {padded_batch_size}.",
+        mrope_position_deltas: dict[str, float],
+    ) -> torch.Tensor:
+        """Decode-step MRoPE: advance each request's position from its stored
+        delta (``cache_position + mrope_position_delta``) and return the padded
+        position embeddings (cos/sin). Mirrors upstream vLLM's
+        ``get_next_input_positions_tensor``.
+        """
+        # int32 mirrors the cache_position dtype the prior decode path used
+        # (cast in preprocess_for_decoder before computing position embeds).
+        cache_position = cache_position.to(torch.int32)
+        padded_batch_size = self.decoder_batch_size
+        if self.use_multiple_decoder:
+            padded_batch_size = select_bucket_size(
+                len(running_requests_ids), self.decoder_batch_sizes
             )
 
-        # NOTE: preprocess_prefill also use dtype casting.
-        # eunji.lee): dtype casting is required
-        inputs_embeds = self.model.embed_tokens(input_ids).to(self.dtype)
         position_embeds = []
         for b_id, request_id in enumerate(running_requests_ids):
-            delta = cache_position[b_id] + self.rope_deltas[request_id]
+            delta = cache_position[b_id] + mrope_position_deltas[request_id]
             position_ids = torch.arange(1).view(1, -1)
             position_ids = position_ids.add(delta)
             position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
@@ -338,12 +321,46 @@ class RBLNOptimumQwenVLForConditionalGeneration(
             position_embeds.append(position_embed)
 
         for _ in range(padded_batch_size - len(running_requests_ids)):
-            position_embed = torch.zeros_like(position_embeds[0])
-            position_embeds.append(position_embed)
+            position_embeds.append(torch.zeros_like(position_embeds[0]))
 
-        position_embeds = torch.cat(position_embeds, dim=1)
+        return torch.cat(position_embeds, dim=1)
 
-        return inputs_embeds, position_embeds
+    def forward(self, model_input: ModelInputForRBLN, **kwargs) -> torch.Tensor:
+        input_ids = model_input.input_tokens
+        cache_position = model_input.input_positions
+        block_tables = model_input.block_tables
+
+        request_nums = input_ids.shape[0]
+        is_prompt = model_input.is_prompt
+
+        kwargs = self.preprocess_for_decoder(
+            is_prompt, block_tables, input_ids, cache_position
+        )
+        cache_position = kwargs.pop("cache_position")
+        block_tables = kwargs.pop("block_tables")
+
+        # inputs_embeds / position_embed are computed at the runner level
+        # (build_forward_inputs); see RBLNOptimumModelRunner._maybe_embed_inputs.
+        if is_prompt:
+            logits = self.model.prefill_decoder(
+                inputs_embeds=model_input.inputs_embeds,
+                position_embed=model_input.position_embed,
+                block_tables=block_tables,
+            ).logits
+        else:
+            padded_batch_size = kwargs.pop("padded_batch_size", self.decoder_batch_size)
+            self.model.decoder = self.model.decoders[padded_batch_size]
+            input_ids = kwargs.pop("input_ids")
+            inputs_embeds = self.model.embed_tokens(input_ids).to(self.dtype)
+            logits = self.model.decoder(
+                inputs_embeds=inputs_embeds,
+                cache_position=cache_position,
+                position_embed=model_input.position_embed,
+                block_tables=block_tables,
+            ).logits
+        if not is_prompt:
+            logits = logits[:request_nums]
+        return logits
 
     def _parse_and_validate_image_input(self, **kwargs: Any) -> Any | None:
         pixel_values = kwargs.pop("pixel_values", None)
@@ -416,12 +433,14 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         *,
         cache_position: torch.Tensor | None = None,
         running_requests_ids: list[str] | None = None,
+        mrope_position_deltas: dict[str, float] | None = None,
     ) -> dict:
         """Build prefill_decoder kwargs from cached encoder outputs (EC consumer).
 
         Reconstructs image/video embeds + grid_thw (+ deepstack) from the
         per-feature dicts produced by embed_multimodal(), runs the merge via
-        preprocess_prefill, and stashes rope_deltas for the decode phase.
+        preprocess_prefill, and stashes the rope delta in the runner-owned
+        mrope_position_deltas for the decode phase.
         cache_position is unused (Qwen feeds positions via position_embed).
         """
         model_dtype = self.dtype
@@ -489,8 +508,12 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         )
 
         rope_deltas = prefill_params.pop("rope_deltas", None)
-        if rope_deltas is not None and running_requests_ids:
-            self.rope_deltas[running_requests_ids[0]] = rope_deltas.item()
+        if (
+            rope_deltas is not None
+            and running_requests_ids
+            and mrope_position_deltas is not None
+        ):
+            mrope_position_deltas[running_requests_ids[0]] = rope_deltas.item()
 
         return prefill_params
 

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -49,6 +49,11 @@ class RBLNOptimumQwenVLForConditionalGeneration(
     Automatically detects model type based on the model configuration.
     """
 
+    # Qwen-VL prefill uses a custom preprocess_prefill (rope_deltas /
+    # position embeddings) rather than the embed_input_ids merge pattern,
+    # so it embeds inside its own forward instead of at the runner level.
+    merges_embeds_in_runner: bool = False
+
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -316,9 +316,11 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         # FIXME This should be removed in the future
         # by moving the padding logic into model runner.
         assert len(model_input.running_requests_ids) == request_nums, (
-            f"The number of running requests is {len(model_input.running_requests_ids)}, "
-            f"but the shape of input_ids is {input_ids.shape}")
-        
+            f"The number of running requests is "
+            f"{len(model_input.running_requests_ids)}, "
+            f"but the shape of input_ids is {input_ids.shape}"
+        )
+
         kwargs = self.preprocess_for_decoder(
             is_prompt, block_tables, input_ids, cache_position
         )

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -393,7 +393,7 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         Unlike the simple MM models (which return a list of per-image token
         embeddings), Qwen's cacheable unit is the dict returned by encode():
         image/video embeds + grid_thw (+ deepstack for Qwen3-VL). It is consumed
-        on the decode side by build_prefill_inputs().
+        on the decode side by build_prefill_inputs_from_cache().
         """
         image_input = self._parse_and_validate_image_input(**kwargs)
         video_input = self._parse_and_validate_video_input(**kwargs)
@@ -401,13 +401,13 @@ class RBLNOptimumQwenVLForConditionalGeneration(
             return []
 
         # Merge the per-modality encoder outputs into a single cacheable dict
-        # (consumed on the decode side by build_prefill_inputs()).
+        # (consumed on the decode side by build_prefill_inputs_from_cache()).
         result = {}
         result.update(self._process_image_input(image_input))
         result.update(self._process_video_input(video_input))
         return result
 
-    def build_prefill_inputs(
+    def build_prefill_inputs_from_cache(
         self,
         input_ids: torch.Tensor,
         cached_mm_outputs: list[dict],

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -319,9 +319,6 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         cache_position = kwargs.pop("cache_position")
         block_tables = kwargs.pop("block_tables")
 
-        # inputs_embeds / position_embed are computed at the runner level; see
-        # RBLNOptimumModelRunner._build_forward_inputs (which calls this model's
-        # build_prefill_forward_inputs / compute_decode_position_embed).
         if is_prompt:
             logits = self.model.prefill_decoder(
                 inputs_embeds=model_input.inputs_embeds,

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -393,13 +393,6 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         return self.model
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | dict:
-        """Vision-only encode entry point (SupportsMultiModal / EC producer).
-
-        Unlike the simple MM models (which return a list of per-image token
-        embeddings), Qwen's cacheable unit is the dict returned by encode():
-        image/video embeds + grid_thw (+ deepstack for Qwen3-VL). It is consumed
-        on the decode side by build_prefill_inputs_from_cache().
-        """
         image_input = self._parse_and_validate_image_input(**kwargs)
         video_input = self._parse_and_validate_video_input(**kwargs)
         if image_input is None and video_input is None:
@@ -421,13 +414,8 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         running_requests_ids: list[str] | None = None,
         mrope_position_deltas: dict[str, float] | None = None,
     ) -> dict:
-        """Build prefill_decoder kwargs from cached encoder outputs (EC consumer).
-
-        Reconstructs image/video embeds + grid_thw (+ deepstack) from the
-        per-feature dicts produced by embed_multimodal(), runs the merge via
-        preprocess_prefill, and stashes the rope delta in the runner-owned
-        mrope_position_deltas for the decode phase.
-        cache_position is unused (Qwen feeds positions via position_embed).
+        """
+        Build prefill_decoder kwargs from cached encoder outputs (EC consumer).
         """
         model_dtype = self.dtype
 

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from dataclasses import replace
 from typing import Any
 
 import torch
@@ -240,59 +239,38 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         """Create video embedding inputs based on model type"""
         pass
 
-    def build_forward_inputs(
+    def build_prefill_forward_inputs(
         self,
         model_input: ModelInputForRBLN,
-        mrope_position_deltas: dict[str, float],
-    ) -> ModelInputForRBLN:
-        """Build forward inputs at the runner level (upstream-aligned).
-
-        Prefill: run ``preprocess_prefill`` (embedding merge + MRoPE) and stash
-        the per-request rope delta in the runner-owned
-        ``mrope_position_deltas``; attach inputs_embeds + position_embed.
-        Decode: compute MRoPE ``position_embed`` from the stored delta. Decode
-        ``inputs_embeds`` are still embedded in ``forward`` (they depend on the
-        padded input_ids produced by ``preprocess_for_decoder``).
+    ) -> tuple[torch.Tensor, torch.Tensor | None, float | None]:
+        """Prefill: run ``preprocess_prefill`` (embedding merge + MRoPE) and
+        return ``(inputs_embeds, position_embed, rope_delta)``. The runner owns
+        and stores the per-request rope delta; this hook only returns it.
         """
         input_ids = model_input.input_tokens
-        if model_input.is_prompt:
-            image_input = None
-            video_input = None
-            if model_input.multi_modal_kwargs:
-                image_input = self._parse_and_validate_image_input(
-                    **model_input.multi_modal_kwargs
-                )
-                video_input = self._parse_and_validate_video_input(
-                    **model_input.multi_modal_kwargs
-                )
-
-            cur_request_id = model_input.running_requests_ids[0]
-            attention_mask = torch.ones_like(input_ids)
-            prefill_params = self.preprocess_prefill(
-                input_ids, attention_mask, image_input, video_input
+        image_input = None
+        video_input = None
+        if model_input.multi_modal_kwargs:
+            image_input = self._parse_and_validate_image_input(
+                **model_input.multi_modal_kwargs
+            )
+            video_input = self._parse_and_validate_video_input(
+                **model_input.multi_modal_kwargs
             )
 
-            for request_id in model_input.finished_requests_ids:
-                mrope_position_deltas.pop(request_id, None)
-            mrope_position_deltas[cur_request_id] = prefill_params["rope_deltas"].item()
-
-            return replace(
-                model_input,
-                inputs_embeds=prefill_params["inputs_embeds"],
-                position_embed=prefill_params["position_embed"],
-            )
-
-        position_embed = self._compute_decode_position_embed(
-            model_input.input_positions,
-            model_input.running_requests_ids,
-            mrope_position_deltas,
+        attention_mask = torch.ones_like(input_ids)
+        prefill_params = self.preprocess_prefill(
+            input_ids, attention_mask, image_input, video_input
         )
-        return replace(model_input, position_embed=position_embed)
+        return (
+            prefill_params["inputs_embeds"],
+            prefill_params["position_embed"],
+            prefill_params["rope_deltas"].item(),
+        )
 
-    def _compute_decode_position_embed(
+    def compute_decode_position_embed(
         self,
-        cache_position: torch.Tensor,
-        running_requests_ids: list[str],
+        model_input: ModelInputForRBLN,
         mrope_position_deltas: dict[str, float],
     ) -> torch.Tensor:
         """Decode-step MRoPE: advance each request's position from its stored
@@ -300,6 +278,8 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         position embeddings (cos/sin). Mirrors upstream vLLM's
         ``get_next_input_positions_tensor``.
         """
+        cache_position = model_input.input_positions
+        running_requests_ids = model_input.running_requests_ids
         # int32 mirrors the cache_position dtype the prior decode path used
         # (cast in preprocess_for_decoder before computing position embeds).
         cache_position = cache_position.to(torch.int32)
@@ -339,8 +319,9 @@ class RBLNOptimumQwenVLForConditionalGeneration(
         cache_position = kwargs.pop("cache_position")
         block_tables = kwargs.pop("block_tables")
 
-        # inputs_embeds / position_embed are computed at the runner level
-        # (build_forward_inputs); see RBLNOptimumModelRunner._maybe_embed_inputs.
+        # inputs_embeds / position_embed are computed at the runner level; see
+        # RBLNOptimumModelRunner._build_forward_inputs (which calls this model's
+        # build_prefill_forward_inputs / compute_decode_position_embed).
         if is_prompt:
             logits = self.model.prefill_decoder(
                 inputs_embeds=model_input.inputs_embeds,

--- a/vllm_rbln/v1/worker/ec_disagg_helpers.py
+++ b/vllm_rbln/v1/worker/ec_disagg_helpers.py
@@ -106,13 +106,14 @@ class ECDisaggHelpersMixin:
             self.encoder_cache[mm_hash] = encode_output
             self.maybe_save_ec_to_connector(self.encoder_cache, mm_hash)
 
-    def _run_decoder_with_cached_encoder(
+    def _run_prefill_with_cached_encoder(
         self,
         model_input: ModelInputForRBLN,
         scheduler_output: "SchedulerOutput",
     ) -> torch.Tensor:
-        """Consumer path: gather the cached encoder outputs, let the model
-        merge them (model.build_prefill_inputs), and run the prefill decoder."""
+        """Consumer prefill path: gather the cached encoder outputs, let the
+        model merge them (model.build_prefill_inputs_from_cache), and run the prefill
+        decoder (optimum-rbln's prefill runtime)."""
         if not scheduler_output.scheduled_new_reqs:
             raise RuntimeError("EC consumer: no scheduled_new_reqs on prefill step.")
         req = scheduler_output.scheduled_new_reqs[0]
@@ -140,7 +141,7 @@ class ECDisaggHelpersMixin:
         cache_position = kwargs.pop("cache_position")
         block_tables = kwargs.pop("block_tables")
 
-        prefill_params = self.model.build_prefill_inputs(
+        prefill_params = self.model.build_prefill_inputs_from_cache(
             input_ids,
             cached_mm_outputs,
             cache_position=cache_position,

--- a/vllm_rbln/v1/worker/ec_disagg_helpers.py
+++ b/vllm_rbln/v1/worker/ec_disagg_helpers.py
@@ -35,6 +35,7 @@ class ECDisaggHelpersMixin:
 
     Expects the host class to provide:
       - self.model, self.model_config, self.encoder_cache
+      - self.mrope_position_deltas
       - self.maybe_save_ec_to_connector (from ECConnectorModelRunnerMixin)
     """
 
@@ -44,6 +45,7 @@ class ECDisaggHelpersMixin:
         model: Any
         model_config: "ModelConfig"
         encoder_cache: dict[str, Any]
+        mrope_position_deltas: dict[str, float]
 
         def maybe_save_ec_to_connector(
             self, encoder_cache: dict[str, Any], mm_hash: str
@@ -143,6 +145,7 @@ class ECDisaggHelpersMixin:
             cached_mm_outputs,
             cache_position=cache_position,
             running_requests_ids=model_input.running_requests_ids,
+            mrope_position_deltas=self.mrope_position_deltas,
         )
 
         language_model = self.model.get_language_model()

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -257,6 +257,13 @@ class RBLNOptimumModelRunner(
         # Maps mm_hash → dict of prefill params (inputs_embeds, position_embed, etc.)
         self.encoder_cache: dict[str, Any] = {}
 
+        # Runner-owned per-request MRoPE state (request_id → rope delta), mirroring
+        # upstream vLLM's CachedRequestState.mrope_position_delta. Populated at
+        # prefill by _build_forward_inputs (and the EC consumer path) and consumed
+        # to compute decode-step position embeddings. Model hooks return the delta;
+        # the runner owns storage and finished-request cleanup.
+        self.mrope_position_deltas: dict[str, float] = {}
+
         # Ephemeral state transferred
         # between execute_model() and sample_tokens().
         self.execute_model_state: ExecuteModelState | None = None
@@ -372,7 +379,7 @@ class RBLNOptimumModelRunner(
                         )
                 else:
                     with capture_ctx as model_reports:
-                        model_input = self._maybe_embed_inputs(model_input)
+                        model_input = self._build_forward_inputs(model_input)
                         hidden_states = self.model(model_input)
                 if (
                     envs.VLLM_RBLN_METRICS
@@ -408,33 +415,50 @@ class RBLNOptimumModelRunner(
         )
         return None
 
-    def _maybe_embed_inputs(self, model_input: ModelInputForRBLN) -> ModelInputForRBLN:
-        """Compute prefill ``inputs_embeds`` at the runner level for
+    def _build_forward_inputs(
+        self, model_input: ModelInputForRBLN
+    ) -> ModelInputForRBLN:
+        """Assemble the model's forward inputs at the runner level for
         multimodal models, mirroring upstream vLLM.
 
-        Runs the vision encoder (``embed_multimodal``) and merges the result
-        into the text embeddings (``embed_input_ids``), attaching the result
-        to ``model_input.inputs_embeds`` for the model forward to consume.
+        Prefill: run the model's ``build_prefill_forward_inputs`` (vision encode
+        + text merge, and — for MRoPE models — positions) and attach
+        ``inputs_embeds`` (+ ``position_embed``). The runner owns the per-request
+        MRoPE delta state: the hook returns the delta, the runner stores it.
+        Decode: compute MRoPE ``position_embed`` from the stored delta via the
+        model's ``compute_decode_position_embed`` (``None`` for non-MRoPE models,
+        which pass ``input_ids`` through).
 
-        Left untouched: decode steps and non-multimodal models.
+        Left untouched: non-multimodal models.
         """
-        if not model_input.is_prompt:
-            return model_input
         model = self.model
         if not isinstance(model, RBLNOptimumMultimodalMixin):
             return model_input
 
-        # int64 mirrors the dtype the model forward used to embed with
-        # (previously cast in preprocess_for_decoder before embed_input_ids).
-        input_ids = model_input.input_tokens.to(torch.int64)
-        multimodal_embeddings = model.embed_multimodal(
-            **(model_input.multi_modal_kwargs or {})
+        # Runner owns the per-request MRoPE delta state, including cleanup.
+        for request_id in model_input.finished_requests_ids:
+            self.mrope_position_deltas.pop(request_id, None)
+
+        if model_input.is_prompt:
+            inputs_embeds, position_embed, rope_delta = (
+                model.build_prefill_forward_inputs(model_input)
+            )
+            if rope_delta is not None:
+                self.mrope_position_deltas[model_input.running_requests_ids[0]] = (
+                    rope_delta
+                )
+            return replace(
+                model_input,
+                inputs_embeds=inputs_embeds,
+                position_embed=position_embed,
+            )
+
+        position_embed = model.compute_decode_position_embed(
+            model_input, self.mrope_position_deltas
         )
-        inputs_embeds = model.embed_input_ids(
-            input_ids,
-            multimodal_embeddings or None,
-        )
-        return replace(model_input, inputs_embeds=inputs_embeds)
+        if position_embed is None:
+            return model_input
+        return replace(model_input, position_embed=position_embed)
 
     def mask_block_table(
         self,

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -378,8 +378,8 @@ class RBLNOptimumModelRunner(
                             model_input, scheduler_output
                         )
                 else:
-                    model_input = self._build_forward_inputs(model_input)
                     with capture_ctx as model_reports:
+                        model_input = self._build_forward_inputs(model_input)
                         hidden_states = self.model(model_input)
                 if (
                     envs.VLLM_RBLN_METRICS

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -374,12 +374,12 @@ class RBLNOptimumModelRunner(
                 prefill_has_mm = bool(new_reqs) and bool(new_reqs[0].mm_features)
                 if self.is_ec_consumer and model_input.is_prompt and prefill_has_mm:
                     with capture_ctx as model_reports:
-                        hidden_states = self._run_decoder_with_cached_encoder(
+                        hidden_states = self._run_prefill_with_cached_encoder(
                             model_input, scheduler_output
                         )
                 else:
+                    model_input = self._build_forward_inputs(model_input)
                     with capture_ctx as model_reports:
-                        model_input = self._build_forward_inputs(model_input)
                         hidden_states = self.model(model_input)
                 if (
                     envs.VLLM_RBLN_METRICS

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -257,11 +257,6 @@ class RBLNOptimumModelRunner(
         # Maps mm_hash → dict of prefill params (inputs_embeds, position_embed, etc.)
         self.encoder_cache: dict[str, Any] = {}
 
-        # Runner-owned per-request MRoPE state (request_id → rope delta), mirroring
-        # upstream vLLM's CachedRequestState.mrope_position_delta. Populated at
-        # prefill by _build_forward_inputs (and the EC consumer path) and consumed
-        # to compute decode-step position embeddings. Model hooks return the delta;
-        # the runner owns storage and finished-request cleanup.
         self.mrope_position_deltas: dict[str, float] = {}
 
         # Ephemeral state transferred

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -416,16 +416,12 @@ class RBLNOptimumModelRunner(
         into the text embeddings (``embed_input_ids``), attaching the result
         to ``model_input.inputs_embeds`` for the model forward to consume.
 
-        Left untouched: decode steps, non-multimodal models, and models with
-        a custom prefill (``merges_embeds_in_runner=False``, e.g. Qwen-VL)
-        that still embed inside their own forward.
+        Left untouched: decode steps and non-multimodal models.
         """
         if not model_input.is_prompt:
             return model_input
         model = self.model
         if not isinstance(model, RBLNOptimumMultimodalMixin):
-            return model_input
-        if not model.merges_embeds_in_runner:
             return model_input
 
         # int64 mirrors the dtype the model forward used to embed with

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -14,6 +14,7 @@
 import contextlib
 import logging
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, NamedTuple, Union, cast
 
 import numpy as np
@@ -73,6 +74,9 @@ import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
 from vllm_rbln.model_executor.model_loader.rbln_model_loader import get_optimum_model
 from vllm_rbln.model_executor.models.optimum import ModelInputForRBLN
+from vllm_rbln.model_executor.models.optimum.model_base import (
+    RBLNOptimumMultimodalMixin,
+)
 from vllm_rbln.utils.optimum.bucket import select_bucket_size
 from vllm_rbln.utils.optimum.predicates import is_qwen3_pooling
 from vllm_rbln.utils.optimum.registry import (
@@ -368,6 +372,7 @@ class RBLNOptimumModelRunner(
                         )
                 else:
                     with capture_ctx as model_reports:
+                        model_input = self._maybe_embed_inputs(model_input)
                         hidden_states = self.model(model_input)
                 if (
                     envs.VLLM_RBLN_METRICS
@@ -402,6 +407,38 @@ class RBLNOptimumModelRunner(
             ec_connector_output=ec_connector_output,
         )
         return None
+
+    def _maybe_embed_inputs(self, model_input: ModelInputForRBLN) -> ModelInputForRBLN:
+        """Compute prefill ``inputs_embeds`` at the runner level for
+        multimodal models, mirroring upstream vLLM.
+
+        Runs the vision encoder (``embed_multimodal``) and merges the result
+        into the text embeddings (``embed_input_ids``), attaching the result
+        to ``model_input.inputs_embeds`` for the model forward to consume.
+
+        Left untouched: decode steps, non-multimodal models, and models with
+        a custom prefill (``merges_embeds_in_runner=False``, e.g. Qwen-VL)
+        that still embed inside their own forward.
+        """
+        if not model_input.is_prompt:
+            return model_input
+        model = self.model
+        if not isinstance(model, RBLNOptimumMultimodalMixin):
+            return model_input
+        if not model.merges_embeds_in_runner:
+            return model_input
+
+        # int64 mirrors the dtype the model forward used to embed with
+        # (previously cast in preprocess_for_decoder before embed_input_ids).
+        input_ids = model_input.input_tokens.to(torch.int64)
+        multimodal_embeddings = model.embed_multimodal(
+            **(model_input.multi_modal_kwargs or {})
+        )
+        inputs_embeds = model.embed_input_ids(
+            input_ids,
+            multimodal_embeddings or None,
+        )
+        return replace(model_input, inputs_embeds=inputs_embeds)
 
     def mask_block_table(
         self,

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -418,24 +418,10 @@ class RBLNOptimumModelRunner(
     def _build_forward_inputs(
         self, model_input: ModelInputForRBLN
     ) -> ModelInputForRBLN:
-        """Assemble the model's forward inputs at the runner level for
-        multimodal models, mirroring upstream vLLM.
-
-        Prefill: run the model's ``build_prefill_forward_inputs`` (vision encode
-        + text merge, and — for MRoPE models — positions) and attach
-        ``inputs_embeds`` (+ ``position_embed``). The runner owns the per-request
-        MRoPE delta state: the hook returns the delta, the runner stores it.
-        Decode: compute MRoPE ``position_embed`` from the stored delta via the
-        model's ``compute_decode_position_embed`` (``None`` for non-MRoPE models,
-        which pass ``input_ids`` through).
-
-        Left untouched: non-multimodal models.
-        """
         model = self.model
         if not isinstance(model, RBLNOptimumMultimodalMixin):
             return model_input
 
-        # Runner owns the per-request MRoPE delta state, including cleanup.
         for request_id in model_input.finished_requests_ids:
             self.mrope_position_deltas.pop(request_id, None)
 


### PR DESCRIPTION
## Summary

Move multimodal **forward-input assembly** out of each model's `forward` and up to the **runner level**, mirroring upstream vLLM where `GPUModelRunner` produces `inputs_embeds` (and, for MRoPE models, positions) and hands them to the model.

This builds on `feature/mm-refactoring-2` (which introduced `RBLNOptimumMultimodalMixin` + shared `embed_multimodal` / `embed_input_ids`). Here we wire those into the runner, make the per-request MRoPE delta state **runner-owned**, and fold Qwen-VL into the same path.

Previously each model embedded inline in its prefill branch, and Qwen-VL additionally owned its own `rope_deltas` dict and computed decode positions inside `forward`. Now the runner assembles inputs via two **pure** model hooks and passes them to the model through `ModelInputForRBLN`.

## Design

Two pure hooks on `RBLNOptimumMultimodalMixin` (overridable per model):

- `build_prefill_forward_inputs(model_input) -> (inputs_embeds, position_embed | None, rope_delta | None)` — prefill. Default: `embed_multimodal` + `embed_input_ids` (no MRoPE). Qwen-VL overrides to also return the MRoPE `position_embed` and the rope delta.
- `compute_decode_position_embed(model_input, mrope_position_deltas) -> Tensor | None` — decode. Default `None` (non-MRoPE models pass `input_ids` through). Qwen-VL overrides.

The hooks are **pure**: they *return* the per-request MRoPE delta — they never mutate runner state. The **runner owns the state**: `RBLNOptimumModelRunner.mrope_position_deltas` (`request_id → delta`) mirrors upstream `CachedRequestState.mrope_position_delta`. It is populated at prefill, consumed at decode, and cleaned up on finished requests — all by the runner.

> The normal-path prefill hook (`build_prefill_forward_inputs`) is distinct from the EC-consumer-only `build_prefill_inputs_from_cache` (see below); the names are kept separate on purpose.

## Changes

- **`base.py`** — `ModelInputForRBLN` gains `inputs_embeds` and `position_embed` fields (runner-produced, model-consumed).
- **`optimum_model_runner.py`** — add runner-owned `mrope_position_deltas`; add `_build_forward_inputs()` that dispatches prefill/decode, stores the returned delta, attaches `inputs_embeds` / `position_embed`, and cleans up finished requests. Called before `self.model(model_input)` on the normal forward path (EC producer/consumer paths unchanged). `_build_forward_inputs()` runs *before* the `rebel.capture_reports()` context so the captured perf reports cover only the model forward, not the runner-level embed/position assembly.
- **`model_base.py`** — the two default hooks on `RBLNOptimumMultimodalMixin`.
- **`qwen_vl.py`** — override both hooks; drop the model-owned `self.rope_deltas` dict and the inline prefill / `_preprocess_embeds` logic from `forward`, which now just consumes `model_input.inputs_embeds` / `position_embed`.
- **Model forwards (6)** — `gemma3`, `paligemma`, `idefics3`, `llava`, `blip2`, `llava_next`: consume `model_input.inputs_embeds` instead of embedding inline.
- **`ec_disagg_helpers.py`** — the EC consumer path writes the rope delta into the runner-owned `mrope_position_deltas` (was the model's own dict).

## Naming (EC-path clarity)

The encoder-cache (EC) disaggregation hooks were renamed so their names match what they do at the runner level — they had `decoder` / a too-generic name even though they run on the EC consumer's **prefill** step:

| before | after | why |
| --- | --- | --- |
| `_run_decoder_with_cached_encoder` | `_run_prefill_with_cached_encoder` | It is the EC consumer's prefill step; `decoder` only referred to optimum-rbln's internal `prefill_decoder` runtime. |
| `build_prefill_inputs` | `build_prefill_inputs_from_cache` | EC-consumer-only entry point; disambiguates from the normal-path `build_prefill_forward_inputs`. |

`build_prefill_inputs_from_cache` is invoked **only** on the EC consumer prefill path (`_run_prefill_with_cached_encoder`); the normal path never reaches it. (EC itself is currently gated to `RBLNQwen3VLForConditionalGeneration`, so the `model_base` default and the Gemma3 `NotImplementedError` override are unreachable today.)

## Fix: MRO ordering

`RBLNOptimumMultimodalMixin` is now ordered **before** `RBLNOptimumDecoderMixin` in every MM model class. Previously the decoder mixin's `VllmModel.embed_input_ids(input_ids)` (a 2-arg Protocol stub) preceded the mixin's rich `embed_input_ids(input_ids, multimodal_embeddings, *, is_multimodal)` in the MRO, so the runner-level embed call raised:

```
TypeError: embed_input_ids() takes 2 positional arguments but 3 were given
```

`embed_input_ids` is the only method shared between the two mixin chains, so only its resolution changes (`forward` stays per-model, `compute_logits` / `preprocess_for_decoder` stay on the decoder mixin). Gemma3 additionally drops a redundant explicit `VllmModelForTextGeneration` base (already inherited via the decoder mixin) — MRO and `issubclass` checks are unchanged.

## Notes

- **Qwen-VL is now included** in the runner-level path — the earlier `merges_embeds_in_runner` opt-out flag has been removed.
- Qwen-VL decode `inputs_embeds` are still embedded inside `forward` (they depend on the padded `input_ids` produced by `preprocess_for_decoder`); only the positions (`position_embed`) are precomputed at the runner.
- EC producer/consumer encoder paths are otherwise unchanged; only MRoPE delta-state ownership moved to the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
