### PR TITLE
refactor(metrics): report latency percentiles instead of outlier-removed mean

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_metrics.py
+++ b/tests/torch_compile/unit/v1/worker/test_metrics.py
@@ -72,145 +72,100 @@ class TestStepMetricsAddMeasurement:
         assert m.token_counts == [0]
 
 
-class TestOutlierRemoval:
-    """Test _without_outlier edge cases."""
+class TestLatencyPercentiles:
+    """get_latency_percentiles reports the distribution (no data-point removal)."""
 
-    def test_empty_list(self):
-        m = StepMetrics()
-        assert m._without_outlier([]) == []
+    def test_empty(self):
+        assert StepMetrics().get_latency_percentiles() == {}
 
-    def test_single_element(self):
+    def test_keys_and_max(self):
         m = StepMetrics()
-        assert m._without_outlier([42.0]) == [42.0]
-        assert m._without_outlier([42]) == [42]
+        for lat in [0.010, 0.020, 0.030, 0.040]:
+            m.add_measurement(lat, 1)
+        pct = m.get_latency_percentiles()
+        assert set(pct) == {"p50", "p90", "p99", "max"}
+        assert pct["max"] == pytest.approx(40.0)  # 0.040 s -> ms
 
-    def test_two_elements_removes_farthest_from_mean(self):
-        """With [1.0, 100.0], mean=50.5. Both deviate 49.5 — first max wins."""
+    def test_spike_shows_in_tail_not_p50(self):
+        """A one-off spike inflates max/p99 but leaves p50 (median) robust."""
         m = StepMetrics()
-        result = m._without_outlier([1.0, 100.0])
-        # index(max(deviations)) returns 0 when deviations are equal
-        assert len(result) == 1
-        assert result == [100.0]
+        for lat in [0.010, 0.010, 0.010, 0.010, 5.0]:  # 5 s spike
+            m.add_measurement(lat, 1)
+        pct = m.get_latency_percentiles()
+        assert pct["p50"] == pytest.approx(10.0, abs=1.0)  # ~10 ms, spike-robust
+        assert pct["max"] == pytest.approx(5000.0)
 
-    def test_obvious_outlier_removed(self):
+    def test_custom_percentiles(self):
         m = StepMetrics()
-        values = [10.0, 10.1, 9.9, 10.0, 500.0]
-        result = m._without_outlier(values)
-        assert 500.0 not in result
-        assert len(result) == 4
-
-    def test_all_identical_values(self):
-        """All deviations are 0 — removes first element (index 0)."""
-        m = StepMetrics()
-        result = m._without_outlier([5.0, 5.0, 5.0])
-        assert len(result) == 2
-        assert all(v == 5.0 for v in result)
-
-    def test_negative_values(self):
-        m = StepMetrics()
-        result = m._without_outlier([-100.0, 1.0, 2.0, 3.0])
-        assert -100.0 not in result
-        assert len(result) == 3
-
-    def test_outlier_removal_int(self):
-        m = StepMetrics()
-        result = m._without_outlier([10, 11, 9, 10, 999])
-        assert 999 not in result
-        assert len(result) == 4
+        for lat in [0.01, 0.02, 0.03]:
+            m.add_measurement(lat, 1)
+        pct = m.get_latency_percentiles(percentiles=(25.0, 75.0))
+        assert set(pct) == {"p25", "p75", "max"}
 
 
 class TestStepMetricsAverages:
-    """Test average computations including edge cases and outlier flag."""
+    """Averages are plain means (no outlier removal); throughput is sum-based."""
 
     def test_avg_latency_empty(self):
-        m = StepMetrics()
-        assert m.get_avg_latency() == 0.0
-        assert m.get_avg_latency(ignore_outlier=False) == 0.0
+        assert StepMetrics().get_avg_latency() == 0.0
 
     def test_avg_latency_converts_to_ms(self):
         m = StepMetrics()
         m.add_measurement(1.0, 10)  # 1 second
-        # single value, outlier removal returns as-is
         assert m.get_avg_latency() == 1000.0
 
-    def test_avg_latency_with_outlier(self):
+    def test_avg_latency_is_plain_mean(self):
+        """No outlier removal: a spike is included in the mean (use p50 instead)."""
         m = StepMetrics()
         for lat in [0.01, 0.01, 0.01, 0.01, 5.0]:
             m.add_measurement(lat, 1)
