### PR TITLE
fix(model): support Gemma4 multimodal decode on the vLLM path

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/gemma3.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma3.py
@@ -296,14 +296,20 @@ class RBLNOptimumGemma3ForConditionalGeneration(
             # token_type_ids model_input != token_type_ids of gemma3
             # https://github.com/huggingface/transformers/blob/d0c9c66d1c09df3cd70bf036e813d88337b20d4c/src/transformers/models/gemma3/processing_gemma3.py#L143
             token_type_ids = torch.zeros_like(input_ids)
-            token_type_ids[input_ids == self.model.config.image_token_index] = 1
+            # `_image_token_id()` resolves the placeholder id per model: Gemma3Config
+            # has `image_token_index`, Gemma4Config (which inherits this forward) has
+            # `image_token_id`. Subclasses override `_image_token_id()` accordingly.
+            token_type_ids[input_ids == self._image_token_id()] = 1
 
             multimodal_embeddings = self.embed_multimodal(
                 **(model_input.multi_modal_kwargs or {})
             )
+            # Pass through as-is: `embed_input_ids` already treats None / len()==0 as
+            # "text only". A bare `... or None` raises on Gemma4, whose multimodal
+            # embeddings are a Tensor ("Boolean value of Tensor ... is ambiguous").
             inputs_embeds = self.embed_input_ids(
                 input_ids,
-                multimodal_embeddings or None,
+                multimodal_embeddings,
             )
             if self.model.language_model.prefill_decoder is None:
                 raise version_error
@@ -408,8 +414,9 @@ class RBLNOptimumGemma3ForConditionalGeneration(
     ) -> torch.Tensor:
         # Gemma3's image token can be OOV; PAD-mask those positions before the
         # text embedding lookup (mirrors optimum-rbln's _preprocess_prefill).
-        config = self.model.config
-        if config.image_token_index >= self.model.vocab_size:
+        # `_image_token_id()` resolves per model (Gemma3 `image_token_index` /
+        # Gemma4 `image_token_id`).
+        if self._image_token_id() >= self.model.vocab_size:
             input_ids = input_ids.masked_fill(is_multimodal, PAD_TOKEN_ID)
         return self.model.get_input_embeddings()(input_ids)
 

--- a/vllm_rbln/model_executor/models/optimum/gemma4.py
+++ b/vllm_rbln/model_executor/models/optimum/gemma4.py
@@ -60,6 +60,11 @@ class RBLNGemma4MultiModalProcessor(
 class RBLNOptimumGemma4ForConditionalGeneration(
     RBLNOptimumGemma3ForConditionalGeneration
 ):
+    def _image_token_id(self) -> int:
+        # Gemma4Config names the image placeholder `image_token_id`
+        # (Gemma3Config uses `image_token_index`, the base-class default).
+        return self.model.config.image_token_id
+
     def _process_image_input(
         self, image_input: Gemma4ImageInputs
     ) -> list[torch.Tensor]:


### PR DESCRIPTION
### 🚀 Summary of Changes

Fix the Gemma4 multimodal decode path on vLLM. `RBLNOptimumGemma4ForConditionalGeneration` inherits `RBLNOptimumGemma3ForConditionalGeneration.forward`, but Gemma4's config and multimodal embeddings differ from Gemma3, which broke the inherited path.

| Symptom | Root cause | Fix |
|---|---|---|
| `AttributeError: 'Gemma4Config' object has no attribute 'image_token_index'` | `forward` used `config.image_token_index` directly — only present on `Gemma3Config` (`Gemma4Config` exposes `image_token_id`) | Route both usages through `_image_token_id()`. The base default keeps Gemma3's `image_token_index`; **Gemma4 overrides it to return `image_token_id`** |
| `RuntimeError: Boolean value of Tensor with more than one value is ambiguous` | `multimodal_embeddings or None` — Gemma4's multimodal embeddings are a **Tensor** (Gemma3's are a list), so the truthiness check fails | Pass `multimodal_embeddings` through as-is; `embed_input_ids` already treats `None` / `len()==0` as text-only |

**Gemma3 behavior is unchanged** (`_image_token_id()` default equals the previous `image_token_index`, same value).

#### Verification (local)
- gemma4-31B-it: **compile + golden (optimum-rbln) + vLLM run all pass** (previously vLLM run failed with the two errors above).
- gemma3: parity unaffected (full-layer parity stays 1.0).

> Note: this is a Gemma4-specific follow-up on top of the decode `position_ids` / `pad_len` (chunked-prefill left-pad accounting) correction already merged to `dev`.

---

### 📌 Related Issues / Tickets

* Related to # (TBD)

---

### ✅ Type of Change

- [x] 🐛 Bug fix
