### PR TITLE
fix(deps): pin fastapi below 0.137 in pyproject instead of CI

### DIFF
--- a/.github/workflows/rbln_vllm-rbln_pytest.yaml
+++ b/.github/workflows/rbln_vllm-rbln_pytest.yaml
@@ -340,15 +340,6 @@ jobs:
               uv pip install --system --force-reinstall --no-cache-dir dist/vllm_rbln*.whl --index-url http://pypi-cache.devpi.svc.cluster.local/root/pypi/+simple/ --extra-index-url "${VLLM_CPU_URL}" --extra-index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple --index-strategy unsafe-best-match
             fi
 
-      # fastapi>=0.137 keeps included routers as `_IncludedRouter` (no `.path`),
-      # which breaks prometheus-fastapi-instrumentator's route-name middleware and
-      # crashes the OpenAI server on every request. Pin below 0.137 until the
-      # instrumentator handles the new route type.
-      - name: Pin fastapi below 0.137 (instrumentator compat)
-        if: steps.should_skip.outputs.skip != 'true'
-        run: |
-          uv pip install --system "fastapi[standard]<0.137"
-
       - name: Run pytest
         if: steps.should_skip.outputs.skip != 'true'
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "datasets",
     "qwen_vl_utils",
     "vllm==0.22.0+cpu",
+    "fastapi[standard]<0.137",
     "torch",
     "torchvision",
     "torchaudio",


### PR DESCRIPTION
## Summary
- Same issue in upstream vllm https://github.com/vllm-project/vllm/pull/45594 because of new release of fastapi.
- Move the `fastapi[standard]<0.137` pin out of the pytest CI workflow and into the project `dependencies` in `pyproject.toml`, so the constraint applies to every install (not just CI).
- Remove the now-redundant "Pin fastapi below 0.137" step from `.github/workflows/rbln_vllm-rbln_pytest.yaml`.

## Why
`fastapi>=0.137` keeps included routers as `_IncludedRouter` (no `.path`), which breaks prometheus-fastapi-instrumentator's route-name middleware and crashes the OpenAI server on every request. Keeping the pin in `pyproject.toml` ensures every environment resolves to a compatible fastapi until the instrumentator handles the new route type.

## Note
CI installs the wheel with `--force-reinstall --no-cache-dir ... --index-strategy unsafe-best-match`, so the resolver should now honor this constraint at install time. Worth confirming a CI run actually resolves fastapi <0.137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)