### PR TITLE
fix(attn): keep dummy_run block table on CPU in device-tensor mode

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2561,7 +2561,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                 else:
                     blk_table = input_batch.block_table[kv_cache_group_id]
-                    blk_table_tensor = blk_table.get_device_tensor(num_reqs)
+                    # Keep on CPU in device-tensor mode (like _prepare_inputs) so
+                    # .to(device) yields a stable contiguous stride for dynamo.
+                    blk_table_tensor = (
+                        blk_table.get_cpu_tensor()[:num_reqs]
+                        if envs.VLLM_RBLN_USE_DEVICE_TENSOR
+                        else blk_table.get_device_tensor(num_reqs)
+                    )
                     slot_mapping = blk_table.slot_mapping.gpu[
                         :total_num_scheduled_tokens
                     ]


### PR DESCRIPTION
### 🚀 Summary of Changes

`dummy_run` built its block-table tensor with `get_device_tensor()` unconditionally, while `_prepare_inputs` uses `get_cpu_tensor()` in device-tensor mode. This asymmetry triggers a spurious dynamo recompile of the decode graph.

1. **Root cause**: `local_block_tables = block_tables_tensor[..., :1]` (`flash_attention.py`) is a non-contiguous view (row stride = block-table width). With a **CPU** source, `.to(self.device)` copies it into a **contiguous** device tensor (stride 1); with an **already-on-device** source, `.to()` is a **no-op**, leaving it **non-contiguous** (stride = num_blocks). Dynamo guards this stride, so warm-up (`_prepare_inputs`, stride 1) and the busy-loop `dummy_run` (stride num_blocks) disagree → a spurious decode recompile.

2. **Fix**: `dummy_run` mirrors `_prepare_inputs` — uses `get_cpu_tensor()[:num_reqs]` when `VLLM_RBLN_USE_DEVICE_TENSOR`, so the later `.to(device)` yields a contiguous device tensor with a stable stride. Only the device-tensor branch changes; the non-device path is untouched.

3. **Result**: the spurious decode recompile is gone. gpt-oss-120b (sliding-window) with DP4 + `VLLM_RBLN_USE_DEVICE_TENSOR=1` runs to completion (recompile reproduced without the fix, gone with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)