### PR TITLE
fix(deps): constrain datasets to >=4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "setuptools>=64",
     "setuptools-scm>=8",
     "pyyaml",
-    "datasets",
+    "datasets>=4.0.0",
     "qwen_vl_utils",
     "vllm==0.22.0+cpu",
     "fastapi[standard]<0.137",


### PR DESCRIPTION
### 🚀 Summary of Changes

> Adds a lower bound on the `datasets` core dependency.

The unbounded `datasets` dependency let `uv` resolve down to the 2021-era `datasets==1.2.1`, which pins `tqdm<4.50`. That old `tqdm` lacks `tqdm.contrib.logging`, so `transformers 5.x` fails to import and `from vllm import LLM` breaks at import time.

`datasets>=4.0.0` excludes both `1.2.1` and the `2.x`/`3.x` line (which caps `huggingface-hub<1.0`, conflicting with `transformers 5.x`), forcing `uv` to pick a `fsspec` that modern `datasets` accepts. Only `load_dataset` is used in this repo, so no version-sensitive API is affected.

---

### 📌 Related Issues / Tickets

* Resolves #720
* Related to https://github.com/rebellions-sw/fsw-integration/pull/738 (downstream constraint-dependencies workaround)

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Resolve deps with the nightly resolver:
   `uv pip compile pyproject.toml --prerelease=if-necessary-or-explicit --index-strategy=unsafe-best-match`
2. Verify `datasets` resolves to `>=4.0.0` (not `1.2.1`) and `tqdm` to `>=4.66`.
3. Verify `python -c "from vllm import LLM"` no longer raises `ModuleNotFoundError: No module named 'tqdm.contrib.logging'`.

---

### 💬 Notes

* Constraint logic verified against PyPI metadata (datasets 4.0.0/5.0.0 require `tqdm>=4.66.3`, cap `fsspec`, allow `huggingface-hub>=1.0`). Full `uv` resolve not reproduced locally — needs the Nexus nightly index + `torch 2.11+cpu`; please confirm in CI.