### PR TITLE
perf(worker): vectorize VLLM_RBLN_SORT_BATCH batch reorder

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -23,6 +23,7 @@ import numpy as np
 import pytest
 import torch
 from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.sample.logits_processor import MoveDirectionality
 from vllm.v1.worker.gpu_input_batch import InputBatch
 
 import vllm_rbln.v1.worker.rbln_model_runner as model_runner_module
@@ -32,6 +33,7 @@ from vllm_rbln.v1.worker.rbln_model_runner import (
     ExecuteModelState,
     RBLNModelRunner,
 )
+from vllm_rbln.v1.worker.utils import reorder_input_batch
 
 # ===========================================================================
 # Helpers
@@ -901,13 +903,156 @@ class TestMayReorderBatch:
 
     @staticmethod
     def _make_input_batch_mock(req_ids, num_tokens_no_spec, swap_fn=None):
-        """Build a spec-bound mock of InputBatch with real numpy data."""
+        """Spec-bound InputBatch mock for the early-return paths (env off,
+        no kv groups, already-sorted) that don't reach the reindex."""
         batch = MagicMock(spec=InputBatch)
         batch.req_ids = req_ids
         batch.num_tokens_no_spec = np.array(num_tokens_no_spec)
         if swap_fn is not None:
             batch.swap_states = swap_fn
         return batch
