### PR TITLE
fix(core): accept alignment_tokens kwarg in RBLNSlidingWindowManager.cache_blocks

### DIFF
--- a/vllm_rbln/v1/kv_cache.py
+++ b/vllm_rbln/v1/kv_cache.py
@@ -84,7 +84,9 @@ class RBLNSlidingWindowManager(SingleTypeKVCacheManager):
     ) -> tuple[list[KVCacheBlock], ...]:
         return tuple([] for _ in kv_cache_group_ids)
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+    def cache_blocks(
+        self, request: Request, num_tokens: int, alignment_tokens: int | None = None
+    ) -> None:
         pass
 
     def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:


### PR DESCRIPTION
### 🚀 Summary of Changes

Upstream vLLM (the `dev-0.22.0` base) added an `alignment_tokens` keyword to `SingleTypeKVCacheManager.cache_blocks()`, and the SWA coordinator now always passes it (`cache_blocks(request, num_computed_tokens, alignment_tokens=self.lcm_block_size)`). The RBLN SWA override kept the old 2-arg signature, so every request reaching the scheduler raised:

```
TypeError: RBLNSlidingWindowManager.cache_blocks() got an unexpected keyword argument 'alignment_tokens'
```

1. **Signature sync:** add `alignment_tokens: int | None = None` to `RBLNSlidingWindowManager.cache_blocks()` so it matches the upstream base. The body stays a no-op — the RBLN SWA kernel uses a single block slid in-place and disables prefix caching, so there is nothing to cache or align.

**Result:** decode scheduling no longer crashes; an SWA model (gpt-oss-20b) parity run proceeds past `scheduler.schedule()`.

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Run a SWA-attention model parity (e.g. `openai/gpt-oss-20b`) on the RBLN backend.
2. Verify the engine gets past `RBLNScheduler.schedule()` without the `TypeError` above.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] The test method is described, and the expected result is clearly stated
