### PR TITLE
fix(chore): remove legacy tensor_parallel_size

### DIFF
--- a/tests/optimum_compile/converter/test_params.py
+++ b/tests/optimum_compile/converter/test_params.py
@@ -33,7 +33,7 @@ class TestParseDecoder:
         assert params.max_seq_len == 8192
         assert params.kvcache_block_size == 4096
         assert params.prefill_chunk_size == 256
-        # tensor_parallel_size is populated by the caller
+        # num_devices is populated by the caller
         # (`from_rbln_config`), not `_parse_decoder`,
         # so it is not asserted here.
 

--- a/vllm_rbln/utils/optimum/converter/from_optimum.py
+++ b/vllm_rbln/utils/optimum/converter/from_optimum.py
@@ -108,8 +108,8 @@ def sync_from_optimum(
     update_block_size(vllm_config, params.kvcache_block_size, params.prefill_chunk_size)
     # Set num_blocks in cache_config based on rbln_config.json
     update_num_blocks(vllm_config, params.num_blocks)
-    # Sync tensor_parallel_size in envs with optimum pre-compiled model
-    envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK = params.tensor_parallel_size
+    # Sync num_devices in envs with optimum pre-compiled model
+    envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK = params.num_devices
 
 
 def update_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> None:

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -86,7 +86,7 @@ class RBLNParams:
     max_seq_len: int | None = None
     kvcache_block_size: int | None = None
     prefill_chunk_size: int = 128
-    tensor_parallel_size: int = 1
+    num_devices: int = 1
 
     @classmethod
     def from_rbln_config(
@@ -94,7 +94,7 @@ class RBLNParams:
     ) -> "RBLNParams":
         """Parse rbln_config according to the model architecture."""
         hf_config = vllm_config.model_config.hf_config
-        tensor_parallel_size = _cfg_get(rbln_config, "tensor_parallel_size", 1)
+        num_devices = _cfg_get(rbln_config, "num_devices", 1)
 
         if is_enc_dec_arch(hf_config):
             params = cls._parse_enc_dec(rbln_config)
@@ -105,7 +105,7 @@ class RBLNParams:
         else:
             params = cls._parse_decoder(rbln_config)
 
-        params.tensor_parallel_size = tensor_parallel_size
+        params.num_devices = num_devices
         return params
 
     @classmethod

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -64,7 +64,7 @@ def build_compile_options(compile_context: rebel.CompileContext) -> dict:
     if envs.VLLM_RBLN_COMPILE_STRICT_MODE:
         options["mode"] = "strict"
     if has_torch_rbln or use_dt:
-        options["tensor_parallel_size"] = 1
+        options["num_devices"] = 1
         if not use_dt:
             options["use_global_ctx"] = True
             options["global_device_id"] = 0

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1608,7 +1608,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         process_group_dict[DP.cpu_group.group_name] = DP.ranks
 
         options = {
-            "tensor_parallel_size": envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK,
+            "num_devices": envs.VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK,
             "process_group_dict": process_group_dict,
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
             "mode": "strict",


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

The remaining legacy `tensor_parallel_size` must be removed.

1. Just rename RBLNParams.tensor_parallel_size to RBLNParams.num_devices
2. Parsing rbln_config from addtional_config or optimum-rbln pre-compiled using `num_devices`

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
3. Verify output: `...`
4. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
