### PR TITLE
perf(dp): compile padded-decode only for max bucket in PD disaggregation

### DIFF
--- a/tests/torch_compile/unit/test_dp_padding.py
+++ b/tests/torch_compile/unit/test_dp_padding.py
@@ -302,9 +302,63 @@ class TestGetDpPadding:
                 batch_bucket_size=8,
                 is_prefill=False,
             )
-        # any_prefill path: bucket left as the initial (caller-provided) value,
+        # any_prefill + specialized_moe_decode → bucket forced to max bucket (8),
         # padded falls back to max_num_batched_tokens.
-        assert bucket == 8  # caller's initial guess preserved on any-prefill path
+        assert bucket == 8  # already max bucket; value unchanged
+        assert padded == 512
+
+    def test_any_prefill_routes_to_max_bucket(self):
+        """In PD disaggregation (any rank in prefill), padded-decode is always
+        routed to the max bucket so only one padded-decode model is compiled."""
+        runner = _FakeRunner(
+            dp_size=4,
+            dp_rank=0,
+            decode_buckets=[1, 4, 8],
+            max_num_batched_tokens=512,
+            specialized_moe_decode=True,
+        )
+        # Rank 1 is in prefill → any_prefill=True.
+        per_rank = [
+            _encode(4, 4, False),
+            _encode(256, 1, True),
+            _encode(4, 4, False),
+            _encode(4, 4, False),
+        ]
+        with _patch_all_reduce(per_rank):
+            bucket, padded, across_dp, _max_per_req = runner.get_dp_padding(
+                num_tokens=4,
+                num_reqs=4,
+                batch_bucket_size=4,  # caller initially chose bucket=4
+                is_prefill=False,
+            )
+        # any_prefill + specialized_moe_decode → forced to max bucket (8)
+        assert bucket == 8
+        assert padded == 512
+
+    def test_any_prefill_non_specialized_moe_does_not_change_bucket(self):
+        """With specialized_moe_decode=False, any_prefill does NOT force max bucket."""
+        runner = _FakeRunner(
+            dp_size=4,
+            dp_rank=0,
+            decode_buckets=[1, 4, 8],
+            max_num_batched_tokens=512,
+            specialized_moe_decode=False,
+        )
+        per_rank = [
+            _encode(4, 4, False),
+            _encode(256, 1, True),
+            _encode(4, 4, False),
+            _encode(4, 4, False),
+        ]
+        with _patch_all_reduce(per_rank):
+            bucket, padded, across_dp, _max_per_req = runner.get_dp_padding(
+                num_tokens=4,
+                num_reqs=4,
+                batch_bucket_size=4,
+                is_prefill=False,
+            )
+        # bucket unchanged (non-specialized path doesn't modify it)
+        assert bucket == 4
         assert padded == 512
 
     def test_non_specialized_moe_uses_max_num_batched_tokens(self):

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -761,8 +761,8 @@ class TestDetermineAvailableMemory:
         ):
             plat.get_device_name.return_value = "RBLN-CA25"
             worker.determine_available_memory()
-        # 1 + (1 + 1) * 2 = 5
-        assert est.call_args.kwargs["num_runtimes"] == 5
+        # 1 prefill + 2 normal decodes + 1 padded decode (max bucket only) = 4
+        assert est.call_args.kwargs["num_runtimes"] == 4
 
     def test_mixed_dtype_params(self):
         """bf16 params counted as attention, non-bf16 as experts."""

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1980,7 +1980,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     max_batch_size
                 )
                 assert batch_bucket_size is not None
