### PR TITLE
fix(scheduler): support partial remote-KV match in RBLNScheduler

### DIFF
--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -410,33 +410,123 @@ class TestPDDisaggregationScheduler:
         pad_window_sum = sum(ns[r] + slide.get(r, 0) for r in ns)
         assert num_input_tokens == pad_window_sum
 
-    def test_promoted_partial_kv_match_is_rejected(self):
-        """A promoted remote-KV request must be a genuine single-token decode:
-        its prompt KV was prefilled remotely, so num_new_tokens == 1. A partial
-        remote match (num_tokens > matched + 1) would leave a local prefill
-        remainder that cannot mix into the decode batch -- the scheduler asserts
-        loudly rather than emit a corrupt (non-uniform) decode batch.
-        """
-        import pytest
+    def test_promoted_partial_kv_match_scheduled_as_prefill(self):
+        """A PARTIAL remote-KV match (num_tokens > matched + 1) leaves a local
+        prefill remainder. The promoted request must be scheduled as a lone
+        prefill of that remainder -- NOT rejected, and NOT forced into the
+        decode batch.
 
-        matched = _BLOCK_SIZE  # 16
-        # num_tokens = matched + 5 -> num_new_tokens == 5 (> 1): partial match.
-        remote = _create_pd_request(matched + 5, "remote")
+        REGRESSION for the DP4 + LMCache serve crash: the old code asserted
+        `num_new_tokens == 1` in the promotion path and killed the DP rank on
+        every partial prefix-cache hit (gloo cascade -> whole serve dies). With
+        chunk-granular prefix caching a partial match is the norm, so this is
+        the common case, not an edge case.
+        """
+        matched = 2 * _BLOCK_SIZE  # 32 (block-aligned)
+        num_tokens = matched + _BLOCK_SIZE  # 48 -> 16-token remainder
+        scheduler = _create_pd_scheduler(matched_tokens=matched)
+
+        remote = _create_pd_request(num_tokens, "remote")
+        scheduler.add_request(remote)
+
+        # Step 1: async schedule -> WAITING_FOR_REMOTE_KVS, partial match cached.
+        out1 = scheduler.schedule()
+        assert remote.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        assert remote.num_computed_tokens == matched
+
+        # Step 2: KV transfer completes. Partial hit -> no full-hit decrement,
+        # so num_computed_tokens stays at `matched` and the request is still
+        # is_prefill on promotion.
+        _simulate_kv_transfer_completion(scheduler, out1, remote.request_id)
+
+        # Step 3: promoted -> scheduled as a lone prefill of the remainder.
+        # Must NOT raise.
+        out = scheduler.schedule()
+        assert remote.request_id in out.num_scheduled_tokens
+        assert out.num_scheduled_tokens[remote.request_id] == num_tokens - matched
+        assert remote.request_id in {r.req_id for r in out.scheduled_new_reqs}
+        assert remote.status == RequestStatus.RUNNING
+        # Prefill runs alone (num_reqs == 1): no decode reqs this step.
+        assert out.scheduled_cached_reqs.req_ids == []
+
+    def test_promoted_partial_kv_match_then_reaches_decode(self):
+        """After the remainder prefill step, the request advances to decode via
+        the normal running loop (num_scheduled_tokens == 1). Confirms the fix
+        only touches the first promotion step; the rest is ordinary machinery.
+        """
+        matched = 2 * _BLOCK_SIZE  # 32
+        num_tokens = matched + _BLOCK_SIZE  # 48
+        scheduler = _create_pd_scheduler(matched_tokens=matched)
+
+        remote = _create_pd_request(num_tokens, "remote")
+        scheduler.add_request(remote)
+        out1 = scheduler.schedule()
+        _simulate_kv_transfer_completion(scheduler, out1, remote.request_id)
+
+        # Remainder prefill step.
+        out2 = scheduler.schedule()
+        assert out2.num_scheduled_tokens[remote.request_id] == num_tokens - matched
+
+        # Advance the prefill; the request then becomes decode-ready.
+        scheduler.update_from_output(out2, create_runner_output(out2, 1))
+
+        out3 = scheduler.schedule()
+        assert out3.num_scheduled_tokens[remote.request_id] == 1
+        assert remote.status == RequestStatus.RUNNING
+
+    def test_promoted_partial_kv_match_runs_alone_evicting_decode(self):
+        """A promoted partial-match request takes the ordinary lone-prefill
+        path: it evicts running decodes (no mixed batching) and runs at
+        num_reqs == 1, exactly like a normal chunked prefill.
+        """
+        matched = 2 * _BLOCK_SIZE  # 32
+        num_tokens = matched + _BLOCK_SIZE  # 48
+        scheduler = _create_pd_scheduler(matched_tokens=matched)
+
+        # A running decode request.
+        decode = _create_pd_request(10, "decode", do_remote_prefill=False)
+        advance_to_decode(scheduler, decode)
+
+        # Promoted partial-match remote.
+        remote = _create_pd_request(num_tokens, "remote")
+        scheduler.add_request(remote)
+        # decode scheduled; remote -> WAITING_FOR_REMOTE_KVS
+        out1 = scheduler.schedule()
+        assert remote.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        _simulate_kv_transfer_completion(
+            scheduler, out1, remote.request_id, sampled_token_id=2
+        )
+
+        # Promotion step: partial prefill -> evicts the running decode, runs alone.
+        out = scheduler.schedule()
+        assert out.num_scheduled_tokens[remote.request_id] == num_tokens - matched
+        assert decode.request_id not in out.num_scheduled_tokens
+
+    def test_promoted_partial_kv_match_with_spec_decode_no_slide(self):
+        """With spec decode enabled, a promoted partial match is still routed as
+        a prefill: it bypasses `_decide_spec_slide` (no slide entry) instead of
+        joining the decode batch. The slide is applied later by the running loop
+        when the request actually reaches decode.
+        """
+        NUM_SPEC = 3
+        matched = 2 * _BLOCK_SIZE  # 32
+        num_tokens = matched + _BLOCK_SIZE  # 48
         scheduler = create_scheduler(
             block_size=_BLOCK_SIZE,
             num_blocks=_NUM_BLOCKS,
             max_num_seqs=_MAX_NUM_SEQS,
-            num_speculative_tokens=3,
+            num_speculative_tokens=NUM_SPEC,
             use_kv_connector=MockKVConfig(matched_tokens=matched, is_async=True),
         )
