### PR TITLE
fix(deps): gate torch-rbln to x86_64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "torchvision",
     "torchaudio",
     "torchcodec",
-    "torch-rbln~=0.2.2.dev0",
+    "torch-rbln~=0.2.2.dev0; platform_machine == 'x86_64'",
     "optimum-rbln>=0.11.1a1",
 ]
 


### PR DESCRIPTION
## Summary

`torch-rbln` publishes **x86_64-only** wheels. When a downstream project resolves for aarch64 (universal resolution), it pulls `vllm-rbln` → `torch-rbln` and fails:

```
torch-rbln~=0.2.2.dev0 has no `platform_machine == 'aarch64' and sys_platform == 'linux'`-compatible wheels
```

This gates the `torch-rbln` requirement to `x86_64` so aarch64 resolves simply skip it — matching the platform-marker pattern `optimum-rbln` already uses for `torchvision`/`torchaudio`.

## Notes

- `torch-rbln` is required only by this direct edge (`optimum-rbln` does **not** depend on it), so a single marker is sufficient — no `override-dependencies` needed.
- Scoped to `torch-rbln` only; the global platform set is unchanged. Full aarch64 support can be enabled later once the RBLN stack ships aarch64 wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)