-        avg_with = m.get_avg_latency(ignore_outlier=True)
-        avg_without = m.get_avg_latency(ignore_outlier=False)
-        # Removing the 5.0 outlier should give much lower average
-        assert avg_with < avg_without
-        assert avg_with == pytest.approx(10.0, abs=1.0)  # ~0.01s * 1000
+        # mean = (0.04 + 5.0) / 5 = 1.008 s -> 1008 ms
+        assert m.get_avg_latency() == pytest.approx(1008.0, abs=1.0)
 
     def test_avg_throughput_empty(self):
-        m = StepMetrics()
-        assert m.get_avg_throughput() == 0.0
+        assert StepMetrics().get_avg_throughput() == 0.0
 
-    def test_avg_throughput_basic(self):
+    def test_avg_throughput_sum_based(self):
         m = StepMetrics()
         m.add_measurement(1.0, 100)
         m.add_measurement(1.0, 100)
-        # total_tokens=200, total_time=2.0 (single element no outlier removal effective)
-        # Actually 2 elements: outlier removal removes one. So tokens=100, time=1.0
-        throughput = m.get_avg_throughput(ignore_outlier=True)
-        assert throughput == pytest.approx(100.0)
+        # 200 tokens / 2.0 s = 100 tok/s
+        assert m.get_avg_throughput() == pytest.approx(100.0)
 
-    def test_avg_throughput_no_outlier_flag(self):
+    def test_avg_throughput_bimodal_is_stable(self):
+        """Sum-based throughput is unaffected by a bimodal per-step split."""
         m = StepMetrics()
-        m.add_measurement(1.0, 100)
-        m.add_measurement(1.0, 100)
-        throughput = m.get_avg_throughput(ignore_outlier=False)
-        assert throughput == pytest.approx(100.0)
+        m.add_measurement(0.1, 500)  # fast step
+        m.add_measurement(1.9, 500)  # slow step
+        # 1000 tokens / 2.0 s = 500 tok/s regardless of the split
+        assert m.get_avg_throughput() == pytest.approx(500.0)
 
     def test_avg_throughput_zero_latency(self):
-        """If all latencies are 0, total_time=0 → returns 0.0."""
+        """If all latencies are 0, total_time=0 -> returns 0.0."""
         m = StepMetrics()
         m.add_measurement(0.0, 10)
         m.add_measurement(0.0, 10)
         assert m.get_avg_throughput() == 0.0
 
-    def test_avg_throughput_independent_outlier_removal(self):
-        """Outlier removal on latencies and token_counts is independent.
-
-        This means different indices may be removed from each list.
-        Verify the computation still works and doesn't crash.
-        """
-        m = StepMetrics()
-        # latency outlier at index 2, token_count outlier at index 0
-        m.add_measurement(1.0, 9999)
-        m.add_measurement(1.0, 10)
-        m.add_measurement(100.0, 10)
-        throughput = m.get_avg_throughput(ignore_outlier=True)
-        # latencies after removal: [1.0, 1.0], tokens after removal: [10, 10]
-        # throughput = 20 / 2.0 = 10.0
-        assert throughput == pytest.approx(10.0)
-
-    def test_avg_throughput_mismatched_empty_tokens(self):
-        """Latencies present but no token_counts → still returns 0.0."""
+    def test_avg_throughput_no_tokens(self):
+        """Latencies present but no tokens -> 0.0."""
         m = StepMetrics()
         m.latencies = [1.0]
-        # token_counts is empty
         assert m.get_avg_throughput() == 0.0
 
     def test_avg_host_time_empty(self):
-        m = StepMetrics()
-        assert m.get_avg_host_time() == 0.0
+        assert StepMetrics().get_avg_host_time() == 0.0
 
-    def test_avg_device_time(self):
+    def test_avg_device_time_is_mean(self):
         m = StepMetrics()
         m.add_measurement(1.0, 1, device_time=100)
         m.add_measurement(1.0, 1, device_time=200)
-        # With outlier removal: one removed, single value remains
-        assert m.get_avg_device_time(ignore_outlier=True) in (100.0, 200.0)
-        assert m.get_avg_device_time(ignore_outlier=False) == 150.0
+        assert m.get_avg_device_time() == 150.0
 
-    def test_avg_ccl_time(self):
+    def test_avg_ccl_time_is_mean(self):
         m = StepMetrics()
-        m.add_measurement(1.0, 1, ccl_time=300)
-        m.add_measurement(1.0, 1, ccl_time=300)
-        m.add_measurement(1.0, 1, ccl_time=300)
-        # All same, outlier removal removes one, avg still 300
+        for _ in range(3):
+            m.add_measurement(1.0, 1, ccl_time=300)
         assert m.get_avg_ccl_time() == 300.0
 
     def test_get_call_counts(self):