+        remote = _create_pd_request(num_tokens, "remote")
         scheduler.add_request(remote)
-
         out1 = scheduler.schedule()
-        assert remote.status == RequestStatus.WAITING_FOR_REMOTE_KVS
         _simulate_kv_transfer_completion(scheduler, out1, remote.request_id)
 
-        with pytest.raises(AssertionError, match="num_new_tokens"):
-            scheduler.schedule()
+        out = scheduler.schedule()  # must not raise
+        assert out.num_scheduled_tokens[remote.request_id] == num_tokens - matched
+        slide = dict(getattr(out, "spec_decode_slide_distance", {}) or {})
+        assert remote.request_id not in slide
 
 
 # ===========================================================================

--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -317,55 +317,28 @@ class TestPDDisaggregationScheduler:
         assert after_total % len(ns) == 0  # uniform -> view is safe
 
     def test_eviction_drops_evicted_decode_slide_distance(self):
-        """REGRESSION for the index_copy crash (``index 4 is out of bounds for
-        dimension 0 with size 4`` in pad_speculative_draft_tokens).
+        """REGRESSION: the no-mixed-batching eviction must drop each evicted
+        running decode's ``spec_decode_slide_distance`` along with its
+        num_scheduled_tokens / scheduled_spec_decode_tokens. Left behind, the
+        scheduler output carries a slide for a req that is no longer scheduled;
+        the runner then over-counts num_input_tokens (= total_num_scheduled +
+        sum(slide)) while the pad window only accounts for the scheduled reqs ->
+        index_copy overflow.
 
-        The no-mixed-batching eviction drops evicted running decodes from
-        num_scheduled_tokens / scheduled_spec_decode_tokens but MUST also drop
-        their spec_decode_slide_distance -- the map added later for the full-spec
-        sliding-window backfill. Left behind, the scheduler output carries a
-        slide for a req that is no longer scheduled; the runner then over-counts
-        num_input_tokens (= total_num_scheduled + sum(slide)) while the pad
-        window only accounts for the scheduled reqs -> index_copy overflow.
+        Trigger: a genuine LOCAL prefill (num_new_tokens > 1 -> is_prefill) is
+        not decode-ready, so it takes the no-mixed-batching eviction path and
+        kicks out the running decodes. (A num_new == 1 decode-ready request no
+        longer evicts -- it joins the decode batch; see
+        ``test_decode_ready_sync_match_joins_decode_batch``.)
 
