### PR TITLE
feat(worker): verify KV cache physical layout against declared shape after warm-up

### DIFF
--- a/tests/v1/worker/test_kv_physical_layout_verify.py
+++ b/tests/v1/worker/test_kv_physical_layout_verify.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""RBLNModelRunner KV physical-layout drift guard.
+
+``_verify_kv_physical_layout`` compares the compiler-assigned physical shape
+(``torch.rbln.physical_shape``) of each bound KV cache against the shape the
+framework built at init, warning by default and raising when
+``VLLM_RBLN_STRICT_KV_LAYOUT=1``. These drive the method on a stub runner with a
+stubbed ``torch.rbln.physical_shape`` — no device or serve needed.
+"""
+
+# Standard
+import types
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
+
+
+def _runner(expected, names, caches):
+    r = RBLNModelRunner.__new__(RBLNModelRunner)
+    r._kv_expected_physical_by_name = expected
+    r.kv_cache_names = names
+    r.kv_caches = caches
+    return r
+
+
+def _stub_physical_shape(monkeypatch, mapping):
+    ns = types.SimpleNamespace(physical_shape=lambda kv: mapping[kv])
+    monkeypatch.setattr(torch, "rbln", ns, raising=False)
+
+
+def test_match_passes(monkeypatch):
+    r = _runner({"l0": (2, 4), "l1": (2, 4)}, ["l0", "l1"], ["kv0", "kv1"])
+    _stub_physical_shape(monkeypatch, {"kv0": (2, 4), "kv1": (2, 4)})
+    r._verify_kv_physical_layout()
+
+
+def test_mismatch_warns_by_default(monkeypatch):
+    r = _runner({"l0": (2, 4)}, ["l0"], ["kv0"])
+    _stub_physical_shape(monkeypatch, {"kv0": (2, 8)})
+    monkeypatch.delenv("VLLM_RBLN_STRICT_KV_LAYOUT", raising=False)
+    r._verify_kv_physical_layout()
+
+
+def test_mismatch_strict_raises(monkeypatch):
+    r = _runner({"l0": (2, 4)}, ["l0"], ["kv0"])
+    _stub_physical_shape(monkeypatch, {"kv0": (2, 8)})
+    monkeypatch.setenv("VLLM_RBLN_STRICT_KV_LAYOUT", "1")
+    with pytest.raises(RuntimeError, match="physical-layout drift"):
+        r._verify_kv_physical_layout()
+
+
+def test_unbound_view_skipped(monkeypatch):
+    # Empty physical shape (no view bound) is skipped, even in strict mode.
+    r = _runner({"l0": (2, 4)}, ["l0"], ["kv0"])
+    _stub_physical_shape(monkeypatch, {"kv0": ()})
+    monkeypatch.setenv("VLLM_RBLN_STRICT_KV_LAYOUT", "1")
+    r._verify_kv_physical_layout()
+
+
+def test_getter_unavailable_noop(monkeypatch):
+    # Older torch-rbln without the query: verify is a no-op.
+    r = _runner({"l0": (2, 4)}, ["l0"], ["kv0"])
+    monkeypatch.setattr(torch, "rbln", types.SimpleNamespace(), raising=False)
+    r._verify_kv_physical_layout()

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -392,6 +392,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.kv_cache_names: list[str] = []
         self.kv_cache_bases: list[torch.Tensor] = []
         self.kv_cache_view_infos: list[KVCacheViewInfo] = []
+        # Layer name -> expected physical shape, for the post-warm-up drift guard.
+        self._kv_expected_physical_by_name: dict[str, tuple[int, ...]] = {}
         # Initialize in initialize_kv_cache_tensors
         self.cross_layers_kv_cache: torch.Tensor | None = None
         self.cross_layers_attn_backend: type[AttentionBackend] | None = None
@@ -2297,6 +2299,52 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self._warm_up_model_inner()
         finally:
             set_warmup_active(False)
+        # KV physical view is bound after warm-up; check it matches what we built.
+        self._verify_kv_physical_layout()
+
+    def _verify_kv_physical_layout(self) -> None:
+        """Fail loud on KV-cache layout drift.
+
+        Compare the compiler-assigned physical shape against what the framework
+        built; a mismatch means the attention kernel reads wrong memory (silent
+        corruption). Warn by default; ``VLLM_RBLN_STRICT_KV_LAYOUT=1`` raises.
+        """
+        physical_shape = getattr(getattr(torch, "rbln", None), "physical_shape", None)
+        if physical_shape is None:
+            return
+        expected_by_name = self._kv_expected_physical_by_name
+        if not expected_by_name or not self.kv_caches:
+            return
+        strict = os.environ.get("VLLM_RBLN_STRICT_KV_LAYOUT") == "1"
+        total = len(self.kv_caches)
+        checked = 0
+        drift = 0
+        for name, kv in zip(self.kv_cache_names, self.kv_caches):
+            expected = expected_by_name.get(name)
+            if expected is None:
+                continue
+            actual = tuple(physical_shape(kv))
+            if not actual:
+                continue
+            checked += 1
+            if actual != expected:
+                drift += 1
+                msg = (
+                    f"KV cache physical-layout drift for '{name}': framework built "
+                    f"{expected} but device allocated {actual}; the attention kernel "
+                    f"would read wrong memory (silent KV corruption)."
+                )
+                if strict:
+                    raise RuntimeError(msg)
+                logger.warning(
+                    "%s (set VLLM_RBLN_STRICT_KV_LAYOUT=1 to fail hard)", msg
+                )
+        logger.info(
+            "KV layout verify: %d/%d layer(s) had a bound physical view, %d drift.",
+            checked,
+            total,
+            drift,
+        )
 
     def _warm_up_model_inner(self) -> None:
         num_kv_cache_groups = len(self.kv_cache_config.kv_cache_groups)
@@ -5238,6 +5286,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         self.kv_cache_names = get_kv_cache_names(kv_caches, num_attn_module)
         assert len(self.kv_cache_names) == len(self.kv_caches)
+        # Expected physical layout per layer (self.kv_cache_view_infos may be
+        # emptied when base-dedup is off, so use the complete local dict).
+        self._kv_expected_physical_by_name = {
+            name: tuple(info.view_shape)
+            for name, info in kv_cache_view_infos.items()
+            if info.view_shape is not None
+        }
 
         if (
             not envs.VLLM_RBLN_USE_DEVICE_TENSOR


### PR DESCRIPTION
## Why

RBLN is a compiler-decides-layout backend (physical ≠ logical). The attention kernel addresses the KV cache from the layout encoded in `get_kv_cache_shape`, but nothing checks that the compiler actually allocated the buffer with that layout. If they drift (a compiler relayout, a geometry change, a stale hand-declared shape), the kernel reads the wrong addresses → **silent KV corruption** (garbage output, no error). Context: fsw-inference#381; consumes the getter from RBLN-SW/torch-rbln#134.

## What

`RBLNModelRunner._verify_kv_physical_layout`, called at the end of `warm_up_model` (once the KV physical view is bound):

- At KV init, capture the expected physical shape per layer (from the view infos already built).
- After warm-up, read each bound KV cache's compiler-assigned physical shape back via `torch.rbln.physical_shape` and compare, per layer.
- On mismatch: **warn** by default; **raise** with `VLLM_RBLN_STRICT_KV_LAYOUT=1`.
- **No-op** when the getter is unavailable (older torch-rbln) or no physical view is bound — safe to land ahead of torch-rbln#134.

## Testing

- `tests/v1/worker/test_kv_physical_layout_verify.py`: stub runner + stubbed `torch.rbln.physical_shape` (no device/serve) — match, mismatch-warn, strict-raise, unbound-skip, getter-unavailable-noop. **5 passed.**
- pre-commit clean (ruff check/format, typos, mypy 3.10, license headers).
- **End-to-end** on real serves: `KV layout verify: N/N layer(s) had a bound physical view, 0 drift` on **Qwen3-1.7B (28/28)** and **MiniMax-M2.5 (62/62, DP4+EP)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)