### PR TITLE
fix: honor RBLN_FORCE_NPU_NAME (renamed from RBLN_TARGET_SOC)

### DIFF
--- a/examples/cpu_only_compile.py
+++ b/examples/cpu_only_compile.py
@@ -34,9 +34,9 @@ torch.compile pipeline). Three things follow from that:
   (the optimum-rbln path) makes ``VLLM_RBLN_COMPILE_ONLY=1`` raise an error.
 * The compile cache must stay enabled (this is where the artifacts land), so
   ``VLLM_DISABLE_COMPILE_CACHE=1`` is rejected in this mode.
-* Without an NPU, ``rebel.get_npu_name()`` returns ``None`` and the target SOC
-  can no longer be auto-detected, so you must set ``RBLN_TARGET_SOC`` (e.g.
-  ``RBLN-CA25``) to tell the compiler what to target.
+* Without an NPU, ``rebel.get_npu_name()`` returns ``None`` and the target NPU
+  can no longer be auto-detected, so you must set ``RBLN_FORCE_NPU_NAME``
+  (e.g. ``RBLN-CA25``) to tell the compiler what to target.
 
 The compiled runtime lives on a dummy device, so generation is intentionally
 skipped here -- the only useful output of this run is the populated cache.
@@ -44,7 +44,7 @@ skipped here -- the only useful output of this run is the populated cache.
 Usage
 -----
     # Set the SOC you ultimately want to serve on, then run:
-    RBLN_TARGET_SOC=RBLN-CA25 python examples/cpu_only_compile.py \
+    RBLN_FORCE_NPU_NAME=RBLN-CA25 python examples/cpu_only_compile.py \
         --model Qwen/Qwen3-0.6B
 
 The artifacts are written under ``$VLLM_CACHE_ROOT/rbln`` (default
@@ -67,8 +67,8 @@ def parse_args():
     parser.add_argument(
         "--target-soc",
         type=str,
-        default=os.environ.get("RBLN_TARGET_SOC", "RBLN-CA25"),
-        help="Target RBLN SOC to compile for (sets RBLN_TARGET_SOC). Required "
+        default=os.environ.get("RBLN_FORCE_NPU_NAME", "RBLN-CA25"),
+        help="Target RBLN NPU to compile for (sets RBLN_FORCE_NPU_NAME). Required "
         "because no NPU is mounted to auto-detect it.",
     )
     return parser.parse_args()
@@ -84,7 +84,7 @@ def main():
     # compile-only only applies to the vLLM-native (torch.compile) path, not
     # the optimum-rbln path, so select it explicitly.
     os.environ["VLLM_RBLN_USE_VLLM_MODEL"] = "1"
-    os.environ["RBLN_TARGET_SOC"] = args.target_soc
+    os.environ["RBLN_FORCE_NPU_NAME"] = args.target_soc
     # The cache is where compiled artifacts are written; it must stay enabled.
     os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "0")
 

--- a/tests/torch_compile/unit/test_compile_only.py
+++ b/tests/torch_compile/unit/test_compile_only.py
@@ -58,10 +58,12 @@ def test_get_device_name_returns_npu_name(monkeypatch):
 
 def test_get_device_name_raises_when_npu_none(monkeypatch):
     # On a host without an NPU mounted rebel.get_npu_name() returns None; we
-    # should surface an actionable error pointing at RBLN_TARGET_SOC rather
+    # should surface an actionable error pointing at RBLN_FORCE_NPU_NAME rather
     # than a bare AssertionError.
     monkeypatch.setattr(rebel, "get_npu_name", lambda device_id=0: None)