-        Trigger (PDD-specific): a remote-prefill req admitted DIRECTLY
-        (is_async=False, external match == num_tokens-1 -> num_new == 1) is NOT
-        ``promoted_from_waiting_for_remote_kvs``, so it skips the promote path
-        and hits the eviction path, kicking out the running decodes. Being
-        num_new == 1 it keeps the executed step all-decode (any_prefill=False),
-        so the pad path runs on the leaked-slide-inflated input.
-
-        Not PDD-exclusive, just PDD-fatal: spec_decode_slide_distance is the map
-        added for the full-spec sliding-window backfill, and the eviction loop was
-        never taught to pop it -- so EVERY eviction (including the ordinary
-        prefill-arrives-mid-decode eviction that mixed instances hit constantly)
-        leaks the same inconsistency into the scheduler output. It only crashes in
-        PDD because of how the runner routes the two cases:
-          * prefill evictor (num_new > 1): the executed step has a prefill ->
-            any_prefill=True -> get_dp_padding pads to the fixed
-            max_num_batched_tokens (DP-prefill path) and pad_speculative_draft_
-            tokens is SKIPPED. The leaked-slide-inflated input_ids is absorbed by
-            the large fixed buffer -- no tight per-req layout to overflow, so it
-            was masked all along.
-          * decode evictor (num_new == 1, PDD): the executed step is all-decode ->
-            any_prefill=False -> the tight spec pad (out = num_reqs *
-            max_spec_decode_len) runs, input_ids.numel != sum(window), and
-            index_copy overflows.
-        The fix (pop the slide on eviction) removes the inconsistency at the root,
-        cleaning both the PDD crash and the latent prefill-path leak.
-
-        Drop vs restore: the eviction stashes each evicted req's block delta in
-        ``_stranded_new_blocks`` so the physical KV allocation -- persistent,
-        already committed in the coordinator -- is re-emitted when the req is next
-        scheduled. The slide map is NOT persistent: it is a fresh per-step local
-        dict (rebuilt at the top of ``schedule()`` and recomputed for every
-        running req via ``_decide_spec_slide`` each step). An evicted req is
-        re-scheduled next step and gets its slide recomputed there, so the
-        eviction must simply DROP the stale entry -- there is nothing to restore.
-        Leaving it behind is a pure leak into this step's output.
+        The slide map is a fresh per-step local dict (recomputed via
+        ``_decide_spec_slide`` each step), so an evicted req simply DROPS its
+        stale entry -- there is nothing to restore; leaving it behind is a pure
+        leak into this step's output. (The evicted req's block delta IS stashed
+        in ``_stranded_new_blocks`` and re-emitted next step -- that is separate.)
         """
         NUM_SPEC = 3
-        matched = 32  # remote num_tokens = matched+1 -> num_new == 1
+        matched = 32  # num_tokens = matched + 5 -> num_new == 5 (> 1, a prefill)
         scheduler = create_scheduler(
             block_size=_BLOCK_SIZE,
             num_blocks=_NUM_BLOCKS,
@@ -381,19 +354,18 @@ class TestPDDisaggregationScheduler:
         for d in decodes:
             advance_to_decode(scheduler, d)
 
-        # Remote-prefill req: matched == num_tokens-1 -> num_new == 1, and
-        # is_async=False -> direct admission (never WAITING) -> not promoted ->
-        # falls through to the no-mixed-batching eviction of the running decodes.
-        remote = _create_pd_request(matched + 1, "remote")
+        # Local prefill req: partial match -> num_new == 5 > 1 -> is_prefill, so it
+        # takes the no-mixed-batching eviction of the running decodes.
+        remote = _create_pd_request(matched + 5, "remote")
         scheduler.add_request(remote)
 
         out = scheduler.schedule()
         ns = out.num_scheduled_tokens
         slide = dict(getattr(out, "spec_decode_slide_distance", {}) or {})
 
-        # Eviction happened: only the num_new == 1 remote req is scheduled.
+        # Eviction happened: only the prefill req is scheduled; decodes evicted.
         assert remote.request_id in ns
-        assert ns[remote.request_id] == 1
+        assert ns[remote.request_id] == 5
         for d in decodes:
             assert d.request_id not in ns
 
@@ -527,6 +499,47 @@ class TestPDDisaggregationScheduler:
         assert out.num_scheduled_tokens[remote.request_id] == num_tokens - matched
         slide = dict(getattr(out, "spec_decode_slide_distance", {}) or {})
         assert remote.request_id not in slide
+
+    def test_decode_ready_sync_match_joins_decode_batch(self):
+        """UNIFICATION behavior change: a NON-promoted decode-ready request
+        (sync connector match, num_new_tokens == 1) now JOINS the decode batch
+        (with query backfill) instead of evicting the running decodes to run
+        alone. This is the effect of gating the decode shortcut purely on
+        `not is_prefill(request)` (dropping the promoted_from_waiting_for_remote_kvs
+        precondition).
+        """
+        NUM_SPEC = 3
+        # matched=19 keeps num_computed mid-block (19 % 16 == 3), so the
+        # decode-batch backfill fits in-block and yields a real slide (== 3)
+        # rather than the cross-block no-spec fallback that a block-aligned
+        # num_computed would trigger.
+        matched = 19
+        num_tokens = matched + 1  # 20 -> num_new_tokens == 1 (decode-ready)
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=_NUM_BLOCKS,
+            max_num_seqs=_MAX_NUM_SEQS,
+            num_speculative_tokens=NUM_SPEC,
+            use_kv_connector=MockKVConfig(matched_tokens=matched, is_async=False),
+        )
+        decodes = [
+            _create_pd_request(10, f"d{i}", do_remote_prefill=False) for i in range(3)
+        ]
+        for d in decodes:
+            advance_to_decode(scheduler, d)
+
+        remote = _create_pd_request(num_tokens, "remote")  # sync full match
+        scheduler.add_request(remote)
+        out = scheduler.schedule()
+        ns = out.num_scheduled_tokens
+
+        # remote joins as a single-token decode; running decodes NOT evicted.
+        assert ns[remote.request_id] == 1
+        for d in decodes:
+            assert d.request_id in ns
+        # decode-batch backfill is applied to the joined request too.
+        slide = dict(getattr(out, "spec_decode_slide_distance", {}) or {})
+        assert slide.get(remote.request_id) == NUM_SPEC
 
 
 # ===========================================================================

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -63,11 +63,15 @@ graph an identical ``(batch_bucket, query_len)`` tensor:
    sets every decode req's query window to ``num_spec_tokens + 1`` (or 1 on
    the no-spec fallback) within this rank. BOTH paths that enter the decode
    batch go through ``_decide_spec_slide``: the running loop AND the
-   ``WAITING_FOR_REMOTE_KVS`` promotion path (a remote-prefilled req joins
-   decode carrying 0 drafts, so it needs the same backfill). After this stage
-   a rank's flat ``input_ids`` is already ``num_reqs * query_len`` -- uniform
-   and reshape-safe. (Prefill never mixes with decode in one rank: the
-   no-mixed-batching eviction keeps a prefill step at ``num_reqs == 1``.)
+   ``WAITING_FOR_REMOTE_KVS`` promotion path when the remote match is FULL (a
+   fully-remote-prefilled req joins decode carrying 0 drafts, so it needs the
+   same backfill). A PARTIAL remote match instead leaves a local remainder
+   prefill; that request is routed through the ordinary lone-prefill path (not
+   the promotion decode shortcut) and reaches decode via the running loop on a
+   later step. After this stage a rank's flat ``input_ids`` is already
+   ``num_reqs * query_len`` -- uniform and reshape-safe. (Prefill never mixes
+   with decode in one rank: the no-mixed-batching eviction keeps a prefill step
+   at ``num_reqs == 1``.)
 2. Runner -- cross-DP reconciliation (query-length axis). ``any_prefill``
    (a DP PEER prefilling) selects the prefill-sized shape; otherwise
    ``pad_speculative_draft_tokens`` lifts each rank's uniform window up to
@@ -833,17 +837,25 @@ class RBLNScheduler(Scheduler):
                     assert num_new_tokens > 0
 
                     if (
-                        not promoted_from_waiting_for_remote_kvs
-                        and len(scheduled_new_reqs) > 0
+                        not promoted_from_waiting_for_remote_kvs or is_prefill(request)
+                    ) and (
+                        len(scheduled_new_reqs) > 0 or len(scheduled_resumed_reqs) > 0
                     ):
-                        # NOTE(RBLN): promoted_from_waiting_for_remote_kvs is False, so
-                        # this waiting request needs local prefill (not remote prefill).
-                        # scheduled_new_reqs is non-empty because a prior iteration of
-                        # this waiting loop already added a request to the decode batch
-                        # from remote prefill.
-                        # In this case, we defer scheduling this local prefill request
-                        # (waiting request) to the next step.
-                        assert len(scheduled_resumed_reqs) == 0
+                        # NOTE(RBLN): This waiting request needs a LOCAL prefill:
+                        # either an ordinary waiting request, or a request promoted
+                        # from WAITING_FOR_REMOTE_KVS whose remote match was PARTIAL
+                        # (num_computed_tokens < num_tokens-1 -> still is_prefill, a
+                        # local "remainder" prefill). A prior iteration of this
+                        # waiting loop already placed a decode-ready (remote-
+                        # prefilled) request into the decode batch -- in
+                        # scheduled_new_reqs (status WAITING) or scheduled_resumed_reqs
+                        # (status PREEMPTED). The no-mixed-batching eviction below
+                        # only clears scheduled_running_reqs, so running a local
+                        # prefill now would illegally mix it with those already-
+                        # scheduled decode reqs. Defer this prefill to the next step;
+                        # it is left un-popped at the queue head and re-tried next
+                        # step (by then a plain WAITING req with num_computed_tokens
+                        # > 0, no longer promoted_from_waiting_for_remote_kvs).
                         break
 
                     # Schedule encoder inputs.
@@ -1007,25 +1019,25 @@ class RBLNScheduler(Scheduler):
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
 
-                if promoted_from_waiting_for_remote_kvs:
-                    # NOTE(RBLN): A request promoted from WAITING_FOR_REMOTE_KVS is
-                    # decode-ready: its prompt KV was prefilled on the remote
-                    # (producer) instance, so it joins as a single-token decode.
+                if promoted_from_waiting_for_remote_kvs and not is_prefill(request):
+                    # NOTE(RBLN): A request promoted from WAITING_FOR_REMOTE_KVS
+                    # with a FULL remote match is decode-ready: its whole prompt KV
+                    # was prefilled remotely, so it joins as a single-token decode.
                     #
-                    # PRIMARY guard: it must NOT be in prefill. A partial remote
-                    # match leaves a local "remainder prefill" (is_prefill) that
-                    # cannot mix into the (batch, num_spec+1) decode shape -- fail
-                    # loudly instead of silently corrupting
-                    # input_ids.view(num_reqs, -1) downstream. The num_new_tokens
-                    # == 1 check is the equivalent single-token precondition that
-                    # `_decide_spec_slide(new_n=1)` below relies on (given the
-                    # earlier `assert num_new_tokens > 0`).
-                    assert not is_prefill(request), (
-                        f"promoted remote-KV request {request_id} is still in "
-                        f"prefill (num_new_tokens={num_new_tokens}); a partial "
-                        "remote KV match leaves a local prefill remainder that "
-                        "cannot mix into the decode batch."
-                    )
+                    # A PARTIAL remote match instead leaves a local "remainder
+                    # prefill" (still is_prefill). Such a request is NOT handled
+                    # here -- it falls through to the no-mixed-batching eviction
+                    # block below and runs as a lone prefill (num_reqs == 1),
+                    # exactly like a normal chunked prefill, then reaches decode
+                    # via the running loop on a later step. Routing it through the
+                    # decode path here would leave a non-uniform query length that
+                    # corrupts input_ids.view(num_reqs, -1) downstream.
+                    #
+                    # is_prefill is False here, so num_computed == num_tokens - 1
+                    # and (given the earlier `assert num_new_tokens > 0`)
+                    # num_new_tokens == 1 -- the single-token precondition that
+                    # `_decide_spec_slide(new_n=1)` below relies on. Kept as a
+                    # sanity check.
                     assert num_new_tokens == 1, (
                         f"promoted remote-KV request {request_id} has "
                         f"num_new_tokens={num_new_tokens} (expected 1)."

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -691,10 +691,6 @@ class RBLNScheduler(Scheduler):
                 request = request_queue.peek_request()
                 request_id = request.request_id
 
-                promoted_from_waiting_for_remote_kvs = (
-                    request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
-                )
-
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
                     request.status
@@ -836,26 +832,20 @@ class RBLNScheduler(Scheduler):
                     num_new_tokens = min(num_new_tokens, prefill_token_budget)
                     assert num_new_tokens > 0
 
-                    if (
-                        not promoted_from_waiting_for_remote_kvs or is_prefill(request)
-                    ) and (
+                    if is_prefill(request) and (
                         len(scheduled_new_reqs) > 0 or len(scheduled_resumed_reqs) > 0
                     ):
-                        # NOTE(RBLN): This waiting request needs a LOCAL prefill:
-                        # either an ordinary waiting request, or a request promoted
-                        # from WAITING_FOR_REMOTE_KVS whose remote match was PARTIAL
-                        # (num_computed_tokens < num_tokens-1 -> still is_prefill, a
-                        # local "remainder" prefill). A prior iteration of this
-                        # waiting loop already placed a decode-ready (remote-
-                        # prefilled) request into the decode batch -- in
-                        # scheduled_new_reqs (status WAITING) or scheduled_resumed_reqs
-                        # (status PREEMPTED). The no-mixed-batching eviction below
-                        # only clears scheduled_running_reqs, so running a local
-                        # prefill now would illegally mix it with those already-
-                        # scheduled decode reqs. Defer this prefill to the next step;
-                        # it is left un-popped at the queue head and re-tried next
-                        # step (by then a plain WAITING req with num_computed_tokens
-                        # > 0, no longer promoted_from_waiting_for_remote_kvs).
+                        # NOTE(RBLN): Only a request that will run as a LOCAL prefill
+                        # (lone, num_reqs == 1, via the no-mixed-batching eviction
+                        # below) needs deferring. A decode-ready request (not
+                        # is_prefill) instead joins the decode batch at the block
+                        # below and is fine to co-schedule. Defer this prefill
+                        # because a decode-ready request was already admitted this
+                        # step -- in scheduled_new_reqs (status WAITING) or
+                        # scheduled_resumed_reqs (status PREEMPTED) -- and the
+                        # eviction only clears scheduled_running_reqs, so running a
+                        # local prefill now would illegally mix it with those decode
+                        # reqs. Left un-popped at the queue head, re-tried next step.
                         break
 
                     # Schedule encoder inputs.
@@ -1019,19 +1009,14 @@ class RBLNScheduler(Scheduler):
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
 
-                if promoted_from_waiting_for_remote_kvs and not is_prefill(request):
-                    # NOTE(RBLN): A request promoted from WAITING_FOR_REMOTE_KVS
-                    # with a FULL remote match is decode-ready: its whole prompt KV
-                    # was prefilled remotely, so it joins as a single-token decode.
-                    #
-                    # A PARTIAL remote match instead leaves a local "remainder
-                    # prefill" (still is_prefill). Such a request is NOT handled
-                    # here -- it falls through to the no-mixed-batching eviction
-                    # block below and runs as a lone prefill (num_reqs == 1),
-                    # exactly like a normal chunked prefill, then reaches decode
-                    # via the running loop on a later step. Routing it through the
-                    # decode path here would leave a non-uniform query length that
-                    # corrupts input_ids.view(num_reqs, -1) downstream.
+                if not is_prefill(request):
+                    # NOTE(RBLN): A decode-ready request joins the decode batch
+                    # here, regardless of how it became decode-ready -- a FULL
+                    # remote-KV match promoted from WAITING_FOR_REMOTE_KVS, a full
+                    # local/sync prefix-cache match, etc. (A PARTIAL match leaves a
+                    # local remainder prefill -> still is_prefill -> falls through to
+                    # the no-mixed-batching eviction block below and runs as a lone
+                    # prefill, reaching decode via the running loop on a later step.)
                     #
                     # is_prefill is False here, so num_computed == num_tokens - 1
                     # and (given the earlier `assert num_new_tokens > 0`)
@@ -1039,7 +1024,7 @@ class RBLNScheduler(Scheduler):
                     # `_decide_spec_slide(new_n=1)` below relies on. Kept as a
                     # sanity check.
                     assert num_new_tokens == 1, (
-                        f"promoted remote-KV request {request_id} has "
+                        f"decode-ready request {request_id} has "
                         f"num_new_tokens={num_new_tokens} (expected 1)."
                     )
                     # This promotion path bypasses the running-loop spec/slide


### PR DESCRIPTION
## Problem

`RBLNScheduler.schedule()` assumed a request promoted from `WAITING_FOR_REMOTE_KVS` is decode-ready (`num_new_tokens == 1`) — true only for a **full** remote match. LMCache prefix caching returns **partial** matches (e.g. 2048 of 2388 tokens), leaving a local prefill remainder, so the promotion-path assert fires:

```
AssertionError: promoted remote-KV request ... is still in prefill (num_new_tokens=340);
  a partial remote KV match leaves a local prefill remainder that cannot mix into the decode batch.
```

The DP rank dies → the per-step gloo DP all-reduce breaks → other ranks cascade with `Connection closed by peer` → `EngineDeadError`, serve down. With chunk_size=1024 a partial match is the norm, so this fires on essentially every cache hit.

## Fix

Route waiting requests by **`is_prefill(request)` alone**, dropping the `promoted_from_waiting_for_remote_kvs` gate (now unused, removed):

- **decode-ready** (`not is_prefill`, `num_new_tokens == 1`) → join the decode batch (regardless of origin);
- **prefill** (`is_prefill`) → run as a lone prefill; deferred to the next step if a decode was already scheduled this step.

A partial match is `is_prefill`, so it takes the lone-prefill path and reaches decode via the running loop on a later step — exactly like a normal chunked prefill. Scoped to `rbln_scheduler.py`; no runner / connector changes.

### Waiting-queue scheduling: before / after

**Before** — gated on `promoted_from_waiting_for_remote_kvs`; a partial match hit the assert:

```mermaid
flowchart TD
    A[waiting request] --> B{promoted from<br/>WAITING_FOR_REMOTE_KVS?}
    B -->|yes| C{is_prefill?}
    C -->|"no · FULL match"| DEC[join decode batch]
    C -->|"yes · PARTIAL match"| X([AssertionError →<br/>DP rank dies → serve down])
    B -->|no| G{decode already<br/>scheduled this step?}
    G -->|yes| DEFER[defer]
    G -->|no| LP[lone prefill · evict decodes]
    style X fill:#f7d7d7,stroke:#c22
    style DEC fill:#d7e7f7,stroke:#26a
    style LP fill:#d7f7d7,stroke:#2a2
```

**After** — gated purely on `is_prefill`; no crash, origin no longer matters:

```mermaid
flowchart TD
    A[waiting request] --> D{is_prefill?}
    D -->|"no · decode-ready<br/>(any origin)"| DEC[join decode batch<br/>+ spec-slide]
    D -->|yes| G{decode already<br/>scheduled this step?}
    G -->|yes| DEFER[defer to next step]
    G -->|no| LP[lone prefill · runs alone<br/>→ decode via running loop later]
    style DEC fill:#d7e7f7,stroke:#26a
    style LP fill:#d7f7d7,stroke:#2a2
```

The two-level `promoted?` → `is_prefill?` decision (with a crash leaf for partial matches) collapses into a single `is_prefill?` decision: the crash leaf is gone, a partial match flows to lone prefill, and a non-promoted decode-ready request reaches the decode batch.

## Tests

`tests/torch_compile/unit/v1/core/test_pd_disaggregation.py` — partial match scheduled as a lone prefill (**red on unpatched: reproduces the assert; green after**), prefill→decode transition, spec-decode variant; new `test_decode_ready_sync_match_joins_decode_batch`; `test_eviction_drops_evicted_decode_slide_distance` retargeted to a prefill evictor (`num_new > 1`).

167 scheduler unit tests pass; `ruff check` + `ruff format` clean.

## Remaining before merge (hardware)

Verify a non-promoted (local/sync-matched) `NewRequestData` is safe in a decode batch — i.e. its KV is resident in the allocated blocks. On the DP4 + LMCache serve, send a >1024-token prompt twice → expect no gloo/DP crash, `external_prefix_cache_hits` climbs, coherent second response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
