### PR TITLE
refactor(metrics): merge model + sampler into a single MODEL+SAMPLER tracker

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -71,7 +71,6 @@ def _make_runner_stub(**overrides):
         sampler=MagicMock(),
         rejection_sampler=MagicMock(),
         performance_tracker=None,
-        sampler_performance_tracker=None,
         e2e_performance_tracker=None,
         uses_mrope=False,
         positions=MagicMock(),

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -1243,19 +1243,16 @@ class TestShutdown:
         worker = _create_worker()
         worker.model_runner = MagicMock()
         worker.model_runner.performance_tracker = MagicMock()
-        worker.model_runner.sampler_performance_tracker = MagicMock()
         worker.model_runner.e2e_performance_tracker = MagicMock()
         with patch("vllm_rbln.v1.worker.rbln_worker.envs.VLLM_RBLN_METRICS", True):
             worker.shutdown()
         worker.model_runner.performance_tracker.print_final_stats.assert_called_once()
-        worker.model_runner.sampler_performance_tracker.print_final_stats.assert_called_once()
         worker.model_runner.e2e_performance_tracker.print_final_stats.assert_called_once()
 
     def test_with_metrics_none_trackers(self):
         worker = _create_worker()
         worker.model_runner = MagicMock()
         worker.model_runner.performance_tracker = None
-        worker.model_runner.sampler_performance_tracker = None
         worker.model_runner.e2e_performance_tracker = None
         with patch("vllm_rbln.v1.worker.rbln_worker.envs.VLLM_RBLN_METRICS", True):
             worker.shutdown()

--- a/vllm_rbln/v1/worker/metrics.py
+++ b/vllm_rbln/v1/worker/metrics.py
@@ -14,7 +14,7 @@
 
 import os
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TypeVar
 
 import vllm_rbln.rbln_envs as envs
@@ -321,6 +321,93 @@ class PerformanceTracker:
         logger.info("=" * 80)
 
 
+@dataclass
+class StepReport:
+    """One execution step's timing before it is recorded into a tracker.
+
+    Lets model and sampler timings be summed into a single combined
+    measurement (merged_with) instead of being tracked separately.
+    """
+
+    latency: float
+    token_count: int = 0
+    host_time: int | None = None
+    device_time: int | None = None
+    ccl_time: int | None = None
+    prepare_time: int | None = None
+    is_prefill: bool = False
+    padded_decode: bool = False
+    request_ids: list[str] | None = None
+
+    @classmethod
+    def from_reports(
+        cls,
+        start_time: float,
+        end_time: float,
+        reports: list[dict] | None,
+        **meta,
+    ) -> "StepReport":
+        host_time = device_time = ccl_time = prepare_time = None
+        if reports:
+            host_time = reports[0].get("total_host", None)
+            device_time = reports[0].get("total_device", None)
+            ccl_time = reports[0].get("total_ccl", None)
+        if reports and len(reports) > 1:
+            prepare_time = reports[1].get("prepare_input_us", 0) + reports[1].get(
+                "prepare_output_us", 0
+            )
+        return cls(
+            latency=end_time - start_time,
+            host_time=host_time,
+            device_time=device_time,
+            ccl_time=ccl_time,
+            prepare_time=prepare_time,
+            **meta,
+        )
+
+    def merged_with(self, other: "StepReport | None") -> "StepReport":
+        """Sum `other`'s timings into this step, keeping this step's metadata."""
+        if other is None:
+            return self
+
+        def _add(a: int | None, b: int | None) -> int | None:
+            if a is None and b is None:
+                return None
+            return (a or 0) + (b or 0)
+
+        return replace(
+            self,
+            latency=self.latency + other.latency,
+            host_time=_add(self.host_time, other.host_time),
+            device_time=_add(self.device_time, other.device_time),
+            ccl_time=_add(self.ccl_time, other.ccl_time),
+            prepare_time=_add(self.prepare_time, other.prepare_time),
+        )
+
+    def record(self, performance_tracker: PerformanceTracker) -> None:
+        if self.is_prefill:
+            performance_tracker.record_prefill(
+                self.latency,
+                self.token_count,
+                host_time=self.host_time,
+                device_time=self.device_time,
+                ccl_time=self.ccl_time,
+                prepare_time=self.prepare_time,
+                request_ids=self.request_ids,
+            )
+        else:
+            performance_tracker.record_decode(
+                self.latency,
+                self.token_count,
+                host_time=self.host_time,
+                device_time=self.device_time,
+                ccl_time=self.ccl_time,
+                prepare_time=self.prepare_time,
+                padded_decode=self.padded_decode,
+                request_ids=self.request_ids,
+            )
+
+
 def collect_metrics(
     performance_tracker: PerformanceTracker,
     is_prefill: bool,
@@ -329,34 +416,10 @@ def collect_metrics(
     reports: list[dict],
     token_count: int,
 ) -> None:
-    execution_time = end_time - start_time
-    host_time = None
-    device_time = None
-    ccl_time = None
-    prepare_time = None
-    if reports is not None and len(reports) > 0:
-        host_time = reports[0].get("total_host", None)
-        device_time = reports[0].get("total_device", None)
-        ccl_time = reports[0].get("total_ccl", None)
-    if reports is not None and len(reports) > 1:
-        prepare_time = reports[1].get("prepare_input_us", 0) + reports[1].get(
-            "prepare_output_us", 0
-        )
-    if is_prefill:
-        performance_tracker.record_prefill(
-            execution_time,
-            token_count,
-            host_time=host_time,
-            device_time=device_time,
-            ccl_time=ccl_time,
-            prepare_time=prepare_time,
-        )
-    else:
-        performance_tracker.record_decode(
-            execution_time,
-            token_count,
-            host_time=host_time,
-            device_time=device_time,
-            ccl_time=ccl_time,
-            prepare_time=prepare_time,
-        )
+    StepReport.from_reports(
+        start_time,
+        end_time,
+        reports,
+        token_count=token_count,
+        is_prefill=is_prefill,
+    ).record(performance_tracker)

--- a/vllm_rbln/v1/worker/metrics.py
+++ b/vllm_rbln/v1/worker/metrics.py
@@ -299,6 +299,29 @@ class PerformanceTracker:
             prepare_time,
         )
 
