### PR TITLE
fix(quant): restore MoE fp8 custom op registrations

### DIFF
--- a/vllm_rbln/model_executor/layers/quantization/fp8.py
+++ b/vllm_rbln/model_executor/layers/quantization/fp8.py
@@ -454,6 +454,358 @@ class Fp8LinearMethod(LinearMethodBase):
             return torch.nn.functional.linear(x, weight_bf16.t(), bias)
 
 
+@torch.library.custom_op(
+    "rbln_custom_ops::custom_moe_glu_group_dequantize",
+    mutates_args=(),
+)
+def custom_moe_glu_group_dequantize(
+    hidden_states: torch.Tensor,
+    gate_proj_weight: torch.Tensor,
+    gate_proj_scale: torch.Tensor,
+    up_proj_weight: torch.Tensor,
+    up_proj_scale: torch.Tensor,
+    down_proj_weight: torch.Tensor,
+    down_proj_scale: torch.Tensor,
+    masked_routing_weights: torch.Tensor,
+    group_size: torch.Tensor,
+    hidden_act: str,
+    gate_proj_bias: torch.Tensor | None = None,
+    up_proj_bias: torch.Tensor | None = None,
+    down_proj_bias: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """
+    Customized MoE GLU operation with pre-computed routing weights and
+    group dequantization.
+
+    Expected tensor shapes:
+    - hidden_states: [batch*seq_len, hidden_size]
+    - gate_proj_weight: [num_experts, hidden_size, intermediate_size]
+    - gate_proj_scale: [num_experts, intermediate_size, hidden_size // 128]
+    - up_proj_weight: [num_experts, hidden_size, intermediate_size]
+    - up_proj_scale: [num_experts, intermediate_size, hidden_size // 128]
+    - down_proj_weight: [num_experts, intermediate_size, hidden_size]
+    - down_proj_scale: [num_experts, hidden_size, intermediate_size // 128]
+    - masked_routing_weights: [num_experts, num_tokens]
+      (token dim may be padded to 64-align)
+    - group_size: group size for weight scale
+    - hidden_act: gate activation name ("silu"/"swish" or "gelu*")
+    - gate_proj_bias: [num_experts, intermediate_size]
+    - up_proj_bias: [num_experts, intermediate_size]
+    - down_proj_bias: [num_experts, hidden_size]
+    - expert_map: [num_experts] mapping global -> local expert index (-1 for non-local)
+
+    Returns:
+        Tensor: [batch * seq_len, hidden_size]
+    """
+
+    def _dequantize_blockwise_weight(
+        weight: torch.Tensor,
+        scale: torch.Tensor,
+        in_block_size: int,
+        out_block_size: int | None = None,
+    ) -> torch.Tensor:
+        # `weight` is [num_experts, out_features, in_features].
+        # `scale` is [num_experts, out_blocks, in_blocks].
+        out_features = weight.shape[1]
+        in_features = weight.shape[2]
+        out_blocks = scale.shape[1]
+        out_block_size = out_block_size or (
+            (out_features + out_blocks - 1) // out_blocks
+        )
+
+        expanded = scale.repeat_interleave(out_block_size, dim=1).repeat_interleave(
+            in_block_size, dim=2
+        )
+        expanded = expanded[:, :out_features, :in_features]
+        return weight.to(hidden_states.dtype) * expanded.to(hidden_states.dtype)
+
+    in_block_size = int(group_size.item())
+    gate_out_block = (
+        gate_proj_weight.shape[1] + gate_proj_scale.shape[1] - 1
+    ) // gate_proj_scale.shape[1]
+    down_out_block = (
+        down_proj_weight.shape[1] + down_proj_scale.shape[1] - 1
+    ) // down_proj_scale.shape[1]
+
+    gate_proj_weight_dq = _dequantize_blockwise_weight(
+        gate_proj_weight, gate_proj_scale, in_block_size, gate_out_block
+    )
+    up_proj_weight_dq = _dequantize_blockwise_weight(
+        up_proj_weight, up_proj_scale, in_block_size, gate_out_block
+    )
+    down_proj_weight_dq = _dequantize_blockwise_weight(
+        down_proj_weight, down_proj_scale, in_block_size, down_out_block
+    )
+
+    num_tokens, hidden_size = hidden_states.shape
+    num_experts = gate_proj_weight_dq.shape[0]
+    dtype = hidden_states.dtype
+
+    act = hidden_act.lower()
+    if act in ("silu", "swish"):
+        act_fn = torch.nn.functional.silu
+    elif "gelu" in act:
+        act_fn = torch.nn.functional.gelu
+    else:
+        raise ValueError(f"Unsupported hidden_act={hidden_act!r}")
+
+    # masked_routing_weights: [E, T_padded]
+    routing_t = masked_routing_weights[:, :num_tokens]
+
+    final_hidden_states = torch.zeros(num_tokens, hidden_size, dtype=dtype)
+
+    for expert_idx in range(num_experts):
+        expert_weights = routing_t[expert_idx]  # [T]
+        token_indices = expert_weights.nonzero(as_tuple=True)[0]
+        if token_indices.numel() == 0:
+            continue
+
+        weights = expert_weights[token_indices]  # [num_selected]
+        current_state = hidden_states[token_indices]  # [num_selected, hidden_size]
+
+        gate = torch.nn.functional.linear(
+            current_state,
+            gate_proj_weight_dq[expert_idx],
+            gate_proj_bias[expert_idx] if gate_proj_bias is not None else None,
+        )
+        up = torch.nn.functional.linear(
+            current_state,
+            up_proj_weight_dq[expert_idx],
+            up_proj_bias[expert_idx] if up_proj_bias is not None else None,
+        )
+        glu = act_fn(gate) * up
+        down = torch.nn.functional.linear(
+            glu,
+            down_proj_weight_dq[expert_idx],
+            down_proj_bias[expert_idx] if down_proj_bias is not None else None,
+        )
+        current_hidden_states = down * weights.unsqueeze(-1)
+        final_hidden_states.index_add_(
+            0, token_indices, current_hidden_states.to(dtype)
+        )
+
+    return final_hidden_states
+
+
+@custom_moe_glu_group_dequantize.register_fake
+def custom_moe_glu_group_dequantize_fake(
+    hidden_states: torch.Tensor,
+    gate_proj_weight: torch.Tensor,
+    gate_proj_scale: torch.Tensor,
+    up_proj_weight: torch.Tensor,
+    up_proj_scale: torch.Tensor,
+    down_proj_weight: torch.Tensor,
+    down_proj_scale: torch.Tensor,
+    masked_routing_weights: torch.Tensor,
+    group_size: torch.Tensor,
+    hidden_act: str,
+    gate_proj_bias: torch.Tensor | None = None,
+    up_proj_bias: torch.Tensor | None = None,
+    down_proj_bias: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states)
+
+
+@torch.library.custom_op(
+    "rbln_custom_ops::custom_moe_glu_w8a8",
+    mutates_args=(),
+)
+def custom_moe_glu_w8a8(
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gate_proj_weight: torch.Tensor,
+    gate_proj_scale: torch.Tensor,
+    up_proj_weight: torch.Tensor,
+    up_proj_scale: torch.Tensor,
+    down_proj_weight: torch.Tensor,
+    down_proj_scale: torch.Tensor,
+    masked_routing_weights: torch.Tensor,
+    group_size: torch.Tensor,
+    hidden_act: str,
+    compute_dtype: torch.dtype,
+    gate_proj_bias: torch.Tensor | None = None,
+    up_proj_bias: torch.Tensor | None = None,
+    down_proj_bias: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+    dp_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """
+    Customized MoE GLU operation (W8A8 block-fp8) with pre-computed routing.
+
+    Routing (softmax + topk) is done externally, exactly like
+    custom_moe_glu_group_dequantize; the only differences are the fp8 activation
+    plus its per-(token, K-block) scale, and the fp8 quantization of the GLU
+    intermediate before the down projection.
+
+    Expected tensor shapes:
+    - hidden_states: [batch*seq_len, hidden_size]  (fp8)
+    - hidden_states_scale: [batch*seq_len, hidden_size // 128]
+    - gate_proj_weight: [num_experts, hidden_size, intermediate_size]
+    - gate_proj_scale: [num_experts, intermediate_size, hidden_size // 128]
+    - up_proj_weight: [num_experts, hidden_size, intermediate_size]
+    - up_proj_scale: [num_experts, intermediate_size, hidden_size // 128]
+    - down_proj_weight: [num_experts, intermediate_size, hidden_size]
+    - down_proj_scale: [num_experts, hidden_size, intermediate_size // 128]
+    - masked_routing_weights: [num_experts, num_tokens]
+      (token dim may be padded to 64-align)
+    - group_size: group size for weight scale
+    - hidden_act: gate activation name ("silu"/"swish" or "gelu*")
+    - gate_proj_bias: [num_experts, intermediate_size]
+    - up_proj_bias: [num_experts, intermediate_size]
+    - down_proj_bias: [num_experts, hidden_size]
+    - expert_map: [num_experts] mapping global -> local expert index (-1 for non-local)
+
+    Returns:
+        Tensor: [batch * seq_len, hidden_size]
+    """
+
+    def _dequantize_blockwise_weight(
+        weight: torch.Tensor,
+        scale: torch.Tensor,
+        in_block_size: int,
+        out_block_size: int | None = None,
+    ) -> torch.Tensor:
+        # `weight` is [num_experts, out_features, in_features].
+        # `scale` is [num_experts, out_blocks, in_blocks].
+        out_features = weight.shape[1]
+        in_features = weight.shape[2]
+        out_blocks = scale.shape[1]
+        out_block_size = out_block_size or (
+            (out_features + out_blocks - 1) // out_blocks
+        )
+
+        expanded = scale.repeat_interleave(out_block_size, dim=1).repeat_interleave(
+            in_block_size, dim=2
+        )
+        expanded = expanded[:, :out_features, :in_features]
+        return weight.to(hidden_states.dtype) * expanded.to(hidden_states.dtype)
+
+    in_block_size = int(group_size.item())
+
+    def _quant_glu_intermediate(state: torch.Tensor) -> torch.Tensor:
+        # Dynamically quantize the GLU intermediate to fp8 per
+        # (1, in_block_size) group along the contraction dim, then dequant.
+        fp8_dtype = torch.float8_e4m3fn
+        finfo = torch.finfo(fp8_dtype)
+        orig_shape = state.shape
+        s_g = state.reshape(-1, in_block_size).to(torch.float32)
+        amax = s_g.abs().amax(dim=-1, keepdim=True).clamp_min(1e-10)
+        scale = amax / finfo.max
+        q = (s_g / scale).clamp(finfo.min, finfo.max).to(fp8_dtype)
+        deq = (q.to(state.dtype) * scale.to(state.dtype)).reshape(orig_shape)
+        return deq
+
+    # W8A8: the caller hands us fp8-quantized hidden_states plus a
+    # per-(token, K-block) scale. Dequantize back to the compute dtype so the
+    # reference matmuls below run in bf16, exactly like the W8A16 path. When
+    # W8A8 is off, hidden_states is already the unquantized activation.
+    if hidden_states_scale is not None:
+        # compute_dtype is the explicit output/compute dtype passed by the caller
+        # (the saved pre-quant hidden_states dtype: bf16 or dlfp16).
+        hidden_states = hidden_states.to(compute_dtype) * hidden_states_scale.to(
+            compute_dtype
+        ).repeat_interleave(in_block_size, dim=-1)
+
+    gate_out_block = (
+        gate_proj_weight.shape[1] + gate_proj_scale.shape[1] - 1
+    ) // gate_proj_scale.shape[1]
+    down_out_block = (
+        down_proj_weight.shape[1] + down_proj_scale.shape[1] - 1
+    ) // down_proj_scale.shape[1]
+
+    gate_proj_weight_dq = _dequantize_blockwise_weight(
+        gate_proj_weight, gate_proj_scale, in_block_size, gate_out_block
+    )
+    up_proj_weight_dq = _dequantize_blockwise_weight(
+        up_proj_weight, up_proj_scale, in_block_size, gate_out_block
+    )
+    down_proj_weight_dq = _dequantize_blockwise_weight(
+        down_proj_weight, down_proj_scale, in_block_size, down_out_block
+    )
+
+    num_tokens, hidden_size = hidden_states.shape
+    num_experts = gate_proj_weight_dq.shape[0]
+    dtype = hidden_states.dtype
+
+    act = hidden_act.lower()
+    if act in ("silu", "swish"):
+        act_fn = torch.nn.functional.silu
+    elif "gelu" in act:
+        act_fn = torch.nn.functional.gelu
+    else:
+        raise ValueError(f"Unsupported hidden_act={hidden_act!r}")
+
+    # masked_routing_weights: [E, T_padded] (softmax + topk done externally).
+    routing_t = masked_routing_weights[:, :num_tokens]
+
+    final_hidden_states = torch.zeros(num_tokens, hidden_size, dtype=dtype)
+
+    for expert_idx in range(num_experts):
+        expert_weights = routing_t[expert_idx]  # [T]
+        token_indices = expert_weights.nonzero(as_tuple=True)[0]
+        if token_indices.numel() == 0:
+            continue
+
+        weights = expert_weights[token_indices]  # [num_selected]
+        current_state = hidden_states[token_indices]  # [num_selected, hidden_size]
+
+        gate = torch.nn.functional.linear(
+            current_state,
+            gate_proj_weight_dq[expert_idx],
+            gate_proj_bias[expert_idx] if gate_proj_bias is not None else None,
+        )
+        up = torch.nn.functional.linear(
+            current_state,
+            up_proj_weight_dq[expert_idx],
+            up_proj_bias[expert_idx] if up_proj_bias is not None else None,
+        )
+        # Input activation is already (de)quantized above; only the GLU
+        # intermediate is quantized here for the down projection (W8A8).
+        glu = _quant_glu_intermediate(act_fn(gate) * up)
+        down = torch.nn.functional.linear(
+            glu,
+            down_proj_weight_dq[expert_idx],
+            down_proj_bias[expert_idx] if down_proj_bias is not None else None,
+        )
+        current_hidden_states = down * weights.unsqueeze(-1)
+        final_hidden_states.index_add_(
+            0, token_indices, current_hidden_states.to(dtype)
+        )
+
+    return final_hidden_states
+
+
+@torch.library.register_fake("rbln_custom_ops::custom_moe_glu_w8a8")
+def custom_moe_glu_w8a8_fake(
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gate_proj_weight: torch.Tensor,
+    gate_proj_scale: torch.Tensor,
+    up_proj_weight: torch.Tensor,
+    up_proj_scale: torch.Tensor,
+    down_proj_weight: torch.Tensor,
+    down_proj_scale: torch.Tensor,
+    masked_routing_weights: torch.Tensor,
+    group_size: torch.Tensor,
+    hidden_act: str,
+    compute_dtype: torch.dtype,
+    gate_proj_bias: torch.Tensor | None = None,
+    up_proj_bias: torch.Tensor | None = None,
+    down_proj_bias: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+    dp_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    # Output is in the explicit compute dtype passed by the caller (the saved
+    # pre-quant hidden_states dtype — bf16 or dlfp16). hidden_states here is fp8
+    # and hidden_states_scale is fp32, so neither is the right output dtype; and
+    # deriving it from masked_routing_weights is model-dependent. compute_dtype is
+    # a torch-level-only arg (not in the rebel_compiler CUSTOM_OP_SIGS), so it is
+    # ignored by the compiler frontend and never reaches the converter/kernel.
+    return torch.empty_like(hidden_states, dtype=compute_dtype)
+
+
 class Fp8MoEMethod(FusedMoEMethodBase):
     def __init__(self, quant_config: Fp8Config, layer: torch.nn.Module):
         super().__init__(layer.moe_config)


### PR DESCRIPTION
## Summary

PR #684 removed the Python `@torch.library.custom_op` registration of `custom_moe_glu_group_dequantize` and, in the same change, added calls to a new `custom_moe_glu_w8a8` op **without registering it**. Neither op is registered anywhere else in the tree (or in an installed package), so the block-fp8 MoE path (`Fp8MoEMethod.apply`) fails with an `AttributeError` on `torch.ops.rbln_custom_ops.*` for **both** the W8A8 (default) and W8A16 branches.

This restores both custom op registrations in `vllm_rbln/model_executor/layers/quantization/fp8.py`.

## Changes

- **`custom_moe_glu_group_dequantize`** (op + `register_fake`) — restored verbatim from the pre-#684 version. Used by the W8A16 path (`VLLM_RBLN_USE_W8A16=True`).
- **`custom_moe_glu_w8a8`** (op + `register_fake`) — new registration matching the call site added in #684:
  - Activation is handed in as fp8 plus a per-(token, K-block) `hidden_states_scale`, dequantized back to `compute_dtype`.
  - The GLU intermediate is fp8-requantized before the down projection (true W8A8 semantics).
  - `compute_dtype` sets the output dtype (fp8 input can't infer it) and is a torch-level-only arg, ignored by the compiler frontend.

The custom op bodies are the eager PyTorch reference implementations; on device they are replaced by the RBLN custom kernels.

## Verification

- Both ops register on `torch.ops.rbln_custom_ops` after import.
- `custom_moe_glu_w8a8` eager run produces correct shape/dtype; W8A8 output tracks the W8A16 reference within fp8 quantization error.
- `register_fake` (meta) path returns correct shape/dtype/device.
- `ruff check` / `ruff format` clean.

> Note: the on-device kernel path was not exercised here — this environment lacks `librbln.so` (rebel-compiler), so only the CPU eager reference and meta/fake paths were validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)