### PR TITLE
fix(deps): add torch-rbln dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "torchvision",
     "torchaudio",
     "torchcodec",
-    "torch-rbln==0.2.2",
+    "torch-rbln~=0.2.2.dev0",
     "optimum-rbln>=0.11.1a1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "torchvision",
     "torchaudio",
     "torchcodec",
+    "torch-rbln>=0.2.2",
     "optimum-rbln>=0.11.0",
 ]
 


### PR DESCRIPTION
### 🚀 Summary of Changes

Explicitly adds `torch-rbln` to the dependency list of the `vllm-rbln` project.

**Rationale:** Under the current architecture, the `torch-rbln` package is a hard requirement in any environment that uses VLLM_RBLN_USE_DEVICE_TENSOR=1. When this dependency is missing, it either raises a runtime error or forces the user to install it manually.
Declaring it in `pyproject.toml` automates installation and removes that friction.

### 📌 Related Issues / Tickets

- Resolves #
- Related to #
 -  https://github.com/rebellions-sw/vllm-rbln-internal/issues/127

---

### ✅ Type of Change

- [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Create a fresh environment without `torch-rbln` installed.
2. Install `vllm-rbln` and confirm `torch-rbln` is pulled in automatically.

---

### 📋 Checklist

- [x] PR title follows Conventional Commits format
- [ ] This PR is linked to an existing issue
- [x] The test method is described, and the expected result is clearly stated
- [ ] Relevant documentation has been updated (if applicable)