### PR TITLE
fix(model): VLLM_RBLN_USE_W8A16's default setting

### DIFF
--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -80,10 +80,10 @@ class RblnPlatform(Platform):
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
         # rebel.get_npu_name() returns None on a host without an NPU mounted
-        # (e.g. a CPU-only compile worker) and otherwise falls back to the
-        # RBLN_TARGET_SOC env var. When it is None we cannot determine a target
-        # SOC, so surface an actionable error instead of a bare AssertionError.
-        device_name = rebel.get_npu_name(device_id)
+        # (e.g. a CPU-only compile worker), so fall back to the RBLN_TARGET_SOC
+        # env var. When neither is available we cannot determine a target SOC,
+        # so surface an actionable error instead of a bare AssertionError.
+        device_name = rebel.get_npu_name(device_id) or os.environ.get("RBLN_TARGET_SOC")
         if not device_name:
             raise RuntimeError(
                 "Could not determine the RBLN NPU name "

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -82,6 +82,8 @@ if TYPE_CHECKING:
     VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT: int = 1
     VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS: list[int] = []
     # --- QUANTIZATION ---
+    # FIXME: erase when CR-03 is no longer supported
+    # Default is device-derived (see get_use_w8a16): True on REBEL evt0
     VLLM_RBLN_USE_W8A16: bool = False
     # --- NIXL ---
     VLLM_RBLN_NIXL_SWA_VIEW_OPT: bool = False
@@ -106,6 +108,27 @@ def get_num_devices_per_local_rank() -> int:
             return int(legacy_value)
 
     return int(new_value) if new_value is not None else 1
+
+
+def get_use_w8a16() -> bool:
+    """Resolve ``VLLM_RBLN_USE_W8A16``, defaulting by device when unset.
+
+    An explicit env var always wins. REBEL evt0 (``RBLN-CR03``) lacks W8A8
+    support, so it defaults to W8A16; all other devices default to W8A8.
+    """
+    value = os.environ.get("VLLM_RBLN_USE_W8A16")
+    if value is not None:
+        return value.lower() in ("true", "1")
+
+    # Lazy import: platform imports this module. get_device_name() raises when
+    # the device is undeterminable (e.g. CPU-only host); fall back to W8A8.
+    from vllm.platforms import current_platform
+
+    try:
+        device_name = current_platform.get_device_name()
+    except Exception:
+        device_name = ""
+    return "cr03" in device_name.lower()
 
 
 def get_dp_impl() -> str:
@@ -385,12 +408,9 @@ environment_variables = {
     # Decode batch bucket manual buckets
     "VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS": get_decode_batch_bucket_manual_buckets,  # noqa E501
     # Use W8A16 block fp8 (weight-only dequant) instead of W8A8 (dynamic
-    # activation fp8 quant). Default is W8A8; set True for evt0 compatibility.
-    "VLLM_RBLN_USE_W8A16": (
-        lambda: (
-            os.environ.get("VLLM_RBLN_USE_W8A16", "False").lower() in ("true", "1")
-        )
-    ),
+    # activation fp8 quant). When unset, the default is derived from the device:
+    # REBEL evt0 (RBLN-CR03) defaults to W8A16 (no W8A8 support).
+    "VLLM_RBLN_USE_W8A16": get_use_w8a16,
     # --- NIXL ---
     # Publish a second SWA-sized descriptor range alongside the Full-sized
     # range at the same NIXL base addresses, so SWA groups transfer only


### PR DESCRIPTION
## Summary
Derive the default of `VLLM_RBLN_USE_W8A16` from the target SoC instead of a hardcoded `False`, so other teams no longer have to sync the flag per device (env-var sync overhead was the main pain point raised in review).

## Behavior
Resolution order for `VLLM_RBLN_USE_W8A16`:
1. **Explicit env var wins** — `VLLM_RBLN_USE_W8A16=0/1` overrides everything. Kept for internal **CR13 + fp8×fp16** testing (not for external team sync).
2. **Otherwise device-derived default** via `rebel.get_npu_name()` (→ `RBLN_TARGET_SOC` fallback):
   - `RBLN-CR03` (REBEL evt0, **no W8A8 support**) → default **True (W8A16)**
   - `RBLN-CR13` (evt1), `RBLN-CR23` (mass), ATOM, everything else → default **False (W8A8)**
3. **Device undeterminable** (e.g. CPU-only compile host, no `RBLN_TARGET_SOC`) → falls back to **False (W8A8)**.

## Context / follow-up
This W8A16 path is a **workaround for CR-03's lack of W8A8**. Once CR-03 is deprecated (targeting ~Aug–Sep, pending fp16 deprecation notice to fsw/fde), this fallback can be removed and models like Minimax can run W8A8-only without branching. This does **not** touch models whose original weights are W8A16 (e.g. `ax-k1-fp8`).

## Test
- Resolver logic (override precedence, per-SoC default, `get_npu_name`→`RBLN_TARGET_SOC` fallback, undeterminable→False) verified.
- Existing e2e `tests/torch_compile/e2e/quantization/test_weight_only_fp8.py` sets `VLLM_RBLN_USE_W8A16=1` explicitly, so it stays on the override path — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)