### PR TITLE
fix(model): force parameters/buffers contiguous at load time

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -4196,6 +4196,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 model_loader.load_weights(self.model, model_config=self.model_config)
 
         self.model = self.get_model().eval()
+        # weight-free compile hard-errors on non-contiguous CPU weights.
+        for p in self.model.parameters():
+            if not p.is_contiguous():
+                p.set_(p.contiguous())
+        for b in self.model.buffers():
+            if not b.is_contiguous():
+                b.set_(b.contiguous())
         self.compute_logits_model = self.model
         if self.model_config.is_multimodal_model and hasattr(
             self.model.get_language_model(), "logits_processor"

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2263,9 +2263,19 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     ) -> torch.Tensor:
         return self.model.compute_logits(hidden_states)
 
+    def _make_weights_contiguous(self) -> None:
+        # weight-free compile hard-errors on non-contiguous CPU weights.
+        for p in self.model.parameters():
+            if not p.is_contiguous():
+                p.set_(p.contiguous())
+        for b in self.model.buffers():
+            if not b.is_contiguous():
+                b.set_(b.contiguous())
+
     @torch.inference_mode()
     def warm_up_model(self) -> None:
         set_warmup_active(True)
+        self._make_weights_contiguous()
         offload_ctx = (
             torch.rbln.offload()
             if envs.VLLM_RBLN_USE_DEVICE_TENSOR
@@ -4196,13 +4206,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 model_loader.load_weights(self.model, model_config=self.model_config)
 
         self.model = self.get_model().eval()
-        # weight-free compile hard-errors on non-contiguous CPU weights.
-        for p in self.model.parameters():
-            if not p.is_contiguous():
-                p.set_(p.contiguous())
-        for b in self.model.buffers():
-            if not b.is_contiguous():
-                b.set_(b.contiguous())
+        self._make_weights_contiguous()
         self.compute_logits_model = self.model
         if self.model_config.is_multimodal_model and hasattr(
             self.model.get_language_model(), "logits_processor"


### PR DESCRIPTION
### 🚀 Summary of Changes

Make every model parameter and buffer contiguous at load time so that non-contiguous CPU tensors are never handed to the compile path, keeping the compiler from holding references to non-contiguous tensors.

Some models load a sliced view straight into a parameter — for example `gpt-oss-120b`'s MoE expert bias — which leaves that parameter non-contiguous. The loop runs in `RBLNModelRunner.load_model()` right after `self.get_model().eval()`, before `torch.compile` and where both the from-scratch load and the inplace reload converge. Doing it once at load time keeps it independent of any specific model.

---

### ✅ Type of Change

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Compile a model whose weights include a non-contiguous parameter or buffer, e.g. `gpt-oss-120b`, through the vLLM Dynamo path.
2. Confirm the model loads and compiles.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] The test method is described, and the expected result is clearly stated

---

### 💬 Notes

`p.set_(p.contiguous())` swaps only the underlying storage while keeping the Parameter object identity, so module attribute references stay valid. The optimum-rbln path (`optimum_model_runner.py`) loads already-compiled artifacts and is out of scope here.