+
+    # --- real InputBatch helpers for the vectorized-reorder (B) tests ---
+
+    @staticmethod
+    def _real_input_batch(
+        num_tokens,
+        rng,
+        max_num_reqs=8,
+        max_model_len=64,
+        vocab_size=100,
+        block_size=16,
+        is_pooling_model=False,
+    ):
+        """Build and populate a real InputBatch with distinct per-slot data
+        in every field that swap_states / reorder_input_batch touches."""
+        n = len(num_tokens)
+        ib = InputBatch(
+            max_num_reqs=max_num_reqs,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=512,
+            device=torch.device("cpu"),
+            pin_memory=False,
+            vocab_size=vocab_size,
+            block_sizes=[block_size],
+            kernel_block_sizes=[block_size],
+            max_num_blocks_per_req=[max_model_len // block_size],
+            logitsprocs=None,
+            num_spec_tokens=0,
+            is_pooling_model=is_pooling_model,
+        )
+        # _req_ids length == num_reqs (the runner uses len(req_ids) as n).
+        ib._req_ids = [f"r{i}" for i in range(n)]
+        ib.req_id_to_index = {f"r{i}": i for i in range(n)}
+        ib.req_output_token_ids[:n] = [[i, i * 10] for i in range(n)]
+        ib.spec_token_ids[:n] = [[i + 1] for i in range(n)]
+        ib.num_tokens_no_spec[:n] = np.asarray(
+            num_tokens, dtype=ib.num_tokens_no_spec.dtype
+        )
+        for name in (
+            "num_prompt_tokens",
+            "num_computed_tokens_cpu",
+            "temperature_cpu",
+            "top_p_cpu",
+            "top_k_cpu",
+            "frequency_penalties_cpu",
+            "presence_penalties_cpu",
+            "repetition_penalties_cpu",
+            "num_accepted_tokens_cpu",
+            "request_lora_mapping",
+        ):
+            arr = getattr(ib, name)
+            arr[:n] = rng.integers(1, 999, size=n).astype(arr.dtype)
+        ib.token_ids_cpu[:n] = rng.integers(0, vocab_size, size=(n, max_model_len))
+        ib.is_token_ids[:n] = rng.integers(0, 2, size=(n, max_model_len)).astype(bool)
+        bt = ib.block_table.block_tables[0]
+        bt.num_blocks_per_row[:n] = rng.integers(0, max_model_len // block_size, size=n)
+        bt.block_table.np[:n] = rng.integers(0, 500, size=bt.block_table.np[:n].shape)
+        # sparse index-keyed dicts (deterministic so ref/ours start identical)
+        ib.generators = {}
+        for i in range(0, n, 2):
+            g = torch.Generator()
+            g.manual_seed(1000 + i)
+            ib.generators[i] = g
+        ib.bad_words_token_ids = {
+            i: [[int(x) for x in rng.integers(0, vocab_size, size=2)]]
+            for i in range(1, n, 3)
+        }
+        ib.req_prompt_embeds = {
+            i: torch.from_numpy(rng.random(4).astype(np.float32))
+            for i in range(0, n, 4)
+        }
+        return ib, n
+
+    @staticmethod
+    def _cycle_pairs(sorted_order):
+        """Pairwise swaps realizing `sorted_order` (mirrors _may_reorder_batch)."""
+        n = len(sorted_order)
+        orig = np.arange(n)
+        m = {int(s): int(d) for s, d in zip(orig[sorted_order], orig)}
+        pairs = []
+        for src in list(m):
+            dst = m[src]
+            while src != dst:
+                pairs.append((src, dst))
+                next_dst = m.get(dst, dst)
+                m[dst] = dst
+                dst = next_dst
+        return pairs
+
+    @staticmethod
+    def _assert_input_batch_equal(a, b, n):
+        assert a._req_ids[:n] == b._req_ids[:n]
+        assert a.req_id_to_index == b.req_id_to_index
+        assert a.req_output_token_ids[:n] == b.req_output_token_ids[:n]
+        assert a.spec_token_ids[:n] == b.spec_token_ids[:n]
+        for name in (
+            "num_tokens_no_spec",
+            "num_prompt_tokens",
+            "num_computed_tokens_cpu",
+            "temperature_cpu",
+            "top_p_cpu",
+            "top_k_cpu",
+            "frequency_penalties_cpu",
+            "presence_penalties_cpu",
+            "repetition_penalties_cpu",
+            "num_accepted_tokens_cpu",
+            "request_lora_mapping",
+        ):
+            np.testing.assert_array_equal(
+                getattr(a, name)[:n], getattr(b, name)[:n], err_msg=name
+            )
+        # token matrices: compare each row only over its meaningful extent
+        # (num_tokens + spec). The vectorized reindex narrows to valid columns,
+        # so the don't-care tail beyond a row's extent need not match
+        # swap_states' full-row copy. Independent of the production valid_w
+        # formula — a too-small valid_w would corrupt some row's [:ext].
+        for k in range(n):
+            ext = int(b.num_tokens_no_spec[k]) + len(b.spec_token_ids[k])
+            np.testing.assert_array_equal(
+                a.token_ids_cpu[k, :ext],
+                b.token_ids_cpu[k, :ext],
+                err_msg="token_ids_cpu",
+            )
+            np.testing.assert_array_equal(
+                a.is_token_ids[k, :ext], b.is_token_ids[k, :ext], err_msg="is_token_ids"
+            )
+        bta = a.block_table.block_tables[0]
+        btb = b.block_table.block_tables[0]
+        np.testing.assert_array_equal(
+            bta.num_blocks_per_row[:n], btb.num_blocks_per_row[:n]
+        )
+        np.testing.assert_array_equal(bta.block_table.np[:n], btb.block_table.np[:n])
+        assert a.batch_update_builder.moved == b.batch_update_builder.moved
+        # index-keyed dicts (generators compared by seed; full-dict replacement
+        # must match swap_dict_values for keys in [0, n))
+        assert {k: g.initial_seed() for k, g in a.generators.items()} == {
+            k: g.initial_seed() for k, g in b.generators.items()
+        }
+        assert a.bad_words_token_ids == b.bad_words_token_ids
+        assert set(a.req_prompt_embeds) == set(b.req_prompt_embeds)
+        for k in a.req_prompt_embeds:
+            assert torch.equal(a.req_prompt_embeds[k], b.req_prompt_embeds[k])
 
     def test_no_reorder_when_env_disabled(self):
         """When VLLM_RBLN_SORT_BATCH is False, no reordering occurs."""
@@ -936,28 +1081,25 @@ class TestMayReorderBatch:
         np.testing.assert_array_equal(batch.num_tokens_no_spec, [5, 10])
 
     def test_reorder_sorts_descending(self):
-        """When enabled and groups exist, reorder by descending num_tokens_no_spec."""
-        swap_log = []
-
-        def mock_swap(src, dst):
-            swap_log.append((src, dst))
-            arr = batch.num_tokens_no_spec
-            arr[src], arr[dst] = arr[dst], arr[src]
-
-        batch = self._make_input_batch_mock(
-            ["a", "b", "c"],
-            [10, 30, 20],
-            swap_fn=mock_swap,
-        )
-        stub = SimpleNamespace(
-            kv_cache_config=SimpleNamespace(kv_cache_groups=[1]),
-            input_batch=batch,
-        )
-        bound = types.MethodType(RBLNModelRunner._may_reorder_batch, stub)
+        """End-to-end: _may_reorder_batch sorts a real batch by descending
+        num_tokens_no_spec, carries per-slot state along, and emits move
+        records."""
+        ib, n = self._real_input_batch([10, 30, 20], np.random.default_rng(0))
+        # Tag token rows so we can verify rows follow the permutation.
+        ib.token_ids_cpu[:n, 0] = [100, 101, 102]
+        runner = object.__new__(RBLNModelRunner)
+        runner.kv_cache_config = SimpleNamespace(kv_cache_groups=[1])
+        runner.input_batch = ib
         with patch("vllm_rbln.v1.worker.rbln_model_runner.envs") as mock_envs:
             mock_envs.VLLM_RBLN_SORT_BATCH = True
-            bound(MagicMock())
-        np.testing.assert_array_equal(batch.num_tokens_no_spec, [30, 20, 10])
+            runner._may_reorder_batch(MagicMock())
+
+        np.testing.assert_array_equal(ib.num_tokens_no_spec[:n], [30, 20, 10])
+        # idx1(30)->slot0, idx2(20)->slot1, idx0(10)->slot2
+        np.testing.assert_array_equal(ib.token_ids_cpu[:n, 0], [101, 102, 100])
+        assert ib.req_id_to_index == {"r1": 0, "r2": 1, "r0": 2}
+        assert ib._req_ids[:n] == ["r1", "r2", "r0"]
+        assert ib.batch_update_builder.moved, "expected emitted move records"
 
     def test_already_sorted_no_swaps(self):
         """If already sorted descending, no swaps needed."""
@@ -980,3 +1122,88 @@ class TestMayReorderBatch:
             mock_envs.VLLM_RBLN_SORT_BATCH = True
             bound(MagicMock())
         assert len(swap_log) == 0
+
+    def test_reorder_matches_swap_states(self):
+        """reorder_input_batch is equivalent to N-1 swap_states calls
+        across random permutations and every per-request field."""
+        for trial in range(20):
+            seed_rng = np.random.default_rng(trial)
+            n = int(seed_rng.integers(2, 8))
+            toks = [int(t) for t in seed_rng.integers(1, 50, size=n)]
+            ref, _ = self._real_input_batch(toks, np.random.default_rng(100 + trial))
+            ours, _ = self._real_input_batch(toks, np.random.default_rng(100 + trial))
+            perm = np.argsort(np.asarray(toks) * (-1), kind="stable")
+            pairs = self._cycle_pairs(perm)
+            # reference: realize the permutation via swap_states
+            for i1, i2 in pairs:
+                ref.swap_states(i1, i2)
+            # ours: emit the same move records, then one vectorized reindex
+            for i1, i2 in pairs:
+                ours.batch_update_builder.moved.append(
+                    (i1, i2, MoveDirectionality.SWAP)
+                )
+            reorder_input_batch(ours, perm)
+            self._assert_input_batch_equal(ref, ours, n)
+
+    def test_reorder_allowed_token_ids_mask_gather(self):
+        """(B) allowed_token_ids_mask is permuted correctly (a true gather;
+        upstream swap_states' row tuple-swap is buggy here, so we don't
+        mirror it)."""
+        ib, n = self._real_input_batch([10, 30, 20], np.random.default_rng(0))
+        rng = np.random.default_rng(7)
+        ib.allowed_token_ids_mask_cpu_tensor = torch.from_numpy(
+            rng.integers(0, 2, size=(8, 100)).astype(bool)
+        )
+        orig = ib.allowed_token_ids_mask_cpu_tensor[:n].clone()
+        perm = np.argsort(np.asarray([10, 30, 20]) * (-1), kind="stable")
+        reorder_input_batch(ib, perm)
+        assert torch.equal(ib.allowed_token_ids_mask_cpu_tensor[:n], orig[perm])
+
+    def test_reorder_narrows_to_valid_width(self):
+        """With num_tokens (+spec) << max_model_len, only the valid token
+        columns are permuted; the don't-care tail (columns >= num_tokens,
+        never read) is left untouched. reorder_input_batch derives the valid
+        width itself from num_tokens_no_spec + spec length."""
+        toks = [2, 4, 3]
+        ib, n = self._real_input_batch(toks, np.random.default_rng(0))
+        # _real_input_batch sets one spec token per slot -> valid_w = max + 1.
+        valid_w = max(toks) + 1
+        full_w = ib.token_ids_cpu.shape[1]
+        assert valid_w < full_w
+        ib.token_ids_cpu[:n, valid_w:] = -7  # sentinel in the don't-care tail
+        orig = ib.token_ids_cpu.copy()
+        orig_is = ib.is_token_ids.copy()
+        perm = np.argsort(np.asarray(toks) * (-1), kind="stable")
+        reorder_input_batch(ib, perm)
+        # valid columns are gathered by the permutation ...
+        np.testing.assert_array_equal(
+            ib.token_ids_cpu[:n, :valid_w], orig[perm][:, :valid_w]
+        )
+        np.testing.assert_array_equal(
+            ib.is_token_ids[:n, :valid_w], orig_is[perm][:, :valid_w]
+        )
+        # ... and the tail is untouched (token_ids still the sentinel, and
+        # is_token_ids unchanged — neither is permuted).
+        np.testing.assert_array_equal(
+            ib.token_ids_cpu[:n, valid_w:], np.full((n, full_w - valid_w), -7)
+        )
+        np.testing.assert_array_equal(
+            ib.is_token_ids[:n, valid_w:], orig_is[:n, valid_w:]
+        )
+
+    def test_reorder_pooling_emits_no_move_records(self):
+        """Pooling models carry no sampling/logits state, so the reorder must
+        not emit move records (matching upstream swap_states' early return)."""
+        ib, n = self._real_input_batch(
+            [10, 30, 20], np.random.default_rng(0), is_pooling_model=True
+        )
+        runner = object.__new__(RBLNModelRunner)
+        runner.kv_cache_config = SimpleNamespace(kv_cache_groups=[1])
+        runner.input_batch = ib
+        with patch("vllm_rbln.v1.worker.rbln_model_runner.envs") as mock_envs:
+            mock_envs.VLLM_RBLN_SORT_BATCH = True
+            runner._may_reorder_batch(MagicMock())
+        # Non-sampling state is still reordered ...
+        np.testing.assert_array_equal(ib.num_tokens_no_spec[:n], [30, 20, 10])
+        # ... but no logits-processor move records are emitted.
+        assert ib.batch_update_builder.moved == []

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -99,7 +99,7 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
     SamplerOutput,
 )
-from vllm.v1.sample.logits_processor import build_logitsprocs
+from vllm.v1.sample.logits_processor import MoveDirectionality, build_logitsprocs
 from vllm.v1.sample.logits_processor.interface import LogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
@@ -151,7 +151,11 @@ from vllm_rbln.v1.worker.metrics import (
     StepReport,
     collect_metrics,
 )
-from vllm_rbln.v1.worker.utils import compute_slot_mapping_cpu, get_kv_cache_names
+from vllm_rbln.v1.worker.utils import (
+    compute_slot_mapping_cpu,
+    get_kv_cache_names,
+    reorder_input_batch,
+)
 
 if TYPE_CHECKING:
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
@@ -718,43 +722,48 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return model_kwargs
 
     def _may_reorder_batch(self, scheduler_output: SchedulerOutput) -> None:
+        """Sort the persistent batch by descending ``num_tokens_no_spec`` so the
+        RBLN attention backend sees a length-ordered batch. Override of the
+        upstream (MLA-oriented) hook; gated by ``VLLM_RBLN_SORT_BATCH``.
         """
-        Update the order of requests in the batch based on the attention
-        backend's needs. For example, some attention backends (namely MLA) may
-        want to separate requests based on if the attention computation will be
-        compute-bound or memory-bound.
-
-        Args:
-            scheduler_output: The scheduler output.
-        """
-        # Attention free models have zero kv_cache_goups, however models
-        # like Mamba are also attention free but use the kv_cache for
-        # keeping its internal state. This is why we check the number
-        # of kv_cache groups instead of solely checking
-        # for self.model_config.is_attention_free.
         if not envs.VLLM_RBLN_SORT_BATCH:
             return
+        # Zero kv_cache_groups == attention-free model; nothing to order for.
         if len(self.kv_cache_config.kv_cache_groups) == 0:
             return
 
-        orig_indices = np.arange(len(self.input_batch.req_ids))
-        sorted_order = np.argsort(
-            self.input_batch.num_tokens_no_spec[orig_indices] * (-1), kind="stable"
-        )
+        ib = self.input_batch
+        n = len(ib.req_ids)
+        toks = ib.num_tokens_no_spec[:n]
+
+        # The batch is reordered in place every step, so in steady-state decode
+        # it is already sorted and a stable argsort would be identity; skip via
+        # an O(n) non-increasing check.
+        if n <= 1 or bool(np.all(toks[:-1] >= toks[1:])):
+            return
+
+        orig_indices = np.arange(n)
+        sorted_order = np.argsort(toks * (-1), kind="stable")
         src_indices = orig_indices[sorted_order]
         src_dest_map = {
             int(src): int(dst)
             for src, dst in zip(src_indices, orig_indices, strict=False)
         }
 
-        for src in src_dest_map:
-            dst = src_dest_map[src]
-            while src != dst:
-                self.input_batch.swap_states(src, dst)
-                # Mark dst as done by updating its destination to itself
-                next_dst = src_dest_map.get(dst, dst)
-                src_dest_map[dst] = dst
-                dst = next_dst
+        # Emit the pairwise-swap records logits processors replay to realign
+        # their per-request state (only for non-pooling models, matching
+        # swap_states), then apply the permutation in one pass.
+        if not ib.is_pooling_model:
+            moved = ib.batch_update_builder.moved
+            for src in src_dest_map:
+                dst = src_dest_map[src]
+                while src != dst:
+                    moved.append((src, dst, MoveDirectionality.SWAP))
+                    next_dst = src_dest_map.get(dst, dst)
+                    src_dest_map[dst] = dst
+                    dst = next_dst
+
+        reorder_input_batch(ib, sorted_order)
 
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:

--- a/vllm_rbln/v1/worker/utils.py
+++ b/vllm_rbln/v1/worker/utils.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""CPU affinity utilities for RBLN worker."""
+"""Utilities for the RBLN worker (CPU affinity, batch reorder, …)."""
 
 import math
 import os
 import platform
 from collections import defaultdict
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -33,6 +34,9 @@ from vllm.v1.worker.block_table import MultiGroupBlockTable
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_input_batch import InputBatch
 
 logger = init_logger(__name__)
 
@@ -576,3 +580,92 @@ def get_kv_cache_names(
         for layer_name in layer_names:
             kv_cache_names.append(layer_name)
     return kv_cache_names
+
+
+def reorder_input_batch(input_batch: "InputBatch", perm: np.ndarray) -> None:
+    """Permute every per-request field of ``input_batch`` in one vectorized
+    pass (new slot ``k`` takes old index ``perm[k]``).
+
+    Mirrors upstream ``InputBatch.swap_states`` (vllm 0.22.0) but reindexes each
+    field once instead of via N-1 pairwise swaps; the caller emits the
+    logits-processor move records. Keep the field set in sync with
+    ``swap_states`` on vLLM bumps -- ``test_reorder_matches_swap_states`` guards
+    equivalence.
+    """
+    ib = input_batch
+    n = len(perm)
+    # numpy index: valid for advanced indexing of both numpy arrays and tensors.
+    p = np.asarray(perm)
+
+    # token_ids_cpu / is_token_ids rows are max_model_len wide but only
+    # [:num_tokens + spec] is meaningful, so reindex just those columns. valid_w
+    # is permutation-invariant (max over the same values), so read it first.
+    max_spec = max((len(s) for s in ib.spec_token_ids[:n]), default=0)
+    valid_w = min(
+        int(ib.num_tokens_no_spec[:n].max()) + max_spec,
+        ib.token_ids_cpu.shape[1],
+    )
+
+    # request id / token bookkeeping (python lists + index dict)
+    ib._req_ids[:n] = [ib._req_ids[i] for i in p]
+    ib.req_output_token_ids[:n] = [ib.req_output_token_ids[i] for i in p]
+    ib.spec_token_ids[:n] = [ib.spec_token_ids[i] for i in p]
+    for k in range(n):
+        rid = ib._req_ids[k]
+        if rid is not None:
+            ib.req_id_to_index[rid] = k
+
+    # per-request scalars; RHS fancy-index copies, so in-place assign is alias-safe
+    for arr in (
+        ib.num_tokens_no_spec,
+        ib.num_prompt_tokens,
+        ib.num_computed_tokens_cpu,
+    ):
+        arr[:n] = arr[p]
+
+    ib.token_ids_cpu[:n, :valid_w] = ib.token_ids_cpu[p, :valid_w]
+    ib.is_token_ids[:n, :valid_w] = ib.is_token_ids[p, :valid_w]
+
+    if ib.req_prompt_embeds:
+        ib.req_prompt_embeds = {
+            k: ib.req_prompt_embeds[int(p[k])]
+            for k in range(n)
+            if int(p[k]) in ib.req_prompt_embeds
+        }
+
+    # block-table CPU rows + counts (device copy re-synced downstream)
+    for bt in ib.block_table.block_tables:
+        bt.num_blocks_per_row[:n] = bt.num_blocks_per_row[p]
+        bt.block_table.np[:n] = bt.block_table.np[p]
+
+    ib.request_lora_mapping[:n] = ib.request_lora_mapping[p]
+
+    # Pooling models carry no sampling / logits state.
+    if ib.is_pooling_model:
+        return
+
+    for arr in (
+        ib.temperature_cpu,
+        ib.top_p_cpu,
+        ib.top_k_cpu,
+        ib.frequency_penalties_cpu,
+        ib.presence_penalties_cpu,
+        ib.repetition_penalties_cpu,
+        ib.num_accepted_tokens_cpu,
+    ):
+        arr[:n] = arr[p]
+
+    # index-keyed dicts: new slot k inherits old slot p[k]'s entry
+    ib.generators = {
+        k: ib.generators[int(p[k])] for k in range(n) if int(p[k]) in ib.generators
+    }
+    ib.bad_words_token_ids = {
+        k: ib.bad_words_token_ids[int(p[k])]
+        for k in range(n)
+        if int(p[k]) in ib.bad_words_token_ids
+    }
+
+    if ib.allowed_token_ids_mask_cpu_tensor is not None:
+        ib.allowed_token_ids_mask_cpu_tensor[:n] = ib.allowed_token_ids_mask_cpu_tensor[
+            p
+        ]


### PR DESCRIPTION


<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

#### Summary

On the native path (`VLLM_RBLN_USE_VLLM_MODEL=1`) with `VLLM_RBLN_SORT_BATCH=1`,
`RBLNModelRunner` re-sorts the persistent `InputBatch` by descending
`num_tokens_no_spec` every decode step so the attention backend sees a
length-ordered batch. This ran as N-1 `InputBatch.swap_states()` calls; in
steady-state decode every completion permutes the batch into a near-full
rotation, so it was a recurring per-step spike dominated by Python overhead
(`swap_states` tuple-swaps ~20 fields and copies a full `max_model_len` row).

This PR reframes the reorder as a single vectorized operation:

- **Skip when already sorted** — an O(n) non-increasing check; a stable argsort
  is identity in steady-state decode, so the argsort + reindex is skipped
  entirely on those steps.
- **Single permutation pass** applies the sort order to every per-request field
  at once instead of N-1 pairwise swaps, emitting the equivalent pairwise move
  records so logits processors realign (skipped for pooling models, matching
  `swap_states`).
- **Narrow the token-matrix reindex** to the valid token columns
  (`num_tokens + spec`) rather than the full `max_model_len` width.

No behavior change: the sorted result is identical to the `swap_states` loop.
It also fixes a latent upstream bug — `swap_states` permutes
`allowed_token_ids_mask` with an aliasing row tuple-swap, whereas the
vectorized gather is correct.

#### Structure

Mirrors upstream's reorder hook, which is a runner-method that delegates to a
free function:

- `_may_reorder_batch` stays the `RBLNModelRunner` override of
  `GPUModelRunner._may_reorder_batch` — the env / kv-group gate, the sort, and
  the move-record emission.
- The permutation itself is a free function `reorder_input_batch(input_batch,
  perm)` in `vllm_rbln/v1/worker/utils.py`, parallel to upstream
  `reorder_batch_to_split_decodes_and_prefills(input_batch, ...)`. It uses no
  runner state, so it is unit-tested directly on a real `InputBatch`.

#### Performance

The gain is concentrated in the short-output, large-batch regime: short output
sequences finish often, churning batch composition so reorders fire frequently,
and a large batch makes each reorder an O(N) swap chain — exactly what the
single vectorized pass collapses. With long outputs / stable batches the O(n)
already-sorted check skips the work in both old and new, so the benefit there
is small.

Measured on Qwen3-30B-A3B decode (P/D decode side, batch N≤32, ISL ~1k /
OSL ~100):

| metric | before | after | change |
|---|---|---|---|
| reorder overhead / step | ~234 µs | ~82 µs | −65% |
| worst-case event | 4.7 ms | 0.78 ms | −83% |

#### Compatibility

`reorder_input_batch` mirrors upstream `InputBatch.swap_states`' field set
(verified against vLLM 0.22.0) and **must be kept in sync on vLLM bumps**.
`swap_states`' field set is unchanged (req bookkeeping, per-request scalars,
`token_ids_cpu`/`is_token_ids`, `req_prompt_embeds`, block-table rows,
`request_lora_mapping`, sampling params, generators/`bad_words_token_ids`,
`allowed_token_ids_mask`); `BlockTable.swap_row` still touches only
`num_blocks_per_row` + `block_table.np`; `MoveDirectionality` is still exported
from `vllm.v1.sample.logits_processor`.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

- `test_reorder_matches_swap_states` guards equivalence over random
  permutations and every per-request field.
- Coverage for the valid-width narrowing, the `allowed_token_ids_mask` gather,
  and the pooling-model early return (no move records emitted).
- `pytest tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py -k reorder` — 8 passed.


---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
