### PR TITLE
fix(mm): read num_devices from language_model submodule

### DIFF
--- a/tests/optimum_compile/converter/test_params.py
+++ b/tests/optimum_compile/converter/test_params.py
@@ -15,7 +15,11 @@
 
 import pytest
 
-from vllm_rbln.utils.optimum.converter.params import RBLNParams
+from vllm_rbln.utils.optimum.converter.params import (
+    RBLNParams,
+    _num_devices_of,
+    _resolve_num_devices,
+)
 
 
 class TestParseDecoder:
@@ -224,3 +228,77 @@ class TestImagePrefillChunkSize:
     def test_bool_rejected(self):
         with pytest.raises(TypeError):
             RBLNParams._parse_multimodal(self._cfg(True))
+
+
+class TestNumDevicesOf:
+    def test_top_level_num_devices(self):
+        assert _num_devices_of({"num_devices": 4}) == 4
+
+    def test_falls_back_to_compile_cfgs(self):
+        cfg = {"_compile_cfgs": [{"num_devices": 8}]}
+        assert _num_devices_of(cfg) == 8
+
+    def test_top_level_takes_precedence_over_compile_cfgs(self):
+        cfg = {"num_devices": 2, "_compile_cfgs": [{"num_devices": 8}]}
+        assert _num_devices_of(cfg) == 2
+
+    def test_first_compile_cfg_with_num_devices_wins(self):
+        cfg = {"_compile_cfgs": [{}, {"num_devices": 8}, {"num_devices": 16}]}
+        assert _num_devices_of(cfg) == 8
+
+    def test_returns_none_when_absent(self):
+        assert _num_devices_of({}) is None
+
+    def test_returns_none_when_compile_cfgs_lacks_num_devices(self):
+        assert _num_devices_of({"_compile_cfgs": [{}, {}]}) is None
+
+    def test_non_int_raises(self):
+        with pytest.raises(AssertionError, match="num_devices must be an int"):
+            _num_devices_of({"num_devices": "4"})
+
+    def test_non_positive_raises(self):
+        with pytest.raises(AssertionError, match="positive integer"):
+            _num_devices_of({"num_devices": 0})
+
+    def test_compile_cfgs_non_int_raises(self):
+        with pytest.raises(AssertionError, match="num_devices must be an int"):
+            _num_devices_of({"_compile_cfgs": [{"num_devices": 1.5}]})
+
+    def test_compile_cfgs_non_positive_raises(self):
+        with pytest.raises(AssertionError, match="positive integer"):
+            _num_devices_of({"_compile_cfgs": [{"num_devices": -1}]})
+
+
+class TestResolveNumDevices:
+    def test_top_level(self):
+        assert _resolve_num_devices({"num_devices": 4}) == 4
+
+    def test_defaults_to_one_when_absent(self):
+        assert _resolve_num_devices({}) == 1
+
+    def test_reads_from_language_model_submodule(self):
+        cfg = {"language_model": {"num_devices": 8}}
+        assert _resolve_num_devices(cfg) == 8
+
+    def test_reads_from_text_model_submodule(self):
+        cfg = {"text_model": {"num_devices": 8}}
+        assert _resolve_num_devices(cfg) == 8
+
+    def test_language_model_takes_precedence_over_top_level(self):
+        cfg = {"num_devices": 1, "language_model": {"num_devices": 8}}
+        assert _resolve_num_devices(cfg) == 8
+
+    def test_language_model_preferred_over_text_model(self):
+        cfg = {
+            "language_model": {"num_devices": 8},
+            "text_model": {"num_devices": 16},
+        }
+        assert _resolve_num_devices(cfg) == 8
+
+    def test_reads_from_submodule_compile_cfgs(self):
+        cfg = {"language_model": {"_compile_cfgs": [{"num_devices": 8}]}}
+        assert _resolve_num_devices(cfg) == 8
+
+    def test_falls_back_to_top_level_when_submodule_lacks_num_devices(self):
+        cfg = {"num_devices": 4, "language_model": {"batch_size": 2}}
+        assert _resolve_num_devices(cfg) == 4

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -98,7 +98,6 @@ class RBLNParams:
     ) -> "RBLNParams":
         """Parse rbln_config according to the model architecture."""
         hf_config = vllm_config.model_config.hf_config
-        num_devices = _cfg_get(rbln_config, "num_devices", 1)
 
         if is_enc_dec_arch(hf_config):
             params = cls._parse_enc_dec(rbln_config)
@@ -109,7 +108,7 @@ class RBLNParams:
         else:
             params = cls._parse_decoder(rbln_config)
 
-        params.num_devices = num_devices
+        params.num_devices = _resolve_num_devices(rbln_config)
         return params
 
     @classmethod
@@ -201,6 +200,25 @@ class RBLNParams:
             prefill_chunk_size=prefill_chunk_size,
             image_prefill_chunk_size=image_prefill_chunk_size,
         )
+
+
+def _resolve_num_devices(cfg: RblnConfigLike) -> int:
+    """Resolve ``num_devices``, preferring a language-model submodule.
+
+    Multimodal models pin ``num_devices`` on the ``language_model`` /
+    ``text_model`` submodule at compile time (see the multimodal compilation
+    params), so the top-level key is usually absent and defaults to 1. Read the
+    submodule value first, falling back to the top-level key for models that
+    store it there.
+    """
+    for submodule_name in ("language_model", "text_model"):
+        sub_cfg = _cfg_get_submodule(cfg, submodule_name)
+        if sub_cfg is None:
+            continue
+        sub_val = _cfg_get(sub_cfg, "num_devices")
+        if sub_val is not None:
+            return sub_val
+    return _cfg_get(cfg, "num_devices", 1)
 
 
 def _resolve_image_prefill_chunk_size(cfg: RblnConfigLike) -> list[int] | None:

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -202,23 +202,43 @@ class RBLNParams:
         )
 
 