+    def record(self, report: "StepReport") -> None:
+        if report.is_prefill:
+            self.record_prefill(
+                report.latency,
+                report.token_count,
+                host_time=report.host_time,
+                device_time=report.device_time,
+                ccl_time=report.ccl_time,
+                prepare_time=report.prepare_time,
+                request_ids=report.request_ids,
+            )
+        else:
+            self.record_decode(
+                report.latency,
+                report.token_count,
+                host_time=report.host_time,
+                device_time=report.device_time,
+                ccl_time=report.ccl_time,
+                prepare_time=report.prepare_time,
+                padded_decode=report.padded_decode,
+                request_ids=report.request_ids,
+            )
+
     def print_final_stats(self):
         _attach_metrics_file_handler()
         logger.info("=" * 80)
@@ -345,7 +368,11 @@ class StepReport:
         start_time: float,
         end_time: float,
         reports: list[dict] | None,
-        **meta,
+        *,
+        token_count: int = 0,
+        is_prefill: bool = False,
+        padded_decode: bool = False,
+        request_ids: list[str] | None = None,
     ) -> "StepReport":
         host_time = device_time = ccl_time = prepare_time = None
         if reports:
@@ -358,11 +385,14 @@ class StepReport:
             )
         return cls(
             latency=end_time - start_time,
+            token_count=token_count,
             host_time=host_time,
             device_time=device_time,
             ccl_time=ccl_time,
             prepare_time=prepare_time,
-            **meta,
+            is_prefill=is_prefill,
+            padded_decode=padded_decode,
+            request_ids=request_ids,
         )
 
     def merged_with(self, other: "StepReport | None") -> "StepReport":
@@ -384,29 +414,6 @@ class StepReport:
             prepare_time=_add(self.prepare_time, other.prepare_time),
         )
 
-    def record(self, performance_tracker: PerformanceTracker) -> None:
-        if self.is_prefill:
-            performance_tracker.record_prefill(
-                self.latency,
-                self.token_count,
-                host_time=self.host_time,
-                device_time=self.device_time,
-                ccl_time=self.ccl_time,
-                prepare_time=self.prepare_time,
-                request_ids=self.request_ids,
-            )
-        else:
-            performance_tracker.record_decode(
-                self.latency,
-                self.token_count,
-                host_time=self.host_time,
-                device_time=self.device_time,
-                ccl_time=self.ccl_time,
-                prepare_time=self.prepare_time,
-                padded_decode=self.padded_decode,
-                request_ids=self.request_ids,
-            )
-
 
 def collect_metrics(
     performance_tracker: PerformanceTracker,
@@ -416,10 +423,12 @@ def collect_metrics(
     reports: list[dict],
     token_count: int,
 ) -> None:
-    StepReport.from_reports(
-        start_time,
-        end_time,
-        reports,
-        token_count=token_count,
-        is_prefill=is_prefill,
-    ).record(performance_tracker)
+    performance_tracker.record(
+        StepReport.from_reports(
+            start_time,
+            end_time,
+            reports,
+            token_count=token_count,
+            is_prefill=is_prefill,
+        )
+    )

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -602,7 +602,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     def _flush_pending_model_report(self):
         if self.performance_tracker is not None and self._pending_model_report:
-            self._pending_model_report.record(self.performance_tracker)
+            self.performance_tracker.record(self._pending_model_report)
             self._pending_model_report = None
 
     def _get_positions(self, num_tokens: Any):
@@ -2169,7 +2169,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 if model_report is not None
                 else sampler_report
             )
