### PR TITLE
Fix stale slot_mapping comment

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -3342,9 +3342,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     slot_mappings = new_slot_mappings
 
                 # Push the padded slot_mapping back into per-layer
-                # attn_metadata. The attention builder
-                # (flash_attention.py:1116/1252) already stamped the unpadded
-                # tensor here, so we overwrite in-place.
+                # attn_metadata, overwriting the unpadded tensor the attention
+                # builder stamped on RBLNFlashAttentionMetadata.slot_mapping.
+                # FIXME: no current consumer reads this field -- the attention
+                # path indexes KV via block_tables and reads slot_mapping from
+                # forward_context, not from attn_metadata. This write (and the
+                # field) is likely dead; remove once verified by a runtime
+                # decode smoke test.
                 if attn_metadata is not None:
                     for gid, kv_cache_group in enumerate(
                         self.kv_cache_config.kv_cache_groups


### PR DESCRIPTION
Follow-up to #719.

## What

Fixes the stale comment above the per-layer `slot_mapping` write-back in `rbln_model_runner.py`.

The old comment claimed the attention path reads `RBLNFlashAttentionMetadata.slot_mapping` and pointed at outdated line numbers (`flash_attention.py:1116/1252`).

## Why

Static tracing shows **no consumer reads the field**:
- `RBLNFlashAttentionImpl.forward` reads `block_tables`/`seq_lens`/masks/`cache_*` only.
- The attention entry computes `layer_slot_mapping` from `forward_context.slot_mapping` (a different object, never populated by the runner → `{}`) and then discards it (`_`).
- The only write outside the builder is this `md.slot_mapping = sm`, which writes to a field nobody reads.

The comment is corrected to describe reality, and a `FIXME` flags the field + this write-back as likely dead — to be removed once confirmed by a runtime decode smoke test. The field itself is left in place for now (KV-cache correctness; verify before removing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)