### PR TITLE
chore: bump torch-rbln to 0.3.0rc1.dev29 in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2606,7 +2606,7 @@ wheels = [
 
 [[package]]
 name = "torch-rbln"
-version = "0.3.0rc1.dev2+gf44e18388"
+version = "0.3.0rc1.dev29+gf752794a5"
 source = { registry = "https://pypi.rebellions.in/simple/" }
 dependencies = [
     { name = "libcst", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2617,7 +2617,7 @@ dependencies = [
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.rebellions.in/api/package/torch-rbln/torch_rbln-0.3.0rc1.dev2+gf44e18388-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:308206c6db67005b6130ea73be6e5c24101a74afc1092b160b04ceff495bc505" },
+    { url = "https://pypi.rebellions.in/api/package/torch-rbln/torch_rbln-0.3.0rc1.dev29+gf752794a5-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:cf56bd015fbb915c14031b6fc17ea22ac1962566d7b7ede0e3ddb2ced5a9356b" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 왜

lock에 핀된 `torch-rbln 0.3.0rc1.dev2+gf44e18388`가 import 시점에 죽습니다 — fsw runtime image에서 `import torch` → backend extension `autoload` RuntimeError ([fsw run 29327492666](https://github.com/rebellions-sw/fsw-integration/actions/runs/29327492666)). 반면 범위 내 최신 빌드는 정상 (unpinned resolve가 고르는 dev25+, fsw dev nightly green).

## 무엇

`torch-rbln 0.3.0rc1.dev2 → 0.3.0rc1.dev29+gf752794a5` (범위 내 최신). diff는 version + wheel url/hash 2줄 — 참고로 plain `uv lock --upgrade-package`는 로컬 자격증명에 따라 다른 패키지 source들까지 nexus group으로 대량 flip시켜 외과적으로 편집했습니다.

fsw-integration#815 (uv.lock 기반 resolve re-land)가 이 bump에 의존합니다.