-            combined.record(self.performance_tracker)
+            self.performance_tracker.record(combined)
 
         return sampler_output
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -145,7 +145,11 @@ from vllm_rbln.v1.sample.rbln_rejection_sampler import RBLNRejectionSampler
 from vllm_rbln.v1.spec_decode.eagle import RBLNEagleProposer
 from vllm_rbln.v1.spec_decode.medusa import RBLNMedusaProposer
 from vllm_rbln.v1.worker.bucketing import get_bucketing_manager
-from vllm_rbln.v1.worker.metrics import PerformanceTracker, collect_metrics
+from vllm_rbln.v1.worker.metrics import (
+    PerformanceTracker,
+    StepReport,
+    collect_metrics,
+)
 from vllm_rbln.v1.worker.utils import compute_slot_mapping_cpu, get_kv_cache_names
 
 if TYPE_CHECKING:
@@ -579,8 +583,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         self.performance_tracker: PerformanceTracker | None = None
-        self.sampler_performance_tracker: PerformanceTracker | None = None
         self.e2e_performance_tracker: PerformanceTracker | None = None
+        self._pending_model_report: StepReport | None = None
         self.e2e_start_time: float = 0.0
         self.e2e_end_time: float = 0.0
 
@@ -593,9 +597,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     def _enable_performance_tracker(self):
         if envs.VLLM_RBLN_METRICS:
-            self.performance_tracker = PerformanceTracker("MODEL")
-            self.sampler_performance_tracker = PerformanceTracker("SAMPLER")
+            self.performance_tracker = PerformanceTracker("MODEL+SAMPLER")
             self.e2e_performance_tracker = PerformanceTracker("E2E")
+
+    def _flush_pending_model_report(self):
+        if self.performance_tracker is not None and self._pending_model_report:
+            self._pending_model_report.record(self.performance_tracker)
+            self._pending_model_report = None
 
     def _get_positions(self, num_tokens: Any):
         if isinstance(num_tokens, int):
@@ -2099,6 +2107,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # and sampling, and return empty tensor with expected shape. The output
         # is discarded anyway (discard_sampled_tokens_req_indices).
         if logits is not None and logits.shape[0] == 0:
