### PR TITLE
fix(gemma3,4): resolve image_prefill_chunk_size (int or list) from optimum-rbln

### DIFF
--- a/tests/optimum_compile/converter/test_params.py
+++ b/tests/optimum_compile/converter/test_params.py
@@ -183,3 +183,44 @@ class TestParseMultimodal:
         }
         params = RBLNParams._parse_multimodal(cfg)
         assert params.batch_size == 2
+
+
+class TestImagePrefillChunkSize:
+    def _cfg(self, value):
+        return {
+            "language_model": {
+                "kvcache_num_blocks": 16,
+                "batch_size": 1,
+                "max_seq_len": 2048,
+                "kvcache_partition_len": 128,
+                "image_prefill_chunk_size": value,
+            },
+        }
+
+    def test_gemma3_int_normalized_to_list(self):
+        params = RBLNParams._parse_multimodal(self._cfg(256))
+        assert params.image_prefill_chunk_size == [256]
+
+    def test_gemma4_list_passes_through(self):
+        params = RBLNParams._parse_multimodal(self._cfg([1152, 640, 384]))
+        assert params.image_prefill_chunk_size == [1152, 640, 384]
+
+    def test_absent_is_none(self):
+        cfg = {
+            "language_model": {
+                "kvcache_num_blocks": 16,
+                "batch_size": 1,
+                "max_seq_len": 2048,
+                "kvcache_partition_len": 128,
+            },
+        }
+        params = RBLNParams._parse_multimodal(cfg)
+        assert params.image_prefill_chunk_size is None
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(TypeError):
+            RBLNParams._parse_multimodal(self._cfg("256"))
+
+    def test_bool_rejected(self):
+        with pytest.raises(TypeError):
+            RBLNParams._parse_multimodal(self._cfg(True))

--- a/tests/v1/core/test_chunked_prefill_pad.py
+++ b/tests/v1/core/test_chunked_prefill_pad.py
@@ -31,12 +31,12 @@ from vllm_rbln.v1.core.optimum_kv_cache_manager import RBLNKVCacheManager
 def _make_manager(
     prefill_chunk_size: int,
     attn_block_size: int,
-    image_prefill_chunk_sizes: list[int] | None = None,
+    image_prefill_chunk_size: list[int] | None = None,
 ) -> RBLNKVCacheManager:
     mgr = object.__new__(RBLNKVCacheManager)
     mgr.prefill_chunk_size = prefill_chunk_size
     mgr.attn_block_size = attn_block_size
-    mgr.image_prefill_chunk_sizes = image_prefill_chunk_sizes
+    mgr.image_prefill_chunk_size = image_prefill_chunk_size
     return mgr
 
 
@@ -64,7 +64,7 @@ def _image(offset: int, num_tokens: int, *, lead: int = 0, trail: int = 0):
 
 class TestImageChunkSize:
     def test_smallest_bucket_that_fits(self):
-        mgr = _make_manager(128, 4096, image_prefill_chunk_sizes=[1152, 640, 384])
+        mgr = _make_manager(128, 4096, image_prefill_chunk_size=[1152, 640, 384])
         assert mgr._image_chunk_size(256) == 384
         assert mgr._image_chunk_size(384) == 384
         assert mgr._image_chunk_size(385) == 640
@@ -73,18 +73,18 @@ class TestImageChunkSize:
 
     def test_run_exceeds_all_buckets_raises(self):
         # buckets are descending; a run larger than the largest bucket is invalid.
-        mgr = _make_manager(128, 4096, image_prefill_chunk_sizes=[1152, 640, 384])
+        mgr = _make_manager(128, 4096, image_prefill_chunk_size=[1152, 640, 384])
         with pytest.raises(ValueError):
             mgr._image_chunk_size(2000)
 
     def test_no_buckets_falls_back_to_text_chunk(self):
-        mgr = _make_manager(256, 4096, image_prefill_chunk_sizes=None)
+        mgr = _make_manager(256, 4096, image_prefill_chunk_size=None)
         assert mgr._image_chunk_size(256) == 256
-        mgr_empty = _make_manager(256, 4096, image_prefill_chunk_sizes=[])
+        mgr_empty = _make_manager(256, 4096, image_prefill_chunk_size=[])
         assert mgr_empty._image_chunk_size(256) == 256
 
     def test_gemma3_single_bucket(self):
-        mgr = _make_manager(256, 4096, image_prefill_chunk_sizes=[256])
+        mgr = _make_manager(256, 4096, image_prefill_chunk_size=[256])
         assert mgr._image_chunk_size(256) == 256
 
 