-                # Caller pre-computes pow2-rounded value to align with padded tensor shape.
+                # Caller pre-computes pow2-rounded value to match padded shape.
                 if spec_decode_max_query_len is not None:
                     max_per_req_across_dp = RBLNDPMetadata.num_tokens_across_dp(
                         spec_decode_max_query_len, dp_size, dp_rank
@@ -2310,7 +2310,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         logger.info("Warm-up: prefill (seq_len=%d)", prefill_seq_len)
         self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
 
-        # FIXME(RBLN): cap at block_size // 2 (single-block-per-request limit + spec decode).
+        # FIXME(RBLN): cap at block_size//2 (single-block/req limit + spec decode).
         decode_max_seq_len = min(
             self.max_model_len // 2,
             self.cache_config.block_size // 2,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1876,9 +1876,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         if self.specialized_moe_decode:
             if any_prefill:
-                # PD disaggregation: all padded-decode steps share
-                # num_padded_tokens=max_num_batched_tokens, so route to the max
-                # bucket to compile padded-decode only once.
+                # any_prefill always uses max_num_batched_tokens → max bucket suffices.
                 batch_bucket_size = self.bucketing_manager.decode_batch_buckets[-1]
             else:
                 assert num_reqs_across_dp_cpu is not None
@@ -1887,20 +1885,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     max_batch_size
                 )
                 assert batch_bucket_size is not None
-                # Determine max_tokens_per_req as cross-DP max of per-rank
-                # max(per-req scheduled length). When spec decode is active the
-                # caller pre-computes a pow2-rounded local value so the resulting
-                # num_padded_tokens always matches the actual padded tensor size
-                # produced by pad_speculative_draft_tokens (and aligns with the
-                # pow2 query_len set exercised during warmup).
+                # Caller pre-computes pow2-rounded value to align with padded tensor shape.
                 if spec_decode_max_query_len is not None:
                     max_per_req_across_dp = RBLNDPMetadata.num_tokens_across_dp(
                         spec_decode_max_query_len, dp_size, dp_rank
                     )
                     max_tokens_per_req = int(max_per_req_across_dp.max().item())
                 else:
-                    # Pure single-token decode: ceil(num_tokens/num_reqs) suffices
-                    # and is 1 for the standard case.
                     clamped_reqs = num_reqs_across_dp_cpu.clamp(min=1)
                     tokens_per_req_per_rank = (
                         num_tokens_across_dp_cpu + clamped_reqs - 1
@@ -2218,13 +2209,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         logger.info("Warm-up: prefill (seq_len=%d)", prefill_seq_len)
         self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
 
-        # FIXME(RBLN): At the moment, a single request can’t access multiple
-        # blocks per layer under the current implementation, so we’re forced
-        # to reduce the warmup length to a reasonable value for now.
-        # This is mainly because we still have to run the computation over
-        # the padded tokens in speculative decoding scenario as well.
-        # Stay within a single partition (block_size // 2) — required for
-        # spec decode correctness.
+        # FIXME(RBLN): cap at block_size // 2 (single-block-per-request limit + spec decode).
         decode_max_seq_len = min(
             self.max_model_len // 2,
             self.cache_config.block_size // 2,
@@ -2233,13 +2218,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # compile decode graph considering decode batch buckets
         max_decode_bucket = self.bucketing_manager.decode_batch_buckets[-1]
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
-            # Always-full-spec design: with sliding window padding, every
-            # decode step's runtime query length is num_spec_tokens + 1
-            # regardless of the proposer's output length or block-boundary
-            # position. The scheduler enforces this by sliding the query
-            # window backward to cover any deficit (variable-length drafts
-            # OR boundary squeeze). Only the spec-disabled case still uses
-            # query_len = 1.
+            # Full-spec: query_len = num_spec_tokens + 1 (sliding window enforced by scheduler).
             if self.num_spec_tokens > 0:
                 query_len_range = [self.num_spec_tokens + 1]
             else:
@@ -2290,9 +2269,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 )
                 self._execute_dummy_requests(so, cso, current_intermediate_tensors)
 
-                # In PD disaggregation, any_prefill=True always routes padded-decode
-                # to the max bucket (see get_dp_padding). Compile only at max bucket
-                # to avoid one padded-decode runtime per bucket.
+                # Padded-decode always maps to max bucket in PD mode; compile once.
                 if self.specialized_moe_decode and (
                     batch_bucket_size == max_decode_bucket
                 ):
@@ -2308,18 +2285,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         num_padded_tokens=self.max_num_batched_tokens,
                     )
 
-        # FIXME: remove this code after #474(sampler with decode batch) is merged
-        # compile sampler for all possible decode batches
+        # FIXME: remove after #474 (sampler with decode batch) is merged.
         max_decode_batch = self.bucketing_manager.decode_batch_buckets[-1]
-        # Sampler batch at runtime equals the number of sampling positions
-        # this step, which depends on num_reqs the scheduler actually batches
-        # (any integer in 1..max_decode_batch). Unlike model_wrapper's query
-        # length, sampler shape has no cross-DP padding tie-in, so warm up
-        # every integer batch size to avoid hot-path sampler recompiles.
-        # When spec decoding is active, the sampler query window matches
-        # the decode model's: num_spec_tokens + 1. Mirror the decode warmup
-        # pattern (override num_scheduled + pass scheduled_spec_decode_tokens)
-        # so the sampler graph is compiled for the full-spec shape.
         sampler_query_len = self.num_spec_tokens + 1 if self.num_spec_tokens > 0 else 1
         dummy_decode_requests = []
         dummy_decode_num_scheduled_tokens = {}

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1872,36 +1872,42 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         max_tokens_per_req_across_dp: int | None = None
         any_prefill = num_reqs_across_dp_cpu is None
-        if any_prefill or not self.specialized_moe_decode:
-            num_padded_tokens = self.max_num_batched_tokens
-        else:
-            assert num_reqs_across_dp_cpu is not None
-            max_batch_size = int(torch.max(num_reqs_across_dp_cpu).item())
-            batch_bucket_size = self.bucketing_manager.find_decode_batch_bucket(
-                max_batch_size
-            )
-            assert batch_bucket_size is not None
-            # Determine max_tokens_per_req as cross-DP max of per-rank
-            # max(per-req scheduled length). When spec decode is active the
-            # caller pre-computes a pow2-rounded local value so the resulting
-            # num_padded_tokens always matches the actual padded tensor size
-            # produced by pad_speculative_draft_tokens (and aligns with the
-            # pow2 query_len set exercised during warmup).
-            if spec_decode_max_query_len is not None:
-                max_per_req_across_dp = RBLNDPMetadata.num_tokens_across_dp(
-                    spec_decode_max_query_len, dp_size, dp_rank
-                )
-                max_tokens_per_req = int(max_per_req_across_dp.max().item())
+        num_padded_tokens = self.max_num_batched_tokens
+
+        if self.specialized_moe_decode:
+            if any_prefill:
+                # PD disaggregation: all padded-decode steps share
+                # num_padded_tokens=max_num_batched_tokens, so route to the max
+                # bucket to compile padded-decode only once.
+                batch_bucket_size = self.bucketing_manager.decode_batch_buckets[-1]
             else:
-                # Pure single-token decode: ceil(num_tokens/num_reqs) suffices
-                # and is 1 for the standard case.
-                clamped_reqs = num_reqs_across_dp_cpu.clamp(min=1)
-                tokens_per_req_per_rank = (
-                    num_tokens_across_dp_cpu + clamped_reqs - 1
-                ) // clamped_reqs
-                max_tokens_per_req = int(tokens_per_req_per_rank.max().item())
-            num_padded_tokens = batch_bucket_size * max_tokens_per_req
-            max_tokens_per_req_across_dp = max_tokens_per_req
+                assert num_reqs_across_dp_cpu is not None
+                max_batch_size = int(torch.max(num_reqs_across_dp_cpu).item())
+                batch_bucket_size = self.bucketing_manager.find_decode_batch_bucket(
+                    max_batch_size
+                )
+                assert batch_bucket_size is not None
+                # Determine max_tokens_per_req as cross-DP max of per-rank
+                # max(per-req scheduled length). When spec decode is active the
+                # caller pre-computes a pow2-rounded local value so the resulting
+                # num_padded_tokens always matches the actual padded tensor size
+                # produced by pad_speculative_draft_tokens (and aligns with the
+                # pow2 query_len set exercised during warmup).
+                if spec_decode_max_query_len is not None:
+                    max_per_req_across_dp = RBLNDPMetadata.num_tokens_across_dp(
+                        spec_decode_max_query_len, dp_size, dp_rank
+                    )
+                    max_tokens_per_req = int(max_per_req_across_dp.max().item())
+                else:
+                    # Pure single-token decode: ceil(num_tokens/num_reqs) suffices
+                    # and is 1 for the standard case.
+                    clamped_reqs = num_reqs_across_dp_cpu.clamp(min=1)
+                    tokens_per_req_per_rank = (
+                        num_tokens_across_dp_cpu + clamped_reqs - 1
+                    ) // clamped_reqs
+                    max_tokens_per_req = int(tokens_per_req_per_rank.max().item())
+                num_padded_tokens = batch_bucket_size * max_tokens_per_req
+                max_tokens_per_req_across_dp = max_tokens_per_req
 
         return (
             batch_bucket_size,
@@ -2225,6 +2231,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         # compile decode graph considering decode batch buckets
+        max_decode_bucket = self.bucketing_manager.decode_batch_buckets[-1]
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
             # Always-full-spec design: with sliding window padding, every
             # decode step's runtime query length is num_spec_tokens + 1
@@ -2281,15 +2288,25 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     batch_bucket_size,
                     query_len,
                 )
-                if self.specialized_moe_decode:
+                self._execute_dummy_requests(so, cso, current_intermediate_tensors)
+
+                # In PD disaggregation, any_prefill=True always routes padded-decode
+                # to the max bucket (see get_dp_padding). Compile only at max bucket
+                # to avoid one padded-decode runtime per bucket.
+                if self.specialized_moe_decode and (
+                    batch_bucket_size == max_decode_bucket
+                ):
+                    logger.info(
+                        "Warm-up: padded decode (batch_bucket=%d, num_padded=%d)",
+                        batch_bucket_size,
+                        self.max_num_batched_tokens,
+                    )
                     self._execute_dummy_requests(
                         so,
                         cso,
                         current_intermediate_tensors,
                         num_padded_tokens=self.max_num_batched_tokens,
                     )
-
-                self._execute_dummy_requests(so, cso, current_intermediate_tensors)
 
         # FIXME: remove this code after #474(sampler with decode batch) is merged
         # compile sampler for all possible decode batches

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -220,7 +220,8 @@ class RBLNWorker(WorkerBase):
             self.model_runner.bucketing_manager.decode_batch_buckets_count
         )
 
-        num_runtimes = 1 + (1 + specialized_moe_decode) * decode_batch_buckets_count
+        # 1 prefill + N normal decodes + 1 padded decode (max bucket only)
+        num_runtimes = 1 + decode_batch_buckets_count + specialized_moe_decode
 
         ratio: float = 1.0
         if self.model_config.quantization is not None:


### PR DESCRIPTION
### Summary

**Problem**

PD 분산 추론(Prefill-Decode disaggregation) 모드에서 `specialized_moe_decode=True`일 때, `_warm_up_model_inner`가 decode 버킷 **각각**에 대해 padded-decode 모델을 컴파일했다. 그러나 `any_prefill=True` 상태(어느 DP rank든 prefill 중)에서는 `get_dp_padding`이 항상 `num_padded_tokens = max_num_batched_tokens`를 반환하므로, 실제로 사용되는 컴파일 키는 버킷 수와 무관하게 단 하나다.

**Solution**

padded-decode 컴파일을 버킷별 루프에서 꺼내어 **max 버킷 한 번만** 수행한다.

```
# Before: 1 + (1 + moe) × N runtimes
num_runtimes = 1 + (1 + specialized_moe_decode) * decode_batch_buckets_count

# After:  1 + N + moe runtimes
num_runtimes = 1 + decode_batch_buckets_count + specialized_moe_decode
```

| 버킷 수 (N) | Before | After | 절감 |
|:-----------:|:------:|:-----:|:----:|
| 3 (1,8,16)  | 7      | 5     | −2   |
| 5 (1,4,8,16,32) | 11 | 7     | −4   |

- `get_dp_padding`: `any_prefill=True AND specialized_moe_decode=True`이면 `batch_bucket_size`를 max 버킷으로 강제해 런타임이 컴파일된 슬롯에 항상 hit하도록 함
- `determine_available_memory`: `num_runtimes` 공식 갱신으로 HBM 예측 정확도 유지

### Test plan

- [ ] `tests/torch_compile/unit/test_dp_padding.py` — `test_any_prefill_routes_to_max_bucket`, `test_any_prefill_non_specialized_moe_does_not_change_bucket` 추가, 전체 pass
- [ ] `tests/torch_compile/unit/v1/worker/test_rbln_worker.py::TestDetermineAvailableMemory` — `num_runtimes` 기대값 갱신, pass
- [ ] E2E: `gpt-oss-120b --dp 4 --ep --rsd 1` parity 확인

### Reviewer

Primary: (지정 필요)
Secondary: (코드 오너)
