### PR TITLE
other(structured-output): raise max_tokens for regex email test

### DIFF
--- a/tests/torch_compile/e2e/test_structured_output.py
+++ b/tests/torch_compile/e2e/test_structured_output.py
@@ -60,6 +60,7 @@ def sampling_kwargs(request: pytest.FixtureRequest) -> dict:
         "temperature": gen_cfg.temperature,
         "top_p": gen_cfg.top_p,
         "top_k": gen_cfg.top_k,
+        "max_tokens": 128,
     }
 
 


### PR DESCRIPTION
Compiler primitive 업데이트로 모델의 샘플링 분포가 바뀌면서, structured-output regex 테스트(`test_regex_email_format[random]`)의 출력이 달라졌습니다.

출력 자체는 정규식 `\w+@\w+\.com\n?`의 유효한 prefix이지만, 기존 `max_tokens=64` 예산 안에서 `.com` 종료 상태에 도달하지 못해 `re.fullmatch`가 실패했습니다. (문법 강제는 정상 동작)

`max_tokens`를 128로 올려 분포 변화에 견디도록 수정합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)