+def _num_devices_of(cfg: RblnConfigLike) -> int | None:
+    """Read ``num_devices`` from a single config.
+
+    optimum-rbln does not expose ``num_devices`` as a top-level key; it lives
+    inside each entry of ``_compile_cfgs`` (all entries share the same value).
+    Prefer a direct key when present (e.g. an ``RBLNModelConfig`` attribute),
+    then fall back to the compile configs. Returns ``None`` when absent.
+    """
+    val = _cfg_get(cfg, "num_devices")
+    if val is not None:
+        return val
+    compile_cfgs = _cfg_get(cfg, "_compile_cfgs")
+    if isinstance(compile_cfgs, list):
+        for entry in compile_cfgs:
+            entry_val = _cfg_get(entry, "num_devices")
+            if entry_val is not None:
+                return entry_val
+    return None
+
+
 def _resolve_num_devices(cfg: RblnConfigLike) -> int:
     """Resolve ``num_devices``, preferring a language-model submodule.
 
     Multimodal models pin ``num_devices`` on the ``language_model`` /
     ``text_model`` submodule at compile time (see the multimodal compilation
-    params), so the top-level key is usually absent and defaults to 1. Read the
-    submodule value first, falling back to the top-level key for models that
-    store it there.
+    params), so the top-level config carries no usable value. Read the
+    submodule first, falling back to the top-level config for single-module
+    models. Defaults to 1 when nothing is found.
     """
     for submodule_name in ("language_model", "text_model"):
         sub_cfg = _cfg_get_submodule(cfg, submodule_name)
         if sub_cfg is None:
             continue
-        sub_val = _cfg_get(sub_cfg, "num_devices")
+        sub_val = _num_devices_of(sub_cfg)
         if sub_val is not None:
             return sub_val
-    return _cfg_get(cfg, "num_devices", 1)
+    return _num_devices_of(cfg) or 1
 
 
 def _resolve_image_prefill_chunk_size(cfg: RblnConfigLike) -> list[int] | None:

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -203,13 +203,6 @@ class RBLNParams:
 
 
 def _num_devices_of(cfg: RblnConfigLike) -> int | None:
-    """Read ``num_devices`` from a single config.
-
-    optimum-rbln does not expose ``num_devices`` as a top-level key; it lives
-    inside each entry of ``_compile_cfgs`` (all entries share the same value).
-    Prefer a direct key when present (e.g. an ``RBLNModelConfig`` attribute),
-    then fall back to the compile configs. Returns ``None`` when absent.
-    """
     val = _cfg_get(cfg, "num_devices")
     if val is not None:
         assert isinstance(val, int), (
@@ -231,14 +224,6 @@ def _num_devices_of(cfg: RblnConfigLike) -> int | None:
 
 
 def _resolve_num_devices(cfg: RblnConfigLike) -> int:
-    """Resolve ``num_devices``, preferring a language-model submodule.
-
-    Multimodal models pin ``num_devices`` on the ``language_model`` /
-    ``text_model`` submodule at compile time (see the multimodal compilation
-    params), so the top-level config carries no usable value. Read the
-    submodule first, falling back to the top-level config for single-module
-    models. Defaults to 1 when nothing is found.
-    """
     for submodule_name in ("language_model", "text_model"):
         sub_cfg = _cfg_get_submodule(cfg, submodule_name)
         if sub_cfg is None:

--- a/vllm_rbln/utils/optimum/converter/params.py
+++ b/vllm_rbln/utils/optimum/converter/params.py
@@ -212,12 +212,20 @@ def _num_devices_of(cfg: RblnConfigLike) -> int | None:
     """
     val = _cfg_get(cfg, "num_devices")
     if val is not None:
+        assert isinstance(val, int), (
+            f"num_devices must be an int, got {type(val).__name__}"
+        )
+        assert val > 0, "num_devices must be a positive integer"
         return val
     compile_cfgs = _cfg_get(cfg, "_compile_cfgs")
     if isinstance(compile_cfgs, list):
         for entry in compile_cfgs:
             entry_val = _cfg_get(entry, "num_devices")
             if entry_val is not None:
+                assert isinstance(entry_val, int), (
+                    f"num_devices must be an int, got {type(entry_val).__name__}"
+                )
+                assert entry_val > 0, "num_devices must be a positive integer"
                 return entry_val
     return None
 


### PR DESCRIPTION
## Problem

For multimodal models, `num_devices` is written and read from different places:

- **Compile:** stored on the `language_model` submodule, inside its `_compile_cfgs` entries (`rbln_config.json` → `language_model._compile_cfgs[*].num_devices`).
- **Load:** `RBLNParams.from_rbln_config` reads only the **top-level** `num_devices` key.

The top-level key does not exist for these models, so it defaults to 1. A model compiled with `num_devices=4` is loaded as 1.

## Fix

Resolve `num_devices` from the `language_model`/`text_model` submodule first, and read it out of `_compile_cfgs` (its actual location) rather than expecting a top-level key. Falls back to the top-level config for single-module models, and to 1 when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)