@@ -274,6 +229,14 @@ class TestPrefillMetricsByRequestID:
         latencies = pm.get_avg_latency_per_request()
         # Single measurement: avg = 0.5 * 1000 = 500ms
         assert latencies["req-1"] == pytest.approx(500.0)
+
+    def test_total_latency_per_request_sums_chunks(self):
+        """Per-request total = sum of the request's chunk latencies (ms)."""
+        pm = PrefillMetricsByRequestID()
+        pm.add_measurement("req-1", 0.5, 30)  # chunk 1
+        pm.add_measurement("req-1", 0.3, 20)  # chunk 2
+        totals = pm.get_total_latency_per_request()
+        assert totals["req-1"] == pytest.approx(800.0)  # (0.5 + 0.3) * 1000
 
     def test_timing_fields_forwarded(self):
         """Ensure host/device/ccl times are forwarded to inner StepMetrics."""

--- a/vllm_rbln/v1/worker/metrics.py
+++ b/vllm_rbln/v1/worker/metrics.py
@@ -15,14 +15,13 @@
 import os
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
-from typing import TypeVar
+
+import numpy as np
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger, make_file_handler
 
 logger = init_logger(__name__)
-
-T = TypeVar("T", int, float)
 
 _metrics_file_attached = False
 
@@ -79,106 +78,86 @@ class StepMetrics:
         if prepare_time is not None:
             self.prepare_times.append(prepare_time)
 
-    def _without_outlier(self, values: list[T]) -> list[T]:
-        """Return values excluding one outlier (max absolute deviation)."""
-        if len(values) <= 1:
-            return values
-        mean = sum(values) / len(values)
-        deviations = [abs(v - mean) for v in values]
-        max_idx = deviations.index(max(deviations))
-        return [v for i, v in enumerate(values) if i != max_idx]
-
-    def get_avg_latency(self, ignore_outlier: bool = True) -> float:
-        """Get average latency in milliseconds,
-        optionally ignoring one outlier."""
-        values = (
-            self._without_outlier(self.latencies) if ignore_outlier else self.latencies
-        )
-        return sum(values) / len(values) * 1000 if values else 0.0
-
-    def get_avg_throughput(self, ignore_outlier: bool = True) -> float:
-        """Get average throughput in tokens/second,
-        optionally ignoring one outlier."""
-        if not self.latencies or not self.token_counts:
+    def get_avg_latency(self) -> float:
+        """Mean per-step latency in milliseconds (no outlier removal)."""
+        if not self.latencies:
             return 0.0
-        latencies = (
-            self._without_outlier(self.latencies) if ignore_outlier else self.latencies
-        )
-        tokens = (
-            self._without_outlier(self.token_counts)
-            if ignore_outlier
-            else self.token_counts
-        )
-        total_time = sum(latencies)
-        total_tokens = sum(tokens)
-        return total_tokens / total_time if total_time > 0 else 0.0
+        return sum(self.latencies) / len(self.latencies) * 1000
 
-    def get_avg_host_time(self, ignore_outlier: bool = True) -> float:
-        """Get average host time in microseconds,
-        optionally ignoring one outlier."""
-        values = (
-            self._without_outlier(self.host_times)
-            if ignore_outlier
-            else self.host_times
-        )
-        return sum(values) / len(values) if values else 0.0
+    def get_latency_percentiles(
+        self, percentiles: tuple[float, ...] = (50.0, 90.0, 99.0)
+    ) -> dict[str, float]:
+        """Latency percentiles and max in milliseconds (empty if no data)."""
+        if not self.latencies:
+            return {}
+        arr = np.asarray(self.latencies, dtype=float) * 1000.0
+        stats = {f"p{p:g}": float(np.percentile(arr, p)) for p in percentiles}
+        stats["max"] = float(arr.max())
+        return stats
 
-    def get_avg_device_time(self, ignore_outlier: bool = True) -> float:
-        """Get average device time in microseconds,
-        optionally ignoring one outlier."""
-        values = (
-            self._without_outlier(self.device_times)
-            if ignore_outlier
-            else self.device_times
-        )
-        return sum(values) / len(values) if values else 0.0
+    def get_avg_throughput(self) -> float:
+        """Aggregate throughput in tokens/second (total tokens / total time)."""
+        total_time = sum(self.latencies)
+        return sum(self.token_counts) / total_time if total_time > 0 else 0.0
 
