### PR TITLE
other(ci): pin fastapi below 0.137 for OpenAI entrypoint tests (dev)

### DIFF
--- a/.github/workflows/rbln_vllm-rbln_pytest.yaml
+++ b/.github/workflows/rbln_vllm-rbln_pytest.yaml
@@ -326,6 +326,15 @@ jobs:
               uv pip install --system --force-reinstall --no-cache-dir dist/vllm_rbln*.whl --index-url http://pypi-cache.devpi.svc.cluster.local/root/pypi/+simple/ --extra-index-url "${VLLM_CPU_URL}" --extra-index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple --index-strategy unsafe-best-match
             fi
 
+      # fastapi>=0.137 keeps included routers as `_IncludedRouter` (no `.path`),
+      # which breaks prometheus-fastapi-instrumentator's route-name middleware and
+      # crashes the OpenAI server on every request. Pin below 0.137 until the
+      # instrumentator handles the new route type.
+      - name: Pin fastapi below 0.137 (instrumentator compat)
+        if: steps.should_skip.outputs.skip != 'true'
+        run: |
+          uv pip install --system "fastapi[standard]<0.137"
+
       - name: Run pytest
         if: steps.should_skip.outputs.skip != 'true'
         env:


### PR DESCRIPTION
## Problem
It is not related with bumpup. It is related with recently released fastapi.
Same issue as #691 (which landed on `dev-0.22.0`): `pytest tests/entrypoints/openai` (the `openai` matrix in `pytest-arc`) crashes on the first request to the OpenAI server:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
  prometheus_fastapi_instrumentator/routing.py, line 55, in _get_route_name
    route_name = route.path
```

## Root cause

- **fastapi 0.137.0** (released 2026-06-14) changed `include_router`: child routes are kept as `_IncludedRouter` (a `BaseRoute` with no `.path`) instead of being flattened into `app.routes` as `APIRoute`.
- **prometheus-fastapi-instrumentator** (≤8.0.0) reads `route.path` for every request in its middleware → `AttributeError` before any handler runs.
- vLLM pins `fastapi[standard]>=0.115.0` with no upper bound, so a fresh CI install resolves to the newest fastapi (0.137.x). Dependency-resolution/timing issue, not specific to vllm-rbln.

## Fix



CI-only pin; `pyproject.toml` is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)