### PR TITLE
fix: bind naive attention op in eager mode for is_normal branches

### DIFF
--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -1516,6 +1516,9 @@ class RBLNFlashAttentionImpl(AttentionImpl[RBLNFlashAttentionMetadata]):
                         causal_attention_naive_decode = (
                             torch.ops.rbln_custom_ops.causal_attention_naive_decode
                         )
+                else:
+                    causal_attention_naive_prefill = causal_attention_naive_prefill_impl
+                    causal_attention_naive_decode = causal_attention_naive_decode_impl
 
                 if not attn_metadata.is_prefill:
                     decode_args = [
@@ -1626,6 +1629,9 @@ class RBLNFlashAttentionImpl(AttentionImpl[RBLNFlashAttentionMetadata]):
                         attention_naive_decode = (
                             torch.ops.rbln_custom_ops.attention_naive_decode
                         )
+                else:
+                    attention_naive_prefill = attention_naive_prefill_impl
+                    attention_naive_decode = attention_naive_decode_impl
 
                 if not attn_metadata.is_prefill:
                     decode_args = [


### PR DESCRIPTION
## Summary

Fixes an `UnboundLocalError` when running `generate()` in eager mode (`VLLM_RBLN_COMPILE_MODEL=False`) with the `is_normal` attention path:

```
UnboundLocalError: cannot access local variable
'causal_attention_naive_prefill' where it is not associated with a value
```

## Root cause

In `RBLNFlashAttentionImpl.forward` (`vllm_rbln/v1/attention/backends/flash_attention.py`), the two `is_normal` branches bound their naive attention ops **only** inside `if envs.VLLM_RBLN_COMPILE_MODEL:` but then called them unconditionally. In eager mode the ops were never bound, raising `UnboundLocalError`.

The sibling branches (`flash_causal`, `flash`, `sliding_window`) all bind a pure-torch `*_impl` fallback in an `else:` — these two `is_normal` branches were the only ones missing it.

## Fix

Add the matching `else:` fallback to both `is_normal` branches, mirroring the existing `flash_causal` template:

- `is_causal` + `is_normal` → `causal_attention_naive_{prefill,decode}_impl`
- non-causal + `is_normal` → `attention_naive_{prefill,decode}_impl`

The `_impl` fallbacks already exist in the same file.

## Testing

A regression test drives `forward()` directly in eager mode with `is_normal` forced on, parametrized over both `is_causal` values (mirroring `VLLM_RBLN_FLASH_CAUSAL_ATTN` `"1"`/`"0"`) so both branches are exercised. On the same working tree: without the fix both parametrizations FAIL with the `UnboundLocalError`; with the fix both PASS.

## Note (out of scope)

A separate eager-mode `dtype` assert in the fused-MoE path (`model_executor/layers/fused_moe/layer.py`, `hidden_states` vs `masked_routing_weight`) also fails under eager. It is unrelated to this attention fix and left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)