-    def get_avg_ccl_time(self, ignore_outlier: bool = True) -> float:
-        """Get average ccl time in microseconds,
-        optionally ignoring one outlier."""
-        values = (
-            self._without_outlier(self.ccl_times) if ignore_outlier else self.ccl_times
-        )
-        return sum(values) / len(values) if values else 0.0
+    def get_avg_host_time(self) -> float:
+        """Mean host time in microseconds."""
+        return sum(self.host_times) / len(self.host_times) if self.host_times else 0.0
 
-    def get_avg_prepare_time(self, ignore_outlier: bool = True) -> float:
-        """Get average prepare time (PrepareInputs + PrepareOutputs around Run)
-        in microseconds, optionally ignoring one outlier."""
-        values = (
-            self._without_outlier(self.prepare_times)
-            if ignore_outlier
-            else self.prepare_times
+    def get_avg_device_time(self) -> float:
+        """Mean device time in microseconds."""
+        return (
+            sum(self.device_times) / len(self.device_times)
+            if self.device_times
+            else 0.0
         )
-        return sum(values) / len(values) if values else 0.0
+
+    def get_avg_ccl_time(self) -> float:
+        """Mean ccl time in microseconds."""
+        return sum(self.ccl_times) / len(self.ccl_times) if self.ccl_times else 0.0
+
+    def get_avg_prepare_time(self) -> float:
+        """Mean prepare time (PrepareInputs + PrepareOutputs around Run), us."""
+        return (
+            sum(self.prepare_times) / len(self.prepare_times)
+            if self.prepare_times
+            else 0.0
+        )
 
     def get_call_counts(self) -> int:
         """Get total number of requests processed."""
         return len(self.latencies)
 
     def show_stats(self, stat_type: str):
-        if self.get_call_counts() > 0:
-            logger.info("%s METRICS:", stat_type)
-            logger.info("  Total call counts: %d", self.get_call_counts())
-            logger.info("  Average latency: %.2f ms", self.get_avg_latency())
-            if sum(self.token_counts) > 0:
-                logger.info("  Total tokens processed: %d", sum(self.token_counts))
-                logger.info(
-                    "  Average throughput: %.2f tokens/sec", self.get_avg_throughput()
-                )
-            if self.host_times:
-                logger.info("  Average host time: %.2f us", self.get_avg_host_time())
-            if self.device_times:
-                logger.info(
-                    "  Average device time: %.2f us", self.get_avg_device_time()
-                )
-            if self.ccl_times:
-                logger.info("  Average ccl time: %.2f us", self.get_avg_ccl_time())
-            if self.prepare_times:
-                logger.info(
-                    "  Average prepare time: %.2f us", self.get_avg_prepare_time()
-                )
-        else:
+        if self.get_call_counts() <= 0:
             logger.info("%s METRICS: No data recorded", stat_type)
+            return
+        pct = self.get_latency_percentiles()
+        logger.info("%s METRICS:", stat_type)
+        logger.info("  Total call counts: %d", self.get_call_counts())
+        logger.info(
+            "  Latency (ms): mean %.2f | p50 %.2f | p90 %.2f | p99 %.2f | max %.2f",
+            self.get_avg_latency(),
+            pct["p50"],
+            pct["p90"],
+            pct["p99"],
+            pct["max"],
+        )
+        if sum(self.token_counts) > 0:
+            logger.info("  Total tokens processed: %d", sum(self.token_counts))
+            logger.info(
+                "  Average throughput: %.2f tokens/sec", self.get_avg_throughput()
+            )
+        if self.host_times:
+            logger.info("  Average host time: %.2f us", self.get_avg_host_time())
+        if self.device_times:
+            logger.info("  Average device time: %.2f us", self.get_avg_device_time())
+        if self.ccl_times:
+            logger.info("  Average ccl time: %.2f us", self.get_avg_ccl_time())
+        if self.prepare_times:
+            logger.info(
+                "  Average prepare time: %.2f us", self.get_avg_prepare_time()
+            )
 
 
 class PrefillMetricsByRequestID:
@@ -211,6 +190,13 @@ class PrefillMetricsByRequestID:
         """Get average latency per request."""
         return {
             request_id: metric.get_avg_latency()
+            for request_id, metric in self.metrics.items()
+        }
+
+    def get_total_latency_per_request(self) -> dict[str, float]:
+        """Total prefill latency per request (sum of its chunk latencies), ms."""
+        return {
+            request_id: sum(metric.latencies) * 1000.0
             for request_id, metric in self.metrics.items()
         }
 
@@ -322,6 +308,23 @@ class PerformanceTracker:
                 request_ids=report.request_ids,
             )
 
