### PR TITLE
fix: fix minor vLLM 0.22.0 compatibility issues

### DIFF
--- a/vllm_rbln/lora/punica_wrapper/punica_rbln.py
+++ b/vllm_rbln/lora/punica_wrapper/punica_rbln.py
@@ -15,7 +15,6 @@
 from typing import Union, final
 
 import torch
-from vllm.lora.punica_wrapper import utils as punica_utils
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 from vllm_rbln.lora.inputs import LoRAInputs
@@ -175,15 +174,3 @@ class PunicaWrapperRBLN(PunicaWrapperBase):
     @property
     def sampler_indices_padded(self) -> torch.Tensor:
         return LoRAInputs.get_sampler_indices_padded()
-
-
-# FIXME(RBLN): LoRA metadata copies request pinned CPU memory, but RBLN
-# PrivateUse1 does not provide a pinned-memory allocator.
-if not getattr(punica_utils, "_rbln_async_tensor_h2d_patched", False):
-    async_tensor_h2d = punica_utils.async_tensor_h2d
-
-    def async_tensor_h2d_without_pin_memory(data, dtype, device, pin_memory=False):
-        return async_tensor_h2d(data, dtype, device, pin_memory=False)
-
-    punica_utils.async_tensor_h2d = async_tensor_h2d_without_pin_memory
-    punica_utils._rbln_async_tensor_h2d_patched = True

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -17,6 +17,7 @@ from copy import copy
 import numpy as np
 import torch
 import torch.nn as nn
+from rebel import CompileContext
 from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_dp_group, get_pp_group, get_tp_group
 from vllm.v1.attention.backend import CommonAttentionMetadata
@@ -47,8 +48,7 @@ class RBLNEagleProposer(EagleProposer):
     def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
         super().__init__(vllm_config, device, runner)
 
-        from rebel import CompileContext
-
+        self.runner = runner
         self.compile_context = CompileContext(use_weight_sharing=True)
 
         if self.supports_mm_inputs:

--- a/vllm_rbln/v1/spec_decode/medusa.py
+++ b/vllm_rbln/v1/spec_decode/medusa.py
@@ -16,6 +16,7 @@ from copy import copy
 
 import torch
 import torch.nn as nn
+from rebel import CompileContext
 from vllm.config import VllmConfig
 from vllm.distributed import get_dp_group, get_pp_group, get_tp_group
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -29,8 +30,6 @@ from vllm_rbln.torch_compile_backend import logged_rbln_backend
 class RBLNMedusaProposer(MedusaProposer):
     def __init__(self, vllm_config: VllmConfig, device: torch.device) -> None:
         super().__init__(vllm_config, device)
-
-        from rebel.compile_context import CompileContext
 
         self.compile_context = CompileContext(use_weight_sharing=True)
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -380,7 +380,6 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.use_rbln_sampler:
                 self.rejection_sampler = RBLNRejectionSampler(
                     self.sampler,
-                    seed=self.vllm_config.model_config.seed,
                     compile_context=self.compile_context,
                 )
             else:


### PR DESCRIPTION

<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

This PR contains small compatibility and cleanup fixes for dev-0.22.0.
<!-- Describe your changes in detail -->


  - 6fc329b0 : `revert 0885e20`
    Removes the RBLN-specific Punica async_tensor_h2d monkey patch and restores the previous behavior.

  - e3c813a0 : `remove seed in rejection_sampler`
    Drops the deprecated seed keyword when constructing RBLNRejectionSampler, matching vLLM 0.22.0’s sampler API.

  - 75363b75 : `fix: cleaning specdec proposer`
    Stores runner on RBLNEagleProposer and moves CompileContext imports to module scope for EAGLE and Medusa proposers.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe


---


### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes



---
