### PR TITLE
fix(worker): clear requires_grad on weights/buffers at load

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2277,9 +2277,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         for p in self.model.parameters():
             if not p.is_contiguous():
                 p.set_(p.contiguous())
+            p.requires_grad_(False)
         for b in self.model.buffers():
             if not b.is_contiguous():
                 b.set_(b.contiguous())
+            b.requires_grad_(False)
 
     @torch.inference_mode()
     def warm_up_model(self) -> None:


### PR DESCRIPTION
## 1. Problem
Torch Dynamo repeatedly recompiles `_PlainOp.forward` (`torch_rbln/_internal/ops_utils.py:1626`) at warmup, with one guard failing on `fwd_args[0]` **requires_grad mismatch**. Observed on gpt-oss-20b DP/EP MoE workers.

## 2. Root cause
- **`no_grad`, not `inference_mode`:** RBLN's `Platform.inference_mode()` returns `torch.no_grad()`. `no_grad()` only stops grad *recording* for new ops — it does **not** clear the `requires_grad` attribute on existing `nn.Parameter` (default `True`).
- **Weights leak into eager dispatch:** model weights reach the eager per-op device path (`_PlainOp.forward`) still carrying `requires_grad=True`, while activations built under `no_grad` carry `requires_grad=False`.
- **Shared code object:** every eager op shares the single `_PlainOp` code object, so Dynamo's `fwd_args[0].requires_grad` guard flips between the two populations → repeated recompiles.

## 3. Fix
Force `requires_grad_(False)` on all params/buffers inside the existing `_make_weights_contiguous` load hook (called from both `load_model` and `warm_up_model`). `requires_grad_(False)` is an always-allowed lowering, safe under the `inference_mode`-decorated `warm_up_model` path.

## 4. Result
gpt-oss-20b (DP/EP MoE):
- requires_grad-guard recompiles: **8 → 0**
- total warmup recompiles: **24 → 16**
- No steady-state recompiles, `cache_size_limit` never hit (before and after).

## 5. TODOs
- Remaining warmup recompiles (`len(fwd_args)` / `op_callable` guards, 16) are structural — all eager ops share one `_PlainOp` code object in torch-rbln, so distinct arities/ops collide on one Dynamo slot. They converge at warmup (~3s) and never hit `cache_size_limit`, so they are benign here. Eliminating them would require a torch-rbln change (per-op code object in `get_view_op_module`), out of scope for this PR.