+    def _show_per_request_prefill(self) -> None:
+        """Log per-request prefill latency (sum of each request's chunks)."""
+        totals = list(
+            self.prefill_metrics_by_request_id.get_total_latency_per_request().values()
+        )
+        if not totals:
+            return
+        arr = np.asarray(totals, dtype=float)
+        logger.info(
+            "  Per-request prefill (ms): mean %.2f | p50 %.2f | max %.2f "
+            "(%d requests)",
+            float(arr.mean()),
+            float(np.percentile(arr, 50)),
+            float(arr.max()),
+            len(totals),
+        )
+
     def print_final_stats(self):
         _attach_metrics_file_handler()
         logger.info("=" * 80)
@@ -333,6 +336,7 @@ class PerformanceTracker:
 
         # Prefill stats
         self.prefill_metrics.show_stats("PREFILL")
+        self._show_per_request_prefill()
         logger.info("-" * 40)
 
         # Decode stats

--- a/vllm_rbln/v1/worker/metrics.py
+++ b/vllm_rbln/v1/worker/metrics.py
@@ -155,9 +155,7 @@ class StepMetrics:
         if self.ccl_times:
             logger.info("  Average ccl time: %.2f us", self.get_avg_ccl_time())
         if self.prepare_times:
-            logger.info(
-                "  Average prepare time: %.2f us", self.get_avg_prepare_time()
-            )
+            logger.info("  Average prepare time: %.2f us", self.get_avg_prepare_time())
 
 
 class PrefillMetricsByRequestID:
@@ -317,8 +315,7 @@ class PerformanceTracker:
             return
         arr = np.asarray(totals, dtype=float)
         logger.info(
-            "  Per-request prefill (ms): mean %.2f | p50 %.2f | max %.2f "
-            "(%d requests)",
+            "  Per-request prefill (ms): mean %.2f | p50 %.2f | max %.2f (%d requests)",
             float(arr.mean()),
             float(np.percentile(arr, 50)),
             float(arr.max()),


### PR DESCRIPTION
### 🚀 Summary of Changes

Latency was summarized as a single mean after dropping the one sample farthest from the mean. This misfires whenever a phase's per-step latencies fall into distinct groups instead of clustering around one value.

Example — chunked prefill: a prompt is processed in chunks and only the last chunk produces a token (and runs the sampler), so the per-step latencies are bimodal — fast intermediate chunks and slow final chunks. Dropping the single farthest-from-mean sample then throws away a legitimate fast or slow step, so the reported average is unstable: for the same workload it swung between ~49 ms and ~67 ms depending on which sample happened to be dropped.

This PR follows upstream vLLM's benchmark convention (report mean + percentiles over the raw data) and cleans up the surrounding metrics reporting:

- **Drop the single-outlier removal.** Report `mean | p50 | p90 | p99 | max` per phase, so one-off spikes show up in the tail instead of skewing/silently dropping a sample.
- **Fix throughput.** It is now `total_tokens / total_time`. Previously outliers were removed from the latency and token-count lists independently, which could drop different steps from each list and misalign the ratio.
- **Add a per-request prefill summary** (sum of a request's chunk latencies) — a stable "time to prefill a request" number that does not depend on chunking.
- Update unit tests accordingly.

No engine/runtime behavior changes — this only affects reported metrics.

### 🔎 Example output (prefill)

Before:
```
PREFILL METRICS:
  Average latency: 49.07 ms   # single outlier-removed mean (unstable: ~49–67 ms)
```

After:
```
PREFILL METRICS:
  Latency (ms): mean 58.53 | p50 66.77 | p90 109.01 | p99 110.29 | max 110.43
  Average throughput: 8747.39 tokens/sec
  Per-request prefill (ms): mean 117.06 | p50 111.03 | max 136.47 (4 requests)
```

### ✅ Type of Change

* [x] 🔁 Refactor or code cleanup (`refactor`)
* [x] 🛠 Bug fix (`fix`)

### 🧪 How to Test

1. `pytest tests/torch_compile/unit/v1/worker/test_metrics.py` → passes.
2. Run inference with `VLLM_RBLN_METRICS=1` and inspect the `FINAL PERFORMANCE STATISTICS` block: each phase shows `Latency (ms): mean | p50 | p90 | p99 | max`, and prefill shows `Per-request prefill (ms): ...`.

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