-    with pytest.raises(RuntimeError, match="RBLN_TARGET_SOC"):
+    monkeypatch.delenv("RBLN_FORCE_NPU_NAME", raising=False)
+    monkeypatch.delenv("RBLN_TARGET_SOC", raising=False)
+    with pytest.raises(RuntimeError, match="RBLN_FORCE_NPU_NAME"):
         RblnPlatform.get_device_name()
 
 

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -79,18 +79,20 @@ class RblnPlatform(Platform):
 
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
-        # rebel.get_npu_name() returns None on a host without an NPU mounted
-        # (e.g. a CPU-only compile worker), so fall back to the RBLN_TARGET_SOC
-        # env var. When neither is available we cannot determine a target SOC,
-        # so surface an actionable error instead of a bare AssertionError.
-        device_name = rebel.get_npu_name(device_id) or os.environ.get("RBLN_TARGET_SOC")
+        # No NPU mounted (e.g. CPU-only compile worker): fall back to the env var
+        # the compiler CI sets — RBLN_FORCE_NPU_NAME (RBLN_TARGET_SOC = legacy).
+        device_name = (
+            rebel.get_npu_name(device_id)
+            or os.environ.get("RBLN_FORCE_NPU_NAME")
+            or os.environ.get("RBLN_TARGET_SOC")
+        )
         if not device_name:
             raise RuntimeError(
                 "Could not determine the RBLN NPU name "
                 f"(rebel.get_npu_name({device_id}) returned None). On a host "
                 "without an NPU mounted (e.g. a CPU-only compile worker running "
-                "with VLLM_RBLN_COMPILE_ONLY=1), set RBLN_TARGET_SOC to the "
-                "target SOC (e.g. RBLN-CA25) so compilation can target it."
+                "with VLLM_RBLN_COMPILE_ONLY=1), set RBLN_FORCE_NPU_NAME to the "
+                "target NPU (e.g. RBLN-CA25) so compilation can target it."
             )
         return device_name
 

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -271,8 +271,8 @@ environment_variables = {
     # When set, the rbln torch.compile backend compiles + caches each graph and
     # builds its runtime on a dummy device (no NPU required); the populated
     # cache is later reused by a real NPU host via cache-hit. The target SOC is
-    # taken from rebel.get_npu_name(), which falls back to RBLN_TARGET_SOC, so
-    # set RBLN_TARGET_SOC (e.g. RBLN-CA25) on a host without an NPU mounted.
+    # taken from rebel.get_npu_name(); on a host without an NPU mounted set
+    # RBLN_FORCE_NPU_NAME (e.g. RBLN-CA25) so the target can still be resolved.
     "VLLM_RBLN_COMPILE_ONLY": (
         lambda: (
             os.environ.get("VLLM_RBLN_COMPILE_ONLY", "False").lower() in ("true", "1")


### PR DESCRIPTION
## Description

### Problem
rebel-compiler renamed the target-NPU env var `RBLN_TARGET_SOC` → `RBLN_FORCE_NPU_NAME`, and the compiler CI now sets the new name. vllm-rbln still referenced the old name in several places:

- `platform.py` `get_device_name()`: on a CPU-only compile host (no NPU) it fell back to `RBLN_TARGET_SOC` only, so the renamed var was missed and the device-less compile raised `RuntimeError`.
- `examples/cpu_only_compile.py` (FSW example): set/documented `RBLN_TARGET_SOC`.
- `tests/torch_compile/unit/test_compile_only.py`: asserted the error mentions `RBLN_TARGET_SOC`.
- `rbln_envs.py`: comment referenced `RBLN_TARGET_SOC`.

### Solution
Honor `RBLN_FORCE_NPU_NAME` (current name) across vllm-rbln, keeping `RBLN_TARGET_SOC` as a back-compat fallback where it's read:

- `get_device_name()`: read `RBLN_FORCE_NPU_NAME` first, then legacy `RBLN_TARGET_SOC`; error message now points at `RBLN_FORCE_NPU_NAME` / "target NPU".
- Example: use `RBLN_FORCE_NPU_NAME` in docs, default, help, and the env it sets.
- Test: assert on `RBLN_FORCE_NPU_NAME`; clear both env vars so the raise path is deterministic.
- Comment updated.

The NPU-attached path (`rebel.get_npu_name()` returns a value) is unaffected.

### Verification
- `py_compile` OK on all changed files.
- NPU host: `rebel.get_npu_name()` takes precedence → unchanged.
- CPU compile host + `RBLN_FORCE_NPU_NAME=RBLN-CA25`: resolves the target; legacy `RBLN_TARGET_SOC` still works.

Related: minimax-m2_7 CR-13 compile-only cases in rebel_compiler's REBEL vLLM-Dynamo compile-only PR.

## Reviewer
* **Primary**: (TBD)
* **Secondary**: (code owner)