@@ -155,7 +155,7 @@ class TestChunkedPrefillPadWithImages:
         mgr = _make_manager(
             prefill_chunk_size=256,
             attn_block_size=4096,
-            image_prefill_chunk_sizes=[256],
+            image_prefill_chunk_size=[256],
         )
         req = _request(_image(100, 256, lead=2, trail=2))
         assert mgr._chunked_prefill_pad(req, query_len=1000) == 0
@@ -173,7 +173,7 @@ class TestChunkedPrefillPadWithImages:
         mgr = _make_manager(
             prefill_chunk_size=4,
             attn_block_size=16,
-            image_prefill_chunk_sizes=[4],
+            image_prefill_chunk_size=[4],
         )
         req = _request(
             _image(3, 4),
@@ -190,7 +190,7 @@ class TestChunkedPrefillPadWithImages:
         mgr = _make_manager(
             prefill_chunk_size=2,
             attn_block_size=8,
-            image_prefill_chunk_sizes=[8],
+            image_prefill_chunk_size=[8],
         )
         req = _request(_image(2, 6))
         assert mgr._chunked_prefill_pad(req, query_len=8) == 6
@@ -207,7 +207,7 @@ class TestChunkedPrefillPadWithImages:
         mgr = _make_manager(
             prefill_chunk_size=4,
             attn_block_size=12,
-            image_prefill_chunk_sizes=[8, 4],  # descending, as optimum stores it
+            image_prefill_chunk_size=[8, 4],  # descending, as optimum stores it
         )
         req = _request(_image(2, 3), _image(7, 6))
         assert mgr._chunked_prefill_pad(req, query_len=13) == 5

--- a/vllm_rbln/utils/optimum/converter/common.py
+++ b/vllm_rbln/utils/optimum/converter/common.py
@@ -77,7 +77,7 @@ def update_block_size(
     vllm_config: VllmConfig,
     kvcache_block_size: int,
     prefill_chunk_size: int,
-    image_prefill_chunk_sizes: list[int] | None = None,
+    image_prefill_chunk_size: list[int] | None = None,
 ) -> None:
     """
     Update the block size in the vllm_config based on the provided kvcache_block_size
@@ -94,9 +94,9 @@ def update_block_size(
     vllm_config.additional_config["prefill_chunk_size"] = prefill_chunk_size
     # Image-prefill buckets (gemma4 multi-bucket / gemma3 single); used to size
     # the per-image chunk in the chunked-prefill block padding.
-    if image_prefill_chunk_sizes is not None:
-        vllm_config.additional_config["image_prefill_chunk_sizes"] = (
-            image_prefill_chunk_sizes
+    if image_prefill_chunk_size is not None:
+        vllm_config.additional_config["image_prefill_chunk_size"] = (
+            image_prefill_chunk_size
         )
     if vllm_config.cache_config.enable_prefix_caching:
         _apply_prefix_caching_block_size(

--- a/vllm_rbln/utils/optimum/converter/from_optimum.py
+++ b/vllm_rbln/utils/optimum/converter/from_optimum.py
@@ -111,7 +111,7 @@ def sync_from_optimum(
         vllm_config,
         params.kvcache_block_size,
         params.prefill_chunk_size,
-        params.image_prefill_chunk_sizes,
+        params.image_prefill_chunk_size,
     )
     # Set num_blocks in cache_config based on rbln_config.json
     update_num_blocks(vllm_config, params.num_blocks)

--- a/vllm_rbln/utils/optimum/converter/from_vllm.py
+++ b/vllm_rbln/utils/optimum/converter/from_vllm.py
@@ -87,7 +87,7 @@ def sync_from_vllm(vllm_config: VllmConfig) -> None:
         vllm_config,
         vllm_config.cache_config.block_size,
         prefill_chunk_size=params.prefill_chunk_size,
-        image_prefill_chunk_sizes=params.image_prefill_chunk_sizes,
+        image_prefill_chunk_size=params.image_prefill_chunk_size,
     )
 
     # max_num_batched_tokens must fit both a full-length prefill and a full

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -88,7 +88,7 @@ class RBLNParams:
     prefill_chunk_size: int = 128
     # Image-prefill buckets for multimodal models (gemma3: single value;
     # gemma4: descending list of 128-multiples). None for non-multimodal models.
-    image_prefill_chunk_sizes: list[int] | None = None
+    image_prefill_chunk_size: list[int] | None = None
     tensor_parallel_size: int = 1
 
     @classmethod
@@ -188,9 +188,9 @@ class RBLNParams:
         prefill_chunk_size = _cfg_get(lm_cfg, "prefill_chunk_size")
         if prefill_chunk_size is None:
             prefill_chunk_size = _cfg_get(cfg, "prefill_chunk_size", 128)
-        image_prefill_chunk_sizes = _resolve_image_prefill_chunk_sizes(lm_cfg)
-        if image_prefill_chunk_sizes is None:
-            image_prefill_chunk_sizes = _resolve_image_prefill_chunk_sizes(cfg)
+        image_prefill_chunk_size = _resolve_image_prefill_chunk_size(lm_cfg)
+        if image_prefill_chunk_size is None:
+            image_prefill_chunk_size = _resolve_image_prefill_chunk_size(cfg)
 
         return cls(
             num_blocks=num_blocks,
@@ -198,32 +198,25 @@ class RBLNParams:
             max_seq_len=max_seq_len,
             kvcache_block_size=kvcache_block_size,
             prefill_chunk_size=prefill_chunk_size,
-            image_prefill_chunk_sizes=image_prefill_chunk_sizes,
+            image_prefill_chunk_size=image_prefill_chunk_size,
         )
 
 
-def _resolve_image_prefill_chunk_sizes(cfg: RblnConfigLike) -> list[int] | None:
+def _resolve_image_prefill_chunk_size(cfg: RblnConfigLike) -> list[int] | None:
     """Resolve image-prefill buckets exactly as optimum-rbln persists them.
 
-    gemma4 stores ``image_prefill_chunk_sizes`` as a ``list[int]``; gemma3 stores
-    the scalar ``image_prefill_chunk_size`` as an ``int``. Any other type is a
-    config error. Returns ``None`` when neither key is present.
+    Both gemma3 and gemma4 store ``image_prefill_chunk_size`` as a ``list[int]``
+    (gemma3: single-element list; gemma4: descending multi-bucket list). Any
+    other type is a config error. Returns ``None`` when the key is absent.
     """
-    sizes = _cfg_get(cfg, "image_prefill_chunk_sizes")
+    sizes = _cfg_get(cfg, "image_prefill_chunk_size")
     if sizes is not None:
         if not isinstance(sizes, list):
             raise TypeError(
-                "image_prefill_chunk_sizes must be a list[int], got "
+                "image_prefill_chunk_size must be a list[int], got "
                 f"{type(sizes).__name__}"
             )
         return sizes
-    size = _cfg_get(cfg, "image_prefill_chunk_size")
-    if size is not None:
-        if not isinstance(size, int):
-            raise TypeError(
-                f"image_prefill_chunk_size must be an int, got {type(size).__name__}"
-            )
-        return [size]
     return None
 
 

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -205,19 +205,24 @@ class RBLNParams:
 def _resolve_image_prefill_chunk_size(cfg: RblnConfigLike) -> list[int] | None:
     """Resolve image-prefill buckets exactly as optimum-rbln persists them.
 
-    Both gemma3 and gemma4 store ``image_prefill_chunk_size`` as a ``list[int]``
-    (gemma3: single-element list; gemma4: descending multi-bucket list). Any
-    other type is a config error. Returns ``None`` when the key is absent.
+    optimum-rbln stores ``image_prefill_chunk_size`` under one key but with two
+    shapes: gemma3 persists a scalar ``int`` (a single bucket); gemma4 persists
+    a descending ``list[int]`` (multiple buckets). Both are normalized to a
+    ``list[int]``. Any other type is a config error. Returns ``None`` when the
+    key is absent.
     """
     sizes = _cfg_get(cfg, "image_prefill_chunk_size")
-    if sizes is not None:
-        if not isinstance(sizes, list):
-            raise TypeError(
-                "image_prefill_chunk_size must be a list[int], got "
-                f"{type(sizes).__name__}"
-            )
+    if sizes is None:
+        return None
+    if isinstance(sizes, list):
         return sizes
-    return None
+    # bool is an int subclass; reject it explicitly.
+    if isinstance(sizes, int) and not isinstance(sizes, bool):
+        return [sizes]
+    raise TypeError(
+        "image_prefill_chunk_size must be an int or list[int], got "
+        f"{type(sizes).__name__}"
+    )
 
 
 def _resolve_kvcache_block_size(cfg: RblnConfigLike, *, arch: str) -> int | None:

--- a/vllm_rbln/v1/core/optimum_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/optimum_kv_cache_manager.py
@@ -45,7 +45,7 @@ class RBLNKVCacheManager(KVCacheManager):
         max_num_seqs: int = 1,
         is_encoder_decoder: bool = False,
         prefill_chunk_size: int | None = None,
-        image_prefill_chunk_sizes: list[int] | None = None,
+        image_prefill_chunk_size: list[int] | None = None,
         needs_chunked_prefill_pad: bool = False,
     ) -> None:
         """
@@ -97,7 +97,7 @@ class RBLNKVCacheManager(KVCacheManager):
         self.prefill_chunk_size = prefill_chunk_size
         # gemma3: single image bucket; gemma4: descending list of buckets.
         # Used to size the per-image chunk in `_chunked_prefill_pad`.
-        self.image_prefill_chunk_sizes = image_prefill_chunk_sizes
+        self.image_prefill_chunk_size = image_prefill_chunk_size
         self.attn_block_size = attn_block_size
         if needs_chunked_prefill_pad:
             assert prefill_chunk_size is not None, (
@@ -163,10 +163,10 @@ class RBLNKVCacheManager(KVCacheManager):
         return segments
 
     def _image_chunk_size(self, run_len: int) -> int:
-        buckets = self.image_prefill_chunk_sizes
+        buckets = self.image_prefill_chunk_size
         if not buckets:
             assert self.prefill_chunk_size is not None, (
-                "prefill_chunk_size must be set when image_prefill_chunk_sizes is empty"
+                "prefill_chunk_size must be set when image_prefill_chunk_size is empty"
             )
             return self.prefill_chunk_size
         # buckets is descending, so `reversed` is ascending: the first bucket

--- a/vllm_rbln/v1/core/optimum_scheduler.py
+++ b/vllm_rbln/v1/core/optimum_scheduler.py
@@ -187,11 +187,11 @@ class RBLNOptimumScheduler(Scheduler):
         archs = getattr(vllm_config.model_config.hf_config, "architectures", None) or []
         needs_chunked_prefill_pad = any("Gemma3" in a or "Gemma4" in a for a in archs)
         prefill_chunk_size = None
-        image_prefill_chunk_sizes = None
+        image_prefill_chunk_size = None
         if needs_chunked_prefill_pad and vllm_config.additional_config is not None:
             prefill_chunk_size = vllm_config.additional_config.get("prefill_chunk_size")
-            image_prefill_chunk_sizes = vllm_config.additional_config.get(
-                "image_prefill_chunk_sizes"
+            image_prefill_chunk_size = vllm_config.additional_config.get(
+                "image_prefill_chunk_size"
             )
 
         # Create the KV cache manager.
@@ -213,7 +213,7 @@ class RBLNOptimumScheduler(Scheduler):
             max_num_seqs=self.max_num_running_reqs,
             is_encoder_decoder=self.is_encoder_decoder,
             prefill_chunk_size=prefill_chunk_size,
-            image_prefill_chunk_sizes=image_prefill_chunk_sizes,
+            image_prefill_chunk_size=image_prefill_chunk_size,
             needs_chunked_prefill_pad=needs_chunked_prefill_pad,
         )
         self.perf_metrics: ModelMetrics | None = None


### PR DESCRIPTION
## Summary
optimum-rbln persists the image-prefill buckets under a single key, `image_prefill_chunk_size`, but with two shapes depending on the model:
- **gemma3**: a scalar `int` (single bucket)
- **gemma4**: a descending `list[int]` (multiple buckets)

Previously the code keyed off `image_prefill_chunk_sizes` (plural) for gemma4 and `image_prefill_chunk_size` (singular) for gemma3, which did not match how optimum-rbln actually stores them. This PR unifies on the single `image_prefill_chunk_size` key and normalizes both shapes to a `list[int]`.

## Changes
- Rename `image_prefill_chunk_sizes` → `image_prefill_chunk_size` across the converter (`params`, `common`, `from_optimum`, `from_vllm`), the scheduler, and the KV cache manager.
- `_resolve_image_prefill_chunk_size`: accept a scalar `int` (gemma3) or `list[int]` (gemma4) and normalize both to `list[int]`; `bool` (an `int` subclass) is rejected explicitly; any other type raises `TypeError`.
- Update docstrings/comments to reflect the int-or-list storage.
- Add tests in `test_params.py` covering int→list normalization, list pass-through, absent→None, and invalid-type/bool rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)