### PR TITLE
fix(platform): guard against VLLM_RBLN_USE_VLLM_MODEL set after `import vllm`

### DIFF
--- a/tests/torch_compile/conftest.py
+++ b/tests/torch_compile/conftest.py
@@ -14,6 +14,14 @@
 
 import os
 
+# Must be set before the vllm imports below. RblnPlatform freezes
+# device_name/device_type/dist_backend from VLLM_RBLN_USE_VLLM_MODEL when
+# vllm_rbln.platform is imported (during `import vllm`), and
+# check_and_update_config raises if they later disagree with the env. Setting
+# it here keeps the frozen attributes consistent with the value the whole test
+# tree runs under.
+os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
+
 import pytest
 from vllm.config import (
     CacheConfig,
@@ -42,10 +50,10 @@ def pytest_collection_modifyitems(items):
 
 
 def pytest_configure(config):
-    # Must run before test collection so that monkey patches applied by
-    # `register_ops()` are in place before any test module does
-    # `from vllm.xxx import yyy` at import time and captures the original symbol.
-    os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
+    # VLLM_RBLN_USE_VLLM_MODEL is set at module import above so that monkey
+    # patches applied by `register_ops()` are in place before any test module
+    # does `from vllm.xxx import yyy` at import time and captures the original
+    # symbol.
     # Running torch.compile-based tests in this tree leaves hundreds of
     # background threads alive in the pytest process (we saw ~2400 before
     # the EngineCore spawn). POSIX fork() clones only the calling thread

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -53,6 +53,14 @@ def bypass_backend(graph_module: torch.fx.GraphModule, example_inputs):
 register_backend(name="bypass", compiler_fn=bypass_backend)
 
 
+def _derive_platform_attrs(use_vllm_model: bool) -> dict:
+    return {
+        "device_name": "rbln" if use_vllm_model else "cpu",
+        "device_type": "rbln" if use_vllm_model else "cpu",
+        "dist_backend": "rbln-ccl" if use_vllm_model else "",
+    }
+
+
 class RblnPlatform(Platform):
     _enum = PlatformEnum.OOT
 
@@ -75,9 +83,11 @@ class RblnPlatform(Platform):
             ) from e
 
     plugin_name: str = "rbln"
-    device_name: str = "rbln" if _USE_VLLM_MODEL else "cpu"
-    device_type: str = "rbln" if _USE_VLLM_MODEL else "cpu"
-    dist_backend: str = "rbln-ccl" if _USE_VLLM_MODEL else ""
+    _frozen_attrs = _derive_platform_attrs(_USE_VLLM_MODEL)
+    device_name: str = _frozen_attrs["device_name"]
+    device_type: str = _frozen_attrs["device_type"]
+    dist_backend: str = _frozen_attrs["dist_backend"]
+    del _frozen_attrs
     dispatch_key: str = "CPU"
     ray_device_key: str = "RBLN"
     simple_compile_backend = "bypass"
@@ -236,6 +246,7 @@ class RblnPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        cls._guard_import_time_envs()
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
@@ -441,6 +452,23 @@ class RblnPlatform(Platform):
                 hf_config, "use_sliding_window", True
             ):
                 cls._disable_prefix_caching(vllm_config, "sliding window models")
+
+    @classmethod
+    def _guard_import_time_envs(cls) -> None:
+        expected = _derive_platform_attrs(envs.VLLM_RBLN_USE_VLLM_MODEL)
+        actual = {name: getattr(cls, name) for name in expected}
+        if expected != actual:
+            details = ", ".join(
+                f"{name}: frozen={actual[name]!r} but current env implies "
+                f"{expected[name]!r}"
+                for name in expected
+                if actual[name] != expected[name]
+            )
+            raise RuntimeError(
+                f"RBLN platform attributes do not match the current env ({details}). "
+                "VLLM_RBLN_USE_VLLM_MODEL is read only once, at `import vllm`. "
+                "Please set it before importing vllm."
+            )
 
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

## Problem
https://github.com/RBLN-SW/vllm-rbln/pull/609 started using an env var to initialize a class attribute.
This can cause a mismatch in the class attribute if the env var is set after `from vllm import LLM`.
```
from vllm import LLM, SamplingParams        # ← platform.py import → _USE_DEVICE_TENSOR
import os
os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"  # ← Too late. The attribute is already initialized.
```

## Solution
Added a guard against `VLLM_RBLN_USE_VLLM_MODEL` being set after import vllm by validating the values of the class attributes.



---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [x] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