+            self._flush_pending_model_report()
             return SamplerOutput(
                 sampled_token_ids=torch.empty(
                     0, 1, dtype=torch.int32, device=logits.device
@@ -2146,16 +2155,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self._update_states_after_model_execute(
                     sampler_output.sampled_token_ids
                 )
-        if envs.VLLM_RBLN_METRICS and self.sampler_performance_tracker is not None:
-            collect_metrics(
-                self.sampler_performance_tracker,
-                self.is_prefill_phase(),
-                start_time=sampler_start_time,
-                end_time=time.perf_counter(),
-                reports=sampler_reports,
-                token_count=0,
-                # the performance of sampler doesn't depend on token count
+        if envs.VLLM_RBLN_METRICS and self.performance_tracker is not None:
+            sampler_report = StepReport.from_reports(
+                sampler_start_time,
+                time.perf_counter(),
+                sampler_reports,
+                is_prefill=self.is_prefill_phase(),
             )
+            model_report = self._pending_model_report
+            self._pending_model_report = None
+            combined = (
+                model_report.merged_with(sampler_report)
+                if model_report is not None
+                else sampler_report
+            )
+            combined.record(self.performance_tracker)
 
         return sampler_output
 
@@ -3512,48 +3526,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     **model_kwargs,
                 )
             if self.performance_tracker is not None:
-                # Record performance metrics
-                model_end_time = time.perf_counter()
-                model_execution_time = model_end_time - model_start_time
-                host_time = None
-                device_time = None
-                ccl_time = None
-                prepare_time = None
-
-                if reports is not None and len(reports) > 0:
-                    host_time = reports[0].get("total_host", None)
-                    device_time = reports[0].get("total_device", None)
-                    ccl_time = reports[0].get("total_ccl", None)
-                if reports is not None and len(reports) > 1:
-                    prepare_time = reports[1].get("prepare_input_us", 0) + reports[
-                        1
-                    ].get("prepare_output_us", 0)
-
-                if is_prefill_phase:
-                    self.performance_tracker.record_prefill(
-                        model_execution_time,
-                        num_scheduled_tokens,
-                        host_time=host_time,
-                        device_time=device_time,
-                        ccl_time=ccl_time,
-                        prepare_time=prepare_time,
-                        request_ids=self.input_batch.req_ids,
-                    )
-                else:
-                    padded_decode = (
-                        num_padded_tokens is not None
-                        and num_padded_tokens != batch_bucket_size
-                    )
-                    self.performance_tracker.record_decode(
-                        model_execution_time,
-                        num_scheduled_tokens,
-                        host_time=host_time,
-                        device_time=device_time,
-                        ccl_time=ccl_time,
-                        prepare_time=prepare_time,
-                        padded_decode=padded_decode,
-                        request_ids=self.input_batch.req_ids,
-                    )
+                # Stash model timing; combined with sampler timing in _sample().
+                padded_decode = (
+                    not is_prefill_phase
+                    and num_padded_tokens is not None
+                    and num_padded_tokens != batch_bucket_size
+                )
+                self._pending_model_report = StepReport.from_reports(
+                    model_start_time,
+                    time.perf_counter(),
+                    reports,
+                    token_count=num_scheduled_tokens,
+                    is_prefill=is_prefill_phase,
+                    padded_decode=padded_decode,
+                    request_ids=self.input_batch.req_ids,
+                )
 
         with record_function_or_nullcontext("Postprocess"):
             if self.use_aux_hidden_state_outputs:
@@ -3577,6 +3564,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 if not broadcast_pp_output:
                     hidden_states.kv_connector_output = kv_connector_output
                     self.kv_connector_output = kv_connector_output
+                    self._flush_pending_model_report()
                     return hidden_states
                 # NOTE - DO NOT all_gather_group for RBLN pp
                 get_pp_group().send_tensor_dict(hidden_states.tensors)
@@ -3584,6 +3572,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 # for last-pipeline stages, return hidden states
                 if self.is_pooling_model:
+                    self._flush_pending_model_report()
                     return self._pool(
                         hidden_states.flatten(0, -2),
                         num_scheduled_tokens,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -645,8 +645,6 @@ class RBLNWorker(WorkerBase):
         if envs.VLLM_RBLN_METRICS:
             if self.model_runner.performance_tracker:
                 self.model_runner.performance_tracker.print_final_stats()
-            if self.model_runner.sampler_performance_tracker:
-                self.model_runner.sampler_performance_tracker.print_final_stats()
             if self.model_runner.e2e_performance_tracker:
                 self.model_runner.e2e_performance_tracker.print_final_stats()
 


### PR DESCRIPTION
### 🚀 Summary of Changes

Report model and sampler timings as a single combined `MODEL+SAMPLER` tracker instead of two separate `MODEL` / `SAMPLER` blocks. Per step the model time and sampler time are summed into one measurement, halving the metrics output and reflecting the real model+sampler compute time.

**1. Combined tracker:** Replace the separate `MODEL` / `SAMPLER` trackers with one `MODEL+SAMPLER` tracker. Model and sampler run 1:1 per step, so their timings are summed into a single per-step measurement.

**2. StepReport (metrics.py):** New `StepReport` dataclass — `from_reports()` extracts timings (host/device/ccl/prepare) from `capture_reports`, `merged_with()` sums model + sampler timings (None-safe), `record()` writes into a tracker. `collect_metrics` is reimplemented on top of it, so the E2E tracker and the optimum runner keep identical behavior.

**3. rbln_model_runner:** `execute_model` stashes the model `StepReport` in `_pending_model_report` instead of recording immediately; `_sample` builds the sampler `StepReport` and records `model.merged_with(sampler)` once. `_flush_pending_model_report()` records the model report alone on paths that skip sampling — intermediate chunked prefill (`logits.shape[0] == 0`), pooling models, and PP non-last rank — so no model timing is lost.

**4. rbln_worker:** Drop the separate `SAMPLER` print at shutdown; only `MODEL+SAMPLER` and `E2E` are printed.

**5. Scope:** The optimum runner/worker are unchanged (still separate `MODEL` / `SAMPLER`). The shared `collect_metrics` signature/behavior is preserved.

---

### 📌 Related Issues / Tickets

* N/A

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [x] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run any rbln model with metrics enabled: `VLLM_RBLN_METRICS=1 <serve/inference cmd>`
2. On shutdown, verify a single `FINAL PERFORMANCE STATISTICS [MODEL+SAMPLER]` block is printed (plus `[E2E]`) — no separate `[SAMPLER]` block.
3. Edge cases: pooling model, chunked prefill, and PP non-last rank still record model timing (no lost steps).

---

### 📸 Screenshots / Logs (if applicable)

**Before** (two blocks):
```
FINAL PERFORMANCE STATISTICS [MODEL]
FINAL PERFORMANCE STATISTICS [SAMPLER]
```

**After** (one combined block; values are model + sampler per step):
```
FINAL PERFORMANCE STATISTICS [MODEL+SAMPLER]
FINAL PERFORMANCE STATISTICS [E2E]
```

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The optimum runner is intentionally left untouched in this PR. The E2E tracker stays separate (it measures whole-step time, which differs in meaning from model+sampler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
