### PR TITLE
feature(pp): make pipeline parallelism first-class on the vLLM-native decode path

### DIFF
--- a/tests/torch_compile/unit/test_query_backfill.py
+++ b/tests/torch_compile/unit/test_query_backfill.py
@@ -1289,7 +1289,7 @@ class TestCrossBlockNoSpecRollback:
         assert sched_out.scheduled_spec_decode_tokens[rid] == [777]
 
         # The runner forces query_len=1 for the collective no-spec step.
-        scrub_scheduler_output_for_no_spec(sched_out, scheduler.requests)
+        scrub_scheduler_output_for_no_spec(sched_out)
         assert sched_out.num_scheduled_tokens[rid] == 1
 
         # The model emits a single (no-spec) token; the engine must roll the
@@ -1341,7 +1341,7 @@ class TestNoSpecScrubPrefill:
 
         # A peer decode rank elected no-spec -> this prefill rank is scrubbed.
         # scrub excludes prefill reqs (via is_prefill) from the clamp.
-        scrub_scheduler_output_for_no_spec(sched_out, scheduler.requests)
+        scrub_scheduler_output_for_no_spec(sched_out)
 
         assert sched_out.num_scheduled_tokens[rid] == chunk, (
             f"prefill query_len wrongly clamped to "
@@ -1378,7 +1378,7 @@ class TestNoSpecScrubPrefill:
 
         # A peer decode rank elected no-spec -> this chunked-prefill rank is
         # scrubbed. The intermediate chunk must NOT be clamped to 1.
-        scrub_scheduler_output_for_no_spec(sched2, scheduler.requests)
+        scrub_scheduler_output_for_no_spec(sched2)
         assert sched2.num_scheduled_tokens[rid] == chunk, (
             f"intermediate chunked-prefill query_len wrongly clamped to "
             f"{sched2.num_scheduled_tokens[rid]} (was {chunk}) by no-spec scrub"
@@ -1395,7 +1395,7 @@ class TestNoSpecScrubPrefill:
         rid = req.request_id
         assert sched_out.step_no_spec_required is True
         # decode req (num_output > 0) is NOT a prefill -> gets clamped.
-        scrub_scheduler_output_for_no_spec(sched_out, scheduler.requests)
+        scrub_scheduler_output_for_no_spec(sched_out)
         assert sched_out.num_scheduled_tokens[rid] == 1
 
 

--- a/tests/torch_compile/unit/test_query_backfill.py
+++ b/tests/torch_compile/unit/test_query_backfill.py
@@ -38,6 +38,11 @@ from tests.torch_compile.unit.v1.core.utils import (
     create_requests,
     create_scheduler,
 )
+from vllm_rbln.v1.core.utils import (
+    num_base_tokens,
+    resolve_propagated_token_write,
+    should_defer_spec_step,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -160,6 +165,243 @@ class TestSchedulerBackfill:
         assert sched_out.spec_decode_slide_distance["B"] == 2
         assert sched_out.num_scheduled_tokens["B"] == 2
         assert sched_out.scheduled_spec_decode_tokens["B"] == [11]
+
+
+class TestSchedulerBackfillUnderPP:
+    """Query backfill (spec decode) composed with pipeline parallelism.
+
+    Backfill shapes the decode QUERY axis (each decode req's window is padded
+    to num_spec_tokens + 1); the PP per-step decode cap
+    (max_num_seqs // pipeline_parallel_size) bounds the BATCH axis. The two are
+    orthogonal, so PP must not change the per-req backfill decision, and the
+    cap must not shrink an admitted req's spec query window.
+    """
+
+    @pytest.mark.parametrize("pp_size", [1, 2])
+    def test_backfill_decision_invariant_under_pp(self, pp_size):
+        """The per-req backfill decision (slide / trim / drafts) is identical
+        under pp_size=1 and pp_size=2: A (mid-block) stays full-spec with no
+        slide; B (at the block boundary) slides 2 and trims to one draft. The
+        batch cap (max_num_seqs // pp) is not reached here (2 reqs, cap 5)."""
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=100,
+            max_num_seqs=10,  # pp=2 -> per-step cap 5, well above 2 reqs
+            num_speculative_tokens=_NUM_SPEC_TOKENS,
+            pipeline_parallel_size=pp_size,
+        )
+        req_a = _request(512, "A")  # mid-block: full spec, no slide
+        req_b = _request(1022, "B")  # near boundary: slide 2, one draft kept
+        advance_to_decode(scheduler, req_a)
+        advance_to_decode(scheduler, req_b)
+        req_a.spec_token_ids = [1] * _NUM_SPEC_TOKENS
+        req_b.spec_token_ids = [11, 22, 33]
+
+        sched_out = scheduler.schedule()
+
+        assert "A" not in sched_out.spec_decode_slide_distance
+        assert sched_out.num_scheduled_tokens["A"] == _MAX_SPEC_DECODE_LEN
+        assert len(sched_out.scheduled_spec_decode_tokens["A"]) == _NUM_SPEC_TOKENS
+        assert sched_out.spec_decode_slide_distance["B"] == 2
+        assert sched_out.num_scheduled_tokens["B"] == 2
+        assert sched_out.scheduled_spec_decode_tokens["B"] == [11]
+        assert sched_out.step_no_spec_required is False
+
+    def test_decode_cap_bounds_batch_but_preserves_spec_window(self):
+        """The PP decode cap limits how many spec-decodes join one step, but
+        never shrinks an admitted req's spec query window.
+
+        pp=2, max_num_seqs=4 -> per-step cap 2. Three mid-block spec-decodes
+        are ready; exactly two are admitted and each keeps its full window
+        (1 base + num_spec drafts, no slide), the third defers to a later step.
+        """
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=100,
+            max_num_seqs=4,
+            num_speculative_tokens=_NUM_SPEC_TOKENS,
+            pipeline_parallel_size=2,  # per-step decode cap = 4 // 2 = 2
+        )
+        reqs = [_request(512, f"d{i}") for i in range(3)]  # all mid-block
+        for r in reqs:
+            advance_to_decode(scheduler, r)
+        for r in reqs:
+            r.spec_token_ids = [1] * _NUM_SPEC_TOKENS
+
+        sched_out = scheduler.schedule()
+
+        scheduled = [
+            r.request_id for r in reqs if r.request_id in sched_out.num_scheduled_tokens
+        ]
+        assert len(scheduled) == 2, (
+            f"per-step decode cap is 2, got {len(scheduled)} scheduled"
+        )
+        # each admitted spec-decode keeps its full query window, uncapped.
+        for rid in scheduled:
+            assert sched_out.num_scheduled_tokens[rid] == _MAX_SPEC_DECODE_LEN
+            assert len(sched_out.scheduled_spec_decode_tokens[rid]) == _NUM_SPEC_TOKENS
+            assert rid not in sched_out.spec_decode_slide_distance
+        assert sched_out.step_no_spec_required is False
+
+    @pytest.mark.parametrize("pp_size", [1, 2])
+    def test_variable_length_no_spec_fallback_invariant_under_pp(self, pp_size):
+        """The variable-length (ngram) cross-block no-spec fallback decision is
+        identical under pp_size=1 and pp_size=2: entering a fresh block with a
+        draft shortfall crosses a block boundary and elects no-spec (no slide
+        recorded); the same shortfall mid-block backfills in-block (full spec,
+        slide == num_spec). PP shapes the batch axis, not this per-req/per-step
+        query-window decision."""
+        # Cross-block: fresh block entry (num_computed == block_size), 0 drafts
+        # -> desired slide num_spec > used_in_block 0 -> no-spec.
+        sched_cross = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=100,
+            max_num_seqs=10,
+            num_speculative_tokens=_NUM_SPEC_TOKENS,
+            pipeline_parallel_size=pp_size,
+        )
+        assert sched_cross.vllm_config.speculative_config.method == "ngram"
+        req_cross = _request(_BLOCK_SIZE, "X")
+        advance_to_decode(sched_cross, req_cross)
+        req_cross.spec_token_ids = []  # variable-length proposer found no match
+        out_cross = sched_cross.schedule()
+        assert out_cross.step_no_spec_required is True
+        assert "X" not in out_cross.spec_decode_slide_distance
+
+        # In-block: mid-block (used_in_block large), same 0-draft shortfall
+        # backfills in-block -> full spec, slide == num_spec, no no-spec.
+        sched_in = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=100,
+            max_num_seqs=10,
+            num_speculative_tokens=_NUM_SPEC_TOKENS,
+            pipeline_parallel_size=pp_size,
+        )
+        req_in = _request(1500, "Y")
+        advance_to_decode(sched_in, req_in)
+        req_in.spec_token_ids = []
+        out_in = sched_in.schedule()
+        assert out_in.step_no_spec_required is False
+        assert out_in.spec_decode_slide_distance["Y"] == _NUM_SPEC_TOKENS
+
+    def test_spec_optimistic_overshoot_defers_not_negative(self):
+        """A spec request whose num_computed_tokens has been optimistically
+        advanced PAST num_tokens_with_spec must be deferred, never scheduled
+        with a negative num_new_tokens.
+
+        Spec decode advances num_computed_tokens at schedule time (by
+        1 + num_drafts, assuming acceptance) and only reconciles it in
+        update_from_output. Under PP the engine keeps pipeline_parallel_size
+        batches in flight, so a running request can be re-scheduled before its
+        prior step reconciles -- with few requests filling the pipeline its
+        num_computed_tokens overshoots num_tokens_with_spec (simulated here by
+        advancing it directly). The base-count deferral gate catches this: the
+        request has spec_token_ids and its base (num_tokens - num_computed) is
+        <= 0 (anchor in flight), so it is deferred before num_new_tokens is even
+        computed -- no negative num_scheduled_tokens / bogus spec slide leaks
+        (which would trip `total_num_scheduled_tokens > 0` in the runner).
+        """
+        scheduler = _scheduler()
+        healthy = _request(512, "healthy")  # mid-block: full spec, num_new = 4
+        overshot = _request(512, "overshot")
+        advance_to_decode(scheduler, healthy)
+        advance_to_decode(scheduler, overshot)
+        healthy.spec_token_ids = [1, 2, 3]
+        overshot.spec_token_ids = [1, 2, 3]
+        # Simulate the PP optimistic overshoot: push num_computed_tokens past
+        # num_tokens_with_spec so num_new_tokens = num_tokens_with_spec - it < 0.
+        overshot.num_computed_tokens = overshot.num_tokens_with_spec + 2
+
+        sched_out = scheduler.schedule()
+
+        # The overshot request is deferred (not scheduled this step).
+        assert "overshot" not in sched_out.num_scheduled_tokens
+        assert "overshot" not in sched_out.spec_decode_slide_distance
+        # The healthy request is unaffected -- the skip is per-request.
+        assert sched_out.num_scheduled_tokens["healthy"] == _MAX_SPEC_DECODE_LEN
+        # No negative/zero counts leak out; the runner's `> 0` assert holds.
+        assert sched_out.total_num_scheduled_tokens > 0
+        assert all(v >= 1 for v in sched_out.num_scheduled_tokens.values())
+
+    def test_spec_overshoot_empty_drafts_defers_not_negative(self):
+        """Post-verify overshoot with the drafts already CLEARED: num_computed
+        is optimistically advanced past num_tokens while spec_token_ids is
+        empty, so num_new_tokens goes negative. The base-count deferral gate is
+        guarded by `request.spec_token_ids`, so it does NOT fire here; the
+        `num_new_tokens <= 0` guard must catch it. Otherwise a negative
+        num_scheduled_tokens (plus a bogus spec slide) leaks and trips the
+        runner's `total_num_scheduled_tokens > 0` assert. Discriminates the
+        `<= 0` guard from a plain `== 0` (regression guard)."""
+        scheduler = _scheduler()
+        req = _request(512, "X")
+        advance_to_decode(scheduler, req)
+        req.spec_token_ids = []  # drafts consumed by the prior verify step
+        # Optimistic overshoot: num_computed runs past num_tokens -> num_new < 0.
+        req.num_computed_tokens = req.num_tokens + _NUM_SPEC_TOKENS
+
+        sched_out = scheduler.schedule()
+
+        assert "X" not in sched_out.num_scheduled_tokens  # deferred
+        assert "X" not in sched_out.spec_decode_slide_distance
+        assert sched_out.total_num_scheduled_tokens >= 0  # no negative leak
+
+    def test_spec_pp_defers_verify_when_anchor_in_flight(self):
+        """A verify whose anchor (base) token is still in flight -- num_computed
+        == num_tokens, so base == 0 -- must be deferred, even though the drafts
+        keep num_new_tokens > 0. This is the exact empty-new_token_ids trigger
+        on the non-last PP rank (the IndexError). The `== 0` guard alone does
+        NOT catch it (num_new == num_spec here); the base-count deferral gate
+        does. Discriminates the gate from the plain num_new guard."""
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=100,
+            max_num_seqs=10,
+            num_speculative_tokens=_NUM_SPEC_TOKENS,
+            pipeline_parallel_size=2,
+        )
+        req = _request(512, "A")
+        advance_to_decode(scheduler, req)
+        req.spec_token_ids = [1, 2, 3]
+        # Anchor in flight: base == 0. With drafts, num_new would be num_spec.
+        req.num_computed_tokens = req.num_tokens
+        assert req.num_tokens_with_spec - req.num_computed_tokens == _NUM_SPEC_TOKENS
+
+        sched_out = scheduler.schedule()
+
+        # Deferred by the base-count gate (a plain `== 0` guard would not fire).
+        assert "A" not in sched_out.num_scheduled_tokens
+
+    def test_spec_pp_extends_new_token_ids_for_multi_accept(self):
+        """Under spec + PP the scheduler extends the non-last-rank new_token_ids
+        payload backward by num_spec so PP0 can catch up its recorded-token
+        cursor after a prior verify's multi-token accept (bug#2). The payload
+        spans all_token_ids[num_computed - num_spec : num_computed + base]
+        instead of the base-only [num_computed : num_computed + base]."""
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=100,
+            max_num_seqs=10,
+            num_speculative_tokens=_NUM_SPEC_TOKENS,
+            pipeline_parallel_size=2,
+        )
+        req = _request(512, "A")
+        advance_to_decode(scheduler, req)
+        req.spec_token_ids = [1, 2, 3]
+        nc_pre = req.num_computed_tokens  # payload is sliced pre-advance
+
+        sched_out = scheduler.schedule()
+
+        base = sched_out.num_scheduled_tokens["A"] - len(
+            sched_out.scheduled_spec_decode_tokens.get("A", [])
+        )
+        cached = sched_out.scheduled_cached_reqs
+        idx = list(cached.req_ids).index("A")
+        new_token_ids = list(cached.new_token_ids[idx])
+        # Extended backward by num_spec (not the base-only length).
+        assert len(new_token_ids) == base + _NUM_SPEC_TOKENS
+        assert new_token_ids == list(
+            req.all_token_ids[nc_pre - _NUM_SPEC_TOKENS : nc_pre + base]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1146,3 +1388,74 @@ class TestNoSpecScrubPrefill:
         # decode req (num_output > 0) is NOT a prefill -> gets clamped.
         scrub_scheduler_output_for_no_spec(sched_out, scheduler.requests)
         assert sched_out.num_scheduled_tokens[rid] == 1
+
+
+class TestSpecDecodePropagationHelpers:
+    """Pure helpers extracted from the scheduler + runner non-last-rank token
+    propagation: num_base_tokens and resolve_propagated_token_write."""
+
+    def test_num_base_tokens(self):
+        num_sched = {"A": 4, "B": 1}
+        drafts = {"A": [1, 2, 3]}  # B carries no drafts this step
+        assert num_base_tokens(num_sched, drafts, "A") == 1  # 4 - 3 drafts
+        assert num_base_tokens(num_sched, drafts, "B") == 1  # 1 - 0
+        assert num_base_tokens(num_sched, drafts, "missing") == 0
+
+    def test_write_normal_decode_writes_newest_token(self):
+        # base=1, cursor caught up (== num_computed). Payload is extended
+        # backward by num_spec (positions 97..100); write only the newest.
+        payload = [10, 11, 12, 13]
+        assert resolve_propagated_token_write(
+            cursor=100, num_computed_tokens=100, base=1, new_token_ids=payload
+        ) == (101, [13])
+
+    def test_write_multi_accept_lag_fills_gap(self):
+        # After a verify accepted 3 drafts the cursor lags num_computed by 3;
+        # the extended payload lets PP0 fill positions 97..100 by absolute pos.
+        payload = [10, 11, 12, 13]
+        assert resolve_propagated_token_write(
+            cursor=97, num_computed_tokens=100, base=1, new_token_ids=payload
+        ) == (101, [10, 11, 12, 13])
+
+    def test_write_nothing_when_cursor_at_tip(self):
+        assert (
+            resolve_propagated_token_write(
+                cursor=101, num_computed_tokens=100, base=1, new_token_ids=[10, 11]
+            )
+            is None
+        )
+
+    def test_write_empty_payload_advances_cursor_only(self):
+        # Async GPU-broadcast path: no payload, cursor still advances.
+        assert resolve_propagated_token_write(
+            cursor=100, num_computed_tokens=100, base=1, new_token_ids=[]
+        ) == (101, [])
+
+    def test_write_out_of_window_falls_back_to_tail(self):
+        # Defensive: a payload too short to cover [cursor, committed_tip) falls
+        # back to its tail so the cursor still advances in-bounds.
+        assert resolve_propagated_token_write(
+            cursor=97, num_computed_tokens=100, base=1, new_token_ids=[13]
+        ) == (101, [13])
+
+
+class TestShouldDeferSpecStep:
+    """Pure predicate for the spec+PP running-loop deferral."""
+
+    def test_disabled_when_spec_off(self):
+        # num_spec_tokens == 0: never defers, even for a negative num_new.
+        assert should_defer_spec_step(0, [], -3) is False
+        assert should_defer_spec_step(0, [], 0) is False
+
+    def test_drafts_held_defers_on_base_le_zero(self):
+        # base = num_new - len(drafts). drafts=[1,2,3].
+        assert should_defer_spec_step(3, [1, 2, 3], 3) is True  # base 0
+        assert should_defer_spec_step(3, [1, 2, 3], 0) is True  # base -3
+        assert should_defer_spec_step(3, [1, 2, 3], 4) is False  # base 1
+
+    def test_no_drafts_defers_only_on_negative(self):
+        # base == num_new. Only the post-verify overshoot (negative) defers;
+        # the mundane == 0 and any positive are left to the caller.
+        assert should_defer_spec_step(3, [], -3) is True
+        assert should_defer_spec_step(3, [], 0) is False
+        assert should_defer_spec_step(3, [], 1) is False

--- a/tests/torch_compile/unit/test_query_backfill.py
+++ b/tests/torch_compile/unit/test_query_backfill.py
@@ -177,6 +177,15 @@ class TestSchedulerBackfillUnderPP:
     cap must not shrink an admitted req's spec query window.
     """
 
+    @pytest.fixture(autouse=True)
+    def _static_decode_cap(self, monkeypatch):
+        # These tests assert against the STATIC per-step decode cap
+        # (max_num_seqs // pp). Disable the dynamic PP-balancing spread (on by
+        # default), which would otherwise size the cap to ceil(demand / pp) and
+        # change which reqs are admitted -- orthogonal to the backfill decision
+        # under test here.
+        monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "0")
+
     @pytest.mark.parametrize("pp_size", [1, 2])
     def test_backfill_decision_invariant_under_pp(self, pp_size):
         """The per-req backfill decision (slide / trim / drafts) is identical

--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -605,7 +605,7 @@ class TestPDDisaggregationScheduler:
         # A peer decode rank elected cross-block no-spec -> the cross-DP
         # OR-reduce forces this rank's scrub. The promoted decode must be
         # scrubbed like any decode: slide cleared AND query_len forced to 1.
-        scrub_scheduler_output_for_no_spec(out, scheduler.requests)
+        scrub_scheduler_output_for_no_spec(out)
         assert not getattr(out, "spec_decode_slide_distance", {}), (
             "promoted decode's slide must be cleared by the no-spec scrub"
         )

--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -185,6 +185,222 @@ class TestPDDisaggregationScheduler:
         assert output.num_scheduled_tokens[decode.request_id] == 1
         assert output.num_scheduled_tokens[remote.request_id] == 1
 
+    def test_remote_kv_respects_pp_decode_cap(self):
+        """Under PP, remote-KV-promoted decodes must respect the
+        per-step decode cap (max_num_seqs // pp_size).
+
+        pp_size=2, max_num_seqs=4 -> cap 2. Of 3 simultaneously-ready
+        remote-KV requests, at most 2 may join one step's decode batch; the
+        rest stay WAITING_FOR_REMOTE_KVS (deferred).
+
+        Without the fix the waiting loop promotes ALL ready remote-KV decodes
+        (the `//pp_size` cap lives only in the running loop), so the decode
+        batch exceeds the cap -> at runtime this overflows the compiled
+        decode bucket (find_decode_batch_bucket -> None -> assert crash).
+        """
+        num_tokens = 64
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=_NUM_BLOCKS,
+            max_num_seqs=4,
+            pipeline_parallel_size=2,  # per-step decode cap = 4 // 2 = 2
+            use_kv_connector=MockKVConfig(matched_tokens=num_tokens, is_async=True),
+        )
+        remotes = [_create_pd_request(num_tokens, f"remote{i}") for i in range(3)]
+        for r in remotes:
+            scheduler.add_request(r)
+
+        # Step 1: all three go to WAITING_FOR_REMOTE_KVS.
+        out1 = scheduler.schedule()
+        for r in remotes:
+            assert r.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+        # Step 2: mark all three KV transfers complete in one shot.
+        runner_out = create_runner_output(out1, 1)
+        runner_out.kv_connector_output = KVConnectorOutput(
+            finished_recving={r.request_id for r in remotes}
+        )
+        scheduler.update_from_output(out1, runner_out)
+
+        # Step 3: all three are ready, but the per-step decode cap is 2.
+        out3 = scheduler.schedule()
+        scheduled = [r for r in remotes if r.request_id in out3.num_scheduled_tokens]
+        deferred = [
+            r for r in remotes if r.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        ]
+        assert len(scheduled) == 2, (
+            f"decode batch must be capped at 2, got {len(scheduled)}"
+        )
+        assert len(deferred) == 1, (
+            "the over-cap remote-KV request must stay WAITING_FOR_REMOTE_KVS"
+        )
+
+    def test_pp_decode_cap_counts_running_and_remote(self):
+        """The per-step decode cap is unified across BOTH the running
+        loop and the waiting-loop remote-KV promotion.
+
+        pp_size=2, max_num_seqs=4 -> cap 2. One running decode + two ready
+        remote-KV: the running decode + exactly one remote fill the cap; the
+        second remote is deferred (stays WAITING_FOR_REMOTE_KVS).
+        """
+        num_tokens = 64
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=_NUM_BLOCKS,
+            max_num_seqs=4,
+            pipeline_parallel_size=2,  # per-step decode cap = 2
+            use_kv_connector=MockKVConfig(matched_tokens=num_tokens, is_async=True),
+        )
+        # One running decode (local prefill -> decode).
+        decode = _create_pd_request(num_tokens, "decode", do_remote_prefill=False)
+        advance_to_decode(scheduler, decode)
+
+        # Two remote-KV requests -> WAITING_FOR_REMOTE_KVS.
+        remotes = [_create_pd_request(num_tokens, f"remote{i}") for i in range(2)]
+        for r in remotes:
+            scheduler.add_request(r)
+        out = scheduler.schedule()  # decode runs; remotes go WAITING_FOR_REMOTE_KVS
+        for r in remotes:
+            assert r.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+        # Complete both remote transfers.
+        runner_out = create_runner_output(out, 2)
+        runner_out.kv_connector_output = KVConnectorOutput(
+            finished_recving={r.request_id for r in remotes}
+        )
+        scheduler.update_from_output(out, runner_out)
+
+        # Next step: running decode + 1 remote = cap(2); the 2nd remote defers.
+        out2 = scheduler.schedule()
+        assert decode.request_id in out2.num_scheduled_tokens
+        scheduled_remotes = [
+            r for r in remotes if r.request_id in out2.num_scheduled_tokens
+        ]
+        deferred_remotes = [
+            r for r in remotes if r.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        ]
+        # running decode + remote decodes
+        total_decode = 1 + len(scheduled_remotes)
+        assert total_decode == 2, (
+            f"unified per-step decode cap is 2, got {total_decode}"
+        )
+        assert len(deferred_remotes) == 1
+
+    def test_pp_balance_decode_ramps_via_demand(self, monkeypatch):
+        """With PP-balanced decode enabled, the dynamic cap counts
+        ready remote-KV requests as demand so the decode batch can ramp up on
+        the P/D-disaggregated decode side.
+
+        pp=2, 10 ready remote-KV, running empty -> demand = 0 + 10 = 10 ->
+        cap = ceil(10/2) = 5, so 5 are admitted this step. A running-only cap
+        would be ceil(0/2)->1 and stall the ramp at 1 admission/step.
+        """
+        monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "1")
+        num_tokens = 64
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=_NUM_BLOCKS,
+            max_num_seqs=32,
+            pipeline_parallel_size=2,  # static cap = 16
+            use_kv_connector=MockKVConfig(matched_tokens=num_tokens, is_async=True),
+        )
+        remotes = [_create_pd_request(num_tokens, f"r{i}") for i in range(10)]
+        for r in remotes:
+            scheduler.add_request(r)
+
+        # Step 1: all -> WAITING_FOR_REMOTE_KVS (running stays empty).
+        out1 = scheduler.schedule()
+        # Mark every transfer complete -> finished_recving_kv_req_ids holds 10.
+        runner_out = create_runner_output(out1, 1)
+        runner_out.kv_connector_output = KVConnectorOutput(
+            finished_recving={r.request_id for r in remotes}
+        )
+        scheduler.update_from_output(out1, runner_out)
+
+        # Step 2: demand = 0 running + 10 ready -> cap = ceil(10/2) = 5.
+        out2 = scheduler.schedule()
+        scheduled = [r for r in remotes if r.request_id in out2.num_scheduled_tokens]
+        assert len(scheduled) == 5, (
+            f"demand-based cap should admit ceil(10/2)=5, got {len(scheduled)}"
+        )
+
+    def test_local_full_match_counts_against_pp_decode_cap(self):
+        """A full LOCAL prefix match (sync connector, num_new_tokens == 1)
+        that becomes decode-ready in the waiting loop is COUNTED against the
+        shared per-step decode cap -- it consumes a slot just like a running
+        decode or a remote-KV promotion.
+
+        pp=2, max_num_seqs=4 -> static cap 2. One running decode + two sync
+        full-matches: the running decode + exactly ONE match fill the cap; the
+        second match is deferred. If the match were not counted (an admit that
+        counted only remote-KV promotions) both matches would join and overflow
+        the cap.
+        """
+        matched = 19
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=_NUM_BLOCKS,
+            max_num_seqs=4,
+            pipeline_parallel_size=2,  # static per-step decode cap = 4 // 2 = 2
+            use_kv_connector=MockKVConfig(matched_tokens=matched, is_async=False),
+        )
+        # One running decode (no remote prefill -> 0 external tokens -> normal).
+        decode = _create_pd_request(10, "decode", do_remote_prefill=False)
+        advance_to_decode(scheduler, decode)
+        # Two sync full-matches (num_new_tokens == 1 -> decode-ready on schedule).
+        matches = [_create_pd_request(matched + 1, f"m{i}") for i in range(2)]
+        for m in matches:
+            scheduler.add_request(m)
+
+        out = scheduler.schedule()
+        ns = out.num_scheduled_tokens
+        assert decode.request_id in ns
+        scheduled_matches = [m for m in matches if m.request_id in ns]
+        assert len(scheduled_matches) == 1, (
+            "cap=2: running decode + one match fill it; the second match must be "
+            f"counted-out and deferred, got {len(scheduled_matches)} matches"
+        )
+
+    def test_local_full_match_bypasses_soft_cap_hard_only(self, monkeypatch):
+        """A full LOCAL prefix match faces only the HARD cap
+        (compiled bucket ceiling), NOT the soft PP-balance spreading cap: it is
+        not in the demand snapshot, so `apply_soft_cap=False` gates it.
+
+        balance on, pp=2, max_num_seqs=16 (hard cap 8). Two running decodes ->
+        demand 2 -> soft cap ceil(2/2)=1, so the running loop admits only ONE
+        of them (the other spreads to a later step). A sync full-match then
+        still joins THIS step -- past the soft cap (1) but under the hard cap
+        (8) -- proving the soft cap does not gate local matches.
+        """
+        monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "1")
+        matched = 19
+        scheduler = create_scheduler(
+            block_size=_BLOCK_SIZE,
+            num_blocks=_NUM_BLOCKS,
+            max_num_seqs=16,
+            pipeline_parallel_size=2,  # hard cap = 16 // 2 = 8
+            use_kv_connector=MockKVConfig(matched_tokens=matched, is_async=False),
+        )
+        decodes = [
+            _create_pd_request(10, f"d{i}", do_remote_prefill=False) for i in range(2)
+        ]
+        for d in decodes:
+            advance_to_decode(scheduler, d)
+        match = _create_pd_request(matched + 1, "m")
+        scheduler.add_request(match)
+
+        out = scheduler.schedule()
+        ns = out.num_scheduled_tokens
+        # soft cap = ceil(2/2) = 1 spreads the running decodes: only one admitted.
+        scheduled_decodes = [d for d in decodes if d.request_id in ns]
+        assert len(scheduled_decodes) == 1, (
+            f"soft cap 1 should admit one running decode, got {len(scheduled_decodes)}"
+        )
+        # the local match bypasses the soft cap (hard-only) and joins this step.
+        assert match.request_id in ns, (
+            "local full match must join past the soft cap (gated only by hard cap)"
+        )
+
     def test_promotion_keeps_decode_batch_and_defers_local_prefill(self):
         """A ready remote-KV request should join the decode batch, while
         a later local prefill stays deferred to the next step.

--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -416,3 +416,174 @@ def test_spec_decode_cap_prefill_triggers_no_mixed_batching():
     assert len(sched_out.scheduled_new_reqs) == 1
     assert req_a.request_id not in sched_out.num_scheduled_tokens
     assert req_b.request_id in sched_out.num_scheduled_tokens
+
+
+def test_dynamic_decode_cap_policy():
+    """DynamicDecodeCapPolicy spreads active decodes across PP stages:
+    cap = max(1, min(static_max, ceil(active / pp_size)))."""
+    import math
+
+    from vllm_rbln.v1.core.utils import DynamicDecodeCapPolicy
+
+    # static_max = 8 (e.g. max_num_seqs=16, pp=2)
+    # Few active -> spread below the static ceiling (avoids collapse).
+    assert DynamicDecodeCapPolicy(8, 2, 6).cap() == math.ceil(6 / 2) == 3
+    assert DynamicDecodeCapPolicy(8, 2, 1).cap() == 1
+    # No active -> floored at 1 (never 0, which would break the budget).
+    assert DynamicDecodeCapPolicy(8, 2, 0).cap() == 1
+    # ceil(15/2)=8 reaches the ceiling.
+    assert DynamicDecodeCapPolicy(8, 2, 15).cap() == 8
+    # Clamp: never exceed static_max (the compiled bucket ceiling).
+    assert DynamicDecodeCapPolicy(8, 2, 100).cap() == 8
+    # Non-divisible max_num_seqs: ceil(33/2)=17 clamps down to static_max 16.
+    assert DynamicDecodeCapPolicy(16, 2, 33).cap() == 16
+    # pp_size == 1: cap = min(static_max, active) -> no-op vs static.
+    assert DynamicDecodeCapPolicy(16, 1, 5).cap() == 5
+    assert DynamicDecodeCapPolicy(16, 1, 20).cap() == 16
+
+
+def test_decode_budget_hard_vs_soft_cap():
+    """DecodeBatchBudget.can_admit: the hard cap (compiled bucket ceiling)
+    always applies; the soft (spreading) cap applies only when apply_soft_cap.
+    Demand-unbudgeted joins (apply_soft_cap=False -- full local prefix match /
+    resumed-after-eviction) fill up to the hard cap, not the soft one."""
+    from vllm_rbln.v1.core.utils import (
+        DecodeBatchBudget,
+        DynamicDecodeCapPolicy,
+        StaticDecodeCapPolicy,
+    )
+
+    # Balance: hard=8, soft=ceil(4/2)=2.
+    b = DecodeBatchBudget(DynamicDecodeCapPolicy(8, 2, 4), hard_cap=8)
+    b.admit(2)  # count == soft
+    assert not b.can_admit()  # budgeted: gated at soft (2)
+    assert b.can_admit(apply_soft_cap=False)  # unbudgeted: hard (8) has room
+    b.admit(6)  # count == hard
+    assert not b.can_admit(apply_soft_cap=False)  # hard cap reached
+    assert not b.can_admit()
+
+    # Static: soft == hard, so apply_soft_cap makes no difference.
+    b2 = DecodeBatchBudget(StaticDecodeCapPolicy(8), hard_cap=8)
+    b2.admit(8)
+    assert not b2.can_admit()
+    assert not b2.can_admit(apply_soft_cap=False)
+
+
+def test_decode_budget_discard():
+    """discard() un-admits decodes dropped from the step (PRIORITY-policy
+    preemption of an already-scheduled decode) so the can_admit() gate is
+    not stopped early on a stale over-count. Unlike reset() it only removes
+    the dropped ones, leaving the still-admitted decodes counted."""
+    from vllm_rbln.v1.core.utils import DecodeBatchBudget, StaticDecodeCapPolicy
+
+    b = DecodeBatchBudget(StaticDecodeCapPolicy(2), hard_cap=2)
+    b.admit(2)  # batch full at the cap
+    assert not b.can_admit()  # gate closed
+    b.discard()  # a scheduled decode is preempted -> one slot freed
+    assert b.count == 1
+    assert b.can_admit()  # gate reopens for another admit
+    # reset() would instead zero the whole count (whole-batch eviction).
+    b.reset()
+    assert b.count == 0
+
+
+def test_priority_preemption_discards_admitted_decode(monkeypatch):
+    """When the PRIORITY policy preempts an ALREADY-SCHEDULED decode to free KV
+    blocks, the scheduler un-admits it from the per-step decode budget via
+    `discard()`, keeping the admitted count in step with the batch so the
+    `can_admit()` gate is not stopped early on a stale over-count.
+
+    Two decodes each need a fresh block this step but only one block is free,
+    so scheduling the trigger preempts the victim (higher priority value =
+    lower scheduling importance). The victim was already scheduled this step,
+    so `discard()` must fire exactly once.
+    """
+    from vllm.v1.core.sched.request_queue import SchedulingPolicy
+
+    from vllm_rbln.v1.core.utils import DecodeBatchBudget
+
+    discard_calls = []
+    orig_discard = DecodeBatchBudget.discard
+
+    def spy(self, n=1):
+        discard_calls.append(n)
+        return orig_discard(self, n)
+
+    monkeypatch.setattr(DecodeBatchBudget, "discard", spy)
+
+    block_size = 16
+    # num_blocks=4 -> 3 usable (block 0 is the null block): one block per
+    # prefill (2) leaves exactly one free for a decode boundary block, so only
+    # one of the two decodes can grow this step.
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_num_seqs=4,
+        block_size=block_size,
+        num_blocks=4,
+        enable_prefix_caching=False,
+    )
+    scheduler.policy = SchedulingPolicy.PRIORITY
+
+    victim, trigger = create_requests(
+        num_requests=2,
+        num_tokens=block_size,
+        block_size=block_size,
+        req_ids=["victim", "trigger"],
+    )
+    # Higher priority VALUE == lower scheduling importance == preempted first.
+    victim.priority = 1
+    trigger.priority = 0
+    for r in (victim, trigger):
+        advance_to_decode(scheduler, r)
+
+    out = scheduler.schedule()
+
+    assert victim.status == RequestStatus.PREEMPTED
+    assert trigger.request_id in out.num_scheduled_tokens
+    assert discard_calls == [1], (
+        "discard() must fire exactly once for the preempted already-scheduled "
+        f"decode, got {discard_calls}"
+    )
+
+
+def test_pp_balance_decode_spreads_microbatch(monkeypatch):
+    """With VLLM_RBLN_PP_BALANCE_DECODE_BATCH=1 under PP, one step's
+    decode batch is sized to ~ceil(active / pp_size), spreading the active
+    decodes across the PP microbatches instead of packing them into one
+    (which would idle the other stage). The static default packs more.
+    """
+    import math
+
+    from vllm_rbln.v1.core.rbln_scheduler import is_prefill
+
+    n = 6
+
+    def run(balance: bool):
+        if balance:
+            monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "1")
+        else:
+            monkeypatch.delenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", raising=False)
+        # max_num_seqs=16, pp=2 -> static cap 8; n=6 active -> ceil(6/2)=3.
+        scheduler = create_scheduler(
+            max_num_seqs=16, pipeline_parallel_size=2, block_size=16
+        )
+        reqs = create_requests(
+            num_requests=n,
+            num_tokens=32,
+            block_size=16,
+            req_ids=[f"d{i}" for i in range(n)],
+        )
+        for r in reqs:
+            advance_to_decode(scheduler, r)
+        running_decodes = sum(1 for r in scheduler.running if not is_prefill(r))
+        out = scheduler.schedule()
+        return running_decodes, len(out.num_scheduled_tokens)
+
+    run_on, sched_on = run(True)
+    run_off, sched_off = run(False)
+
+    # Balanced: at most ceil(active / pp) admitted this step.
+    assert sched_on <= math.ceil(run_on / 2)
+    assert sched_on >= 1
+    # Static packs more decodes into the single microbatch than balanced does.
+    assert sched_off > sched_on

--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -562,7 +562,9 @@ def test_pp_balance_decode_spreads_microbatch(monkeypatch):
         if balance:
             monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "1")
         else:
-            monkeypatch.delenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", raising=False)
+            # Force the static cap explicitly: the default is now on under PP,
+            # so unsetting would still give the balanced (dynamic) behavior.
+            monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "0")
         # max_num_seqs=16, pp=2 -> static cap 8; n=6 active -> ceil(6/2)=3.
         scheduler = create_scheduler(
             max_num_seqs=16, pipeline_parallel_size=2, block_size=16

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -597,44 +597,7 @@ class TestGetCumsumAndArange:
 
 
 # ===========================================================================
-# 7. is_prefills – REAL code path
-# ===========================================================================
-
-
-class TestIsPrefills:
-    """Test RBLNModelRunner.is_prefills with real numpy arrays."""
-
-    def _call(self, num_computed, num_tokens_no_spec):
-        batch = MagicMock(spec=InputBatch)
-        batch.num_computed_tokens_cpu = np.array(num_computed, dtype=np.int64)
-        batch.num_tokens_no_spec = np.array(num_tokens_no_spec, dtype=np.int64)
-        stub = SimpleNamespace(input_batch=batch)
-        bound = types.MethodType(RBLNModelRunner.is_prefills, stub)
-        return bound()
-
-    def test_all_prefill(self):
-        # computed < total - 1 means prefill
-        result = self._call([0, 0, 0], [10, 20, 30])
-        np.testing.assert_array_equal(result, [True, True, True])
-
-    def test_all_decode(self):
-        # computed >= total - 1 means decode
-        result = self._call([9, 19, 29], [10, 20, 30])
-        np.testing.assert_array_equal(result, [False, False, False])
-
-    def test_mixed(self):
-        result = self._call([0, 19], [10, 20])
-        np.testing.assert_array_equal(result, [True, False])
-
-    def test_boundary(self):
-        # num_computed == num_tokens - 2 => True (prefill)
-        # num_computed == num_tokens - 1 => False (decode)
-        result = self._call([8, 9], [10, 10])
-        np.testing.assert_array_equal(result, [True, False])
-
-
-# ===========================================================================
-# 8. use_wrapped_compute_logits – REAL code path
+# 7. use_wrapped_compute_logits – REAL code path
 # ===========================================================================
 
 

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -334,12 +334,13 @@ class TestDummyRunStateFeature:
             "num_input_tokens",
             "input_ids",
             "positions",
+            "scheduler_output",
             "draft_attn_metadata",
         )
         assert DummyRunState._fields == expected_fields
 
     def test_field_count(self):
-        assert len(DummyRunState._fields) == 5
+        assert len(DummyRunState._fields) == 6
 
     def test_is_named_tuple(self):
         assert issubclass(DummyRunState, tuple)
@@ -350,6 +351,7 @@ class TestDummyRunStateFeature:
             num_input_tokens=32,
             input_ids={0: torch.zeros(32, dtype=torch.long)},
             positions={0: torch.arange(32)},
+            scheduler_output=None,
         )
         assert state.num_input_tokens == 32
         assert isinstance(state.attn_metadata, dict)
@@ -362,6 +364,7 @@ class TestDummyRunStateFeature:
             num_input_tokens=0,
             input_ids={},
             positions={},
+            scheduler_output=None,
         )
         assert state.num_input_tokens == 0
         assert len(state.attn_metadata) == 0

--- a/tests/torch_compile/unit/v1/worker/test_structured_output.py
+++ b/tests/torch_compile/unit/v1/worker/test_structured_output.py
@@ -96,7 +96,7 @@ class TestGrammarBitmaskApplication:
                     [],
                 ),
             ),
-            patch.object(runner, "is_prefills", return_value=[False]),
+            patch.object(runner, "is_prefill_phase", return_value=False),
         ):
             runner.sample_tokens(grammar_output)
 
@@ -142,7 +142,7 @@ class TestGrammarBitmaskApplication:
                     [],
                 ),
             ),
-            patch.object(runner, "is_prefills", return_value=[False]),
+            patch.object(runner, "is_prefill_phase", return_value=False),
         ):
             runner.sample_tokens(None)
 
@@ -189,7 +189,7 @@ class TestGrammarBitmaskApplication:
                     [],
                 ),
             ),
-            patch.object(runner, "is_prefills", return_value=[False]),
+            patch.object(runner, "is_prefill_phase", return_value=False),
         ):
             runner.sample_tokens(grammar_output)
 
@@ -410,7 +410,7 @@ class TestLogitsDtypeConversion:
                     [],
                 ),
             ),
-            patch.object(runner, "is_prefills", return_value=[False]),
+            patch.object(runner, "is_prefill_phase", return_value=False),
         ):
             runner.sample_tokens(grammar_output)
 

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -276,6 +276,50 @@ class RblnPlatform(Platform):
                 "vllm_rbln.v1.core.rbln_scheduler.RBLNScheduler"
             )
 
+            # NOTE(RBLN): max_num_seqs is the max number of concurrently
+            # running sequences (the scheduler's running-queue cap), consistent
+            # with upstream and the non-PP case. The KV cache is provisioned to
+            # hold that many concurrent sequences (e.g. ~max_num_seqs *
+            # ceil(max_model_len / block_size) blocks). Under PP the engine
+            # keeps pipeline_parallel_size microbatches in flight, so to keep
+            # total in-flight sequences <= max_num_seqs the *compiled* decode
+            # batch per PP stage is the derived max_num_seqs // pp_size (unlike
+            # GPU, which uses dynamic batch shapes and never divides). Validate
+            # the relationship here so an impossible config (e.g. max_num_seqs=1
+            # with pp_size=2 -> 0) fails with a clear message instead of a
+            # cryptic assert deep in bucketing/scheduling.
+            pp_size = parallel_config.pipeline_parallel_size
+            if pp_size > 1:
+                max_num_seqs = scheduler_config.max_num_seqs
+                if max_num_seqs < pp_size:
+                    raise ValueError(
+                        f"pipeline_parallel_size={pp_size} requires "
+                        f"max_num_seqs >= {pp_size}: each PP stage is compiled "
+                        f"for max_num_seqs // pipeline_parallel_size decode "
+                        f"slots, but max_num_seqs={max_num_seqs} yields "
+                        f"{max_num_seqs // pp_size}."
+                    )
+                per_stage = max_num_seqs // pp_size
+                if max_num_seqs % pp_size != 0:
+                    logger.warning(
+                        "max_num_seqs=%d is not a multiple of "
+                        "pipeline_parallel_size=%d; the per-PP-stage decode "
+                        "batch floors to %d, so %d sequence slot(s) of the "
+                        "budget are unused. Set max_num_seqs to a multiple of "
+                        "pipeline_parallel_size to use the full budget.",
+                        max_num_seqs,
+                        pp_size,
+                        per_stage,
+                        max_num_seqs - per_stage * pp_size,
+                    )
+                logger.info(
+                    "PP=%d: max_num_seqs=%d (max concurrent sequences) -> "
+                    "per-PP-stage decode batch = %d (compiled).",
+                    pp_size,
+                    max_num_seqs,
+                    per_stage,
+                )
+
             # FIXME(jiwoo.park) This is a temporary workaround.
             if model_config.enforce_eager:
                 if not envs.VLLM_RBLN_USE_DEVICE_TENSOR:

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_USE_W8A16: bool = False
     # --- NIXL ---
     VLLM_RBLN_NIXL_SWA_VIEW_OPT: bool = False
+    VLLM_RBLN_PP_BALANCE_DECODE_BATCH: bool = False
 
 
 def get_num_devices_per_local_rank() -> int:
@@ -418,6 +419,17 @@ environment_variables = {
     # moves the full block — only the remote RDMA payload is trimmed.
     "VLLM_RBLN_NIXL_SWA_VIEW_OPT": lambda: (
         os.environ.get("VLLM_RBLN_NIXL_SWA_VIEW_OPT", "False").lower() in ("true", "1")
+    ),
+    # When pipeline_parallel_size > 1, dynamically size each step's decode
+    # batch to ceil(active_decodes / pp_size) (clamped to the compiled
+    # max_num_seqs // pp_size), spreading available decodes across the
+    # pp_size in-flight microbatches instead of packing them into one. This
+    # avoids PP-depth collapse (one stage left idle, ~2x decode latency) after
+    # a pipeline drain. No-op for pp_size == 1. Opt-in; default keeps the
+    # static max_num_seqs // pp_size cap.
+    "VLLM_RBLN_PP_BALANCE_DECODE_BATCH": lambda: (
+        os.environ.get("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "False").lower()
+        in ("true", "1")
     ),
 }
 

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -87,7 +87,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_USE_W8A16: bool = False
     # --- NIXL ---
     VLLM_RBLN_NIXL_SWA_VIEW_OPT: bool = False
-    VLLM_RBLN_PP_BALANCE_DECODE_BATCH: bool = False
+    VLLM_RBLN_PP_BALANCE_DECODE_BATCH: bool = True
 
 
 def get_num_devices_per_local_rank() -> int:
@@ -425,10 +425,12 @@ environment_variables = {
     # max_num_seqs // pp_size), spreading available decodes across the
     # pp_size in-flight microbatches instead of packing them into one. This
     # avoids PP-depth collapse (one stage left idle, ~2x decode latency) after
-    # a pipeline drain. No-op for pp_size == 1. Opt-in; default keeps the
-    # static max_num_seqs // pp_size cap.
+    # a pipeline drain. On by default under PP (the dynamic cap only ever caps
+    # lower than the static one, never overflows the bucket, and matches it at
+    # saturation); set False to force the static max_num_seqs // pp_size cap.
+    # No-op for pp_size == 1.
     "VLLM_RBLN_PP_BALANCE_DECODE_BATCH": lambda: (
-        os.environ.get("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "False").lower()
+        os.environ.get("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "True").lower()
         in ("true", "1")
     ),
 }

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -123,7 +123,11 @@ from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import init_none_hash
 from vllm.v1.core.sched.interface import PauseState
-from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
@@ -138,7 +142,11 @@ from vllm_rbln.v1.core.rbln_kv_cache_manager import (
     RBLNKVCacheManager,
     SubBlockMatch,
 )
-from vllm_rbln.v1.core.utils import DecodeAdmissionController
+from vllm_rbln.v1.core.utils import (
+    DecodeAdmissionController,
+    num_base_tokens,
+    should_defer_spec_step,
+)
 
 logger = init_logger(__name__)
 
@@ -172,6 +180,15 @@ class RBLNSchedulerOutput(SchedulerOutput):
     # positions' logits are discarded; past KV gets idempotently
     # re-written. Empty / missing key => slide_distance is 0 (no slide).
     spec_decode_slide_distance: dict[str, int] = field(default_factory=dict)
+    # NOTE(RBLN): whether this step runs the prefill graph (True) or the decode
+    # graph (False). RBLN has no mixed batching, so a step is uniformly one or
+    # the other. Stamped by the scheduler (a single authority) from the
+    # authoritative Request state, so every PP rank reads an identical value.
+    # The runner MUST use this instead of re-deriving the phase from its own
+    # per-rank input_batch: num_tokens_no_spec is maintained on different paths
+    # on the last PP rank (sampling) vs other ranks (scheduler output), so a
+    # runner-side classification diverges across ranks under spec-decode + PP.
+    is_prefill_step: bool = False
 
 
 def is_prefill(request: Request) -> bool:
@@ -416,6 +433,17 @@ class RBLNScheduler(Scheduler):
                 + request.num_output_placeholders
                 - request.num_computed_tokens
             )
+            # NOTE(RBLN): Under sync-scheduling PP + spec decode, defer a step
+            # with no reconciled base (anchor) token yet -- num_computed_tokens is
+            # optimistically advanced by the drafts, so the RAW num_new_tokens can
+            # still be draft-inflated (drafts held) or negative (post-verify
+            # overshoot). See should_defer_spec_step. Non-spec decode is untouched
+            # (its no-new-tokens case is the plain `== 0` defer below).
+            if should_defer_spec_step(
+                self.num_spec_tokens, request.spec_token_ids, num_new_tokens
+            ):
+                req_index += 1
+                continue
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
@@ -1293,6 +1321,24 @@ class RBLNScheduler(Scheduler):
             else None
         )
 
+        # NOTE(RBLN): Classify this step (prefill vs decode) here -- BEFORE
+        # `_update_after_schedule` (below) optimistically advances
+        # num_computed_tokens -- from the authoritative Request state, so the
+        # value is identical on every PP rank. The runner reads this rather
+        # than re-deriving from its per-rank input_batch, which diverges across
+        # ranks under spec-decode + PP.
+        #
+        # No mixed batching makes the step uniform (all decodes, or a lone
+        # prefill), so one representative request decides it -- matching the
+        # runner's original is_prefills()[0] and avoiding an O(max_num_seqs)
+        # scan of the whole batch. The first scheduled id is a running-loop
+        # request when any is scheduled (running reqs are inserted first),
+        # else the waiting-loop prefill; either is representative. Empty step
+        # (no tokens) -> False (decode); the runner early-returns anyway.
+        is_prefill_step = bool(num_scheduled_tokens) and is_prefill(
+            self.requests[next(iter(num_scheduled_tokens))]
+        )
+
         scheduler_output = RBLNSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -1311,6 +1357,7 @@ class RBLNScheduler(Scheduler):
             new_block_ids_to_zero=new_block_ids_to_zero,
             step_no_spec_required=step_no_spec_required,
             spec_decode_slide_distance=spec_decode_slide_distance,
+            is_prefill_step=is_prefill_step,
         )
 
         # Drain pending copy ops from the KV cache manager.
@@ -1360,6 +1407,48 @@ class RBLNScheduler(Scheduler):
         # block ids sent on resume.
         self._stranded_new_blocks.pop(request.request_id, None)
         super()._preempt_request(request, timestamp)
+
+    def _make_cached_request_data(
+        self,
+        running_reqs: list[Request],
+        resumed_reqs: list[Request],
+        num_scheduled_tokens: dict[str, int],
+        spec_decode_tokens: dict[str, list[int]],
+        req_to_new_blocks: dict[str, KVCacheBlocks],
+    ) -> CachedRequestData:
+        data = super()._make_cached_request_data(
+            running_reqs,
+            resumed_reqs,
+            num_scheduled_tokens,
+            spec_decode_tokens,
+            req_to_new_blocks,
+        )
+        # NOTE(RBLN): multi-accept token propagation to the non-last PP rank
+        # under sync scheduling. The base builds new_token_ids =
+        # all_token_ids[num_computed : num_computed + base] (base =
+        # num_scheduled - drafts). When a prior verify accepted k drafts, the
+        # non-last rank's write cursor (num_tokens_no_spec) lags num_computed by
+        # up to num_spec, so a base-length payload cannot fill
+        # [cursor : num_computed + base] -> stale/garbage tokens on PP0. Extend
+        # the payload backward by num_spec so it always covers the max lag; the
+        # runner writes it by absolute position, idempotently overwriting any
+        # mis-speculated draft slots. Only the sync-PP spec path (where the base
+        # sends a new_token_ids payload) is touched.
+        if (
+            self.use_pp
+            and not self.scheduler_config.async_scheduling
+            and self.num_spec_tokens > 0
+            and data.new_token_ids
+        ):
+            for idx, req in enumerate(itertools.chain(running_reqs, resumed_reqs)):
+                if idx >= len(data.new_token_ids):
+                    break
+                req_id = req.request_id
+                base = num_base_tokens(num_scheduled_tokens, spec_decode_tokens, req_id)
+                lo = max(0, req.num_computed_tokens - self.num_spec_tokens)
+                hi = req.num_computed_tokens + base
+                data.new_token_ids[idx] = req.all_token_ids[lo:hi]
+        return data
 
     def update_from_output(
         self,

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -1329,9 +1329,9 @@ class RBLNScheduler(Scheduler):
         # ranks under spec-decode + PP.
         #
         # No mixed batching makes the step uniform (all decodes, or a lone
-        # prefill), so one representative request decides it -- matching the
-        # runner's original is_prefills()[0] and avoiding an O(max_num_seqs)
-        # scan of the whole batch. The first scheduled id is a running-loop
+        # prefill), so one representative request decides it -- avoiding an
+        # O(max_num_seqs) scan of the whole batch. The first scheduled id is a
+        # running-loop
         # request when any is scheduled (running reqs are inserted first),
         # else the waiting-loop prefill; either is representative. Empty step
         # (no tokens) -> False (decode); the runner early-returns anyway.

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -138,6 +138,7 @@ from vllm_rbln.v1.core.rbln_kv_cache_manager import (
     RBLNKVCacheManager,
     SubBlockMatch,
 )
+from vllm_rbln.v1.core.utils import DecodeAdmissionController
 
 logger = init_logger(__name__)
 
@@ -242,6 +243,21 @@ class RBLNScheduler(Scheduler):
         # re-emit it on the request's next scheduled step. Keyed by request_id.
         self._stranded_new_blocks: dict[str, KVCacheBlocks] = {}
 
+        # NOTE(RBLN): Per-step decode-batch admission. Under PP the engine keeps
+        # pipeline_parallel_size microbatches in flight, so each step's decode
+        # batch must stay <= max_num_seqs // pp_size (== the runner's compiled
+        # bucket ceiling). The controller produces a per-step budget that both
+        # the running loop and the waiting-loop remote-KV promotion share; it
+        # also owns the static-vs-dynamic (PP-balanced) cap choice. See
+        # vllm_rbln/v1/core/utils.py.
+        self._decode_admission = DecodeAdmissionController(
+            max_num_seqs=self.max_num_running_reqs,
+            pipeline_parallel_size=(
+                self.vllm_config.parallel_config.pipeline_parallel_size
+            ),
+            pp_balance_decode=envs.VLLM_RBLN_PP_BALANCE_DECODE_BATCH,
+        )
+
     def _decide_spec_slide(self, request: Request, new_n: int) -> tuple[int, bool]:
         """Sliding-window backfill decision for one decode request's query
         window so it reaches ``num_spec_tokens + 1``.
@@ -287,6 +303,21 @@ class RBLNScheduler(Scheduler):
             )
             return 0, True
         return desired_slide, False
+
+    def _decode_demand(self) -> int:
+        """Total decode demand for this step's PP-balanced admission cap.
+
+        = running decodes + remote-KV requests ready to be admitted (transfer
+        complete, awaiting promotion). Including the ready remote-KV gives the
+        dynamic cap headroom to ramp the decode batch on the P/D-disaggregated
+        decode side; running-only would stall the ramp. Demand is invariant
+        under admission (promoting a ready remote-KV moves it from ready ->
+        running), so this snapshot is exact even as the running/ready split
+        shifts during the waiting loop. Evaluated only when PP balancing is on.
+        """
+        num_running_decodes = sum(1 for r in self.running if not is_prefill(r))
+        num_ready_remote_kv = len(self.finished_recving_kv_req_ids)
+        return num_running_decodes + num_ready_remote_kv
 
     def schedule(self) -> RBLNSchedulerOutput:
         # Copied from vllm.v1.core.sched.Scheduler.schedule: https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/v1/core/sched/scheduler.py#L338-L927
@@ -344,6 +375,13 @@ class RBLNScheduler(Scheduler):
         # window so it stays within already-allocated KV slots. Populated
         # below as we walk running reqs and detect boundary cases.
         spec_decode_slide_distance: dict[str, int] = {}
+
+        # NOTE(RBLN): Per-step decode-batch admission budget shared by the
+        # running loop and the waiting-loop remote-KV promotion. The controller
+        # evaluates `_decode_demand` only when PP balancing is active.
+        decode_budget = self._decode_admission.make_budget(
+            demand_fn=self._decode_demand
+        )
 
         # First, schedule the RUNNING requests.
         # NOTE(RBLN): Prioritize prefill requests. Given our constraint that the prefill
@@ -455,6 +493,14 @@ class RBLNScheduler(Scheduler):
                         if preempted_req in scheduled_running_reqs:
                             preempted_req_id = preempted_req.request_id
                             scheduled_running_reqs.remove(preempted_req)
+                            # NOTE(RBLN): the victim was admitted to this step's
+                            # decode batch (every scheduled_running_reqs member
+                            # is admit()-ed just below its append). It is now
+                            # dropped, so un-admit it -- otherwise the stale
+                            # (over)count makes the can_admit() gate at the end
+                            # of this loop stop admitting early, under-filling
+                            # the decode batch.
+                            decode_budget.discard()
                             token_budget += num_scheduled_tokens.pop(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
@@ -485,6 +531,7 @@ class RBLNScheduler(Scheduler):
 
             # Schedule the request.
             scheduled_running_reqs.append(request)
+            decode_budget.admit()
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -640,13 +687,12 @@ class RBLNScheduler(Scheduler):
                     if self.ec_connector is not None:
                         self.ec_connector.update_state_after_alloc(request, i)
 
-            # NOTE(RBLN): We restrict the decode batch size to
-            # (max_num_seqs // pipeline_parallel_size) to prevent pipeline
-            # bubbles.
-            if len(scheduled_running_reqs) >= (
-                self.max_num_running_reqs
-                // self.vllm_config.parallel_config.pipeline_parallel_size
-            ):
+            # NOTE(RBLN): Stop once the per-step decode-batch cap is reached
+            # (== max_num_seqs // pipeline_parallel_size, to prevent pipeline
+            # bubbles and match the runner's compiled bucket). The same budget
+            # also gates remote-KV promotion in the waiting loop below, so the
+            # combined decode batch never exceeds the cap.
+            if not decode_budget.can_admit():
                 break
 
         # NOTE(RBLN): The legacy retroactive trim using spec_decode_cap is
@@ -690,6 +736,31 @@ class RBLNScheduler(Scheduler):
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
+
+                # NOTE(RBLN): Unified decode-cap admission gate (peek-time, i.e.
+                # BEFORE promotion). `can_admit` enforces two limits:
+                #   * hard cap (always): the compiled decode-bucket ceiling
+                #     (max_num_seqs // pp). The per-step decode batch may never
+                #     exceed it or the runner has no bucket -> crash. This gates
+                #     EVERY candidate that could join the decode batch, including
+                #     ones only discoverable as decode-ready after allocation --
+                #     a full local prefix-cache match, or a decode resumed after
+                #     eviction that fully re-matches locally (both bypass the
+                #     remote-KV status). A plain prefill is deferred here only
+                #     when the batch is physically full; PP's in-flight rotation
+                #     bounds that wait to ~1 step (pp=2).
+                #   * soft cap (only for remote-KV promotions): the balance
+                #     spreading target ceil(demand/pp). Remote-KV requests are in
+                #     the demand snapshot (ready_remote_kv), so they are spread
+                #     like running decodes. Local-prefix / resumed joins are NOT
+                #     in the snapshot, so only the hard cap gates them (the soft
+                #     cap self-corrects next step once they enter `running`).
+                # Running BEFORE promotion keeps a gated remote-KV request in
+                # WAITING_FOR_REMOTE_KVS (re-evaluated next step) instead of
+                # flipping its status and mis-routing it through local prefill.
+                apply_soft_cap = request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+                if not decode_budget.can_admit(apply_soft_cap=apply_soft_cap):
+                    break
 
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
@@ -1045,6 +1116,14 @@ class RBLNScheduler(Scheduler):
                             step_no_spec_required = True
                         elif slide_distance > 0:
                             spec_decode_slide_distance[request_id] = slide_distance
+                    # NOTE(RBLN): this decode-ready request has just joined the
+                    # decode batch, so count it against the shared per-step cap
+                    # -- regardless of how it became decode-ready (a FULL
+                    # remote-KV match or a full local prefix-cache match). Keyed
+                    # on `is_prefill` (this block), not on how it became
+                    # decode-ready. A PARTIAL remote-KV match stays is_prefill
+                    # (not here) and is counted later via the running loop.
+                    decode_budget.admit()
                     # The scheduled new request is added as a decoding-phase req, so
                     # we can continue to schedule the next request.
                     continue
@@ -1097,6 +1176,10 @@ class RBLNScheduler(Scheduler):
                         )
 
                 scheduled_running_reqs.clear()
+                # NOTE(RBLN): the decode batch was just evicted for a prefill;
+                # clear the admission budget so this step counts only the
+                # prefill (prefill-only step, batch size 1).
+                decode_budget.reset()
                 token_budget = prefill_token_budget
 
                 # NOTE(RBLN): we restrict the prefill batch size to 1 for now.

--- a/vllm_rbln/v1/core/utils.py
+++ b/vllm_rbln/v1/core/utils.py
@@ -1,0 +1,241 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility helpers for the RBLN scheduler (``rbln_scheduler.py``).
+
+A home for small, self-contained, independently-testable pieces factored
+out of ``RBLNScheduler`` so that ``schedule()`` (a large copy of upstream's
+method with RBLN-specific tweaks) stays readable. Add further scheduler
+utilities here.
+
+Currently provides the per-step decode-batch admission budget
+(``DecodeBatchBudget`` + ``DecodeCapPolicy``):
+
+Under pipeline parallelism the engine keeps ``pipeline_parallel_size``
+microbatches in flight (one per PP stage). To bound the total in-flight
+decode requests to ``max_num_seqs`` and to never exceed the runner's
+compiled decode-batch bucket, each single step's decode batch must be
+capped at ``max_num_seqs // pipeline_parallel_size`` (==
+``RBLNModelRunner.max_batch_size``). ``schedule()`` admits decode requests
+from two places — the running loop and the waiting-loop remote-KV promotion
+(P/D-disaggregated decode) — so the cap is centralized into one budget both
+loops share, rather than enforced per-loop.
+"""
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+
+def decode_batch_size(max_num_seqs: int, pipeline_parallel_size: int) -> int:
+    """Per-PP-stage (compiled) decode batch size — the single source of truth.
+
+    ``max_num_seqs`` is the max number of concurrently running sequences (the
+    scheduler's running-queue cap), consistent with upstream vLLM and with the
+    non-PP case; the KV cache is provisioned to hold that many concurrent
+    sequences. Under pipeline parallelism the engine keeps
+    ``pipeline_parallel_size`` microbatches in flight, so to keep total
+    in-flight sequences <= ``max_num_seqs`` the batch RBLN must *compile* for
+    one PP stage is that cap split across stages:
+
+        decode_batch_size = max_num_seqs // pipeline_parallel_size
+
+    Unlike GPU (dynamic batch shapes, no division), RBLN compiles a fixed
+    decode-batch shape, so this derived value — not ``max_num_seqs`` itself —
+    is what the runner buckets to and the scheduler caps at. ``pp_size == 1``
+    returns ``max_num_seqs`` unchanged (non-PP). Callers must ensure
+    ``max_num_seqs >= pipeline_parallel_size`` (validated at config time in
+    ``RBLNPlatform.check_and_update_config``); otherwise this floors to 0.
+    """
+    return max_num_seqs // pipeline_parallel_size
+
+
+@runtime_checkable
+class DecodeCapPolicy(Protocol):
+    """Supplies the per-step decode-batch cap (max decode requests admitted
+    to one PP microbatch).
+
+    Injected into ``DecodeBatchBudget`` so the admission logic stays fixed
+    while the *sizing* rule can evolve — e.g. a future dynamic policy that
+    splits available decodes across PP stages to avoid microbatch collapse."""
+
+    def cap(self) -> int: ...
+
+
+class StaticDecodeCapPolicy:
+    """Fixed cap = ``max_num_seqs // pipeline_parallel_size``.
+
+    Must equal ``RBLNModelRunner.max_batch_size`` so the scheduled decode
+    batch always maps onto a compiled decode-batch bucket. ``pp_size == 1``
+    degenerates to ``max_num_seqs`` (the cap is then a no-op, since the
+    running queue is already bounded by ``max_num_seqs``).
+    """
+
+    def __init__(self, cap: int) -> None:
+        assert cap >= 1, f"decode-batch cap must be >= 1, got {cap}"
+        self._cap = cap
+
+    def cap(self) -> int:
+        return self._cap
+
+
+class DynamicDecodeCapPolicy:
+    """Cap that spreads the decode *demand* across the PP pipeline.
+
+    Avoids PP-depth collapse: after a pipeline drain (e.g. a
+    prefill stall) every decode becomes reschedulable at once, and the static
+    ``max_num_seqs // pp_size`` cap lets them pack into a single microbatch ->
+    the other ``pp_size - 1`` stages idle (depth-1, ~2x decode latency). Sizing
+    each step's batch to ``ceil(demand / pp_size)`` instead spreads the decode
+    demand across ``pp_size`` microbatches so the pipeline stays full.
+
+    ``num_demand_decodes`` is the total decode demand, NOT just the currently
+    running decodes: it must also include remote-KV requests that are ready to
+    join the decode batch (P/D-disaggregated decode). Using running-only would
+    leave no headroom to admit those, stalling the ramp (the cap is fully
+    consumed by the requests already cycling). Crucially, demand is *invariant*
+    under admission -- promoting a ready remote-KV moves it from "ready" to
+    "running" without changing the total -- so a single step-start snapshot is
+    exact even though the running/ready split shifts during the waiting loop.
+
+    The cap is **clamped to** ``static_max_cap`` (== the runner's compiled
+    decode-batch ceiling) so it can only go *lower*, never overflow the bucket;
+    and floored at 1. ``pp_size == 1`` yields ``min(static_max_cap, demand)``,
+    a no-op (only ``demand`` decodes are admittable anyway).
+
+    Constructed per ``schedule()`` call with that step's decode demand.
+    """
+
+    def __init__(
+        self,
+        static_max_cap: int,
+        pipeline_parallel_size: int,
+        num_demand_decodes: int,
+    ) -> None:
+        assert static_max_cap >= 1, f"static_max_cap must be >= 1, got {static_max_cap}"
+        # ceil(num_demand_decodes / pipeline_parallel_size)
+        spread = -(-num_demand_decodes // pipeline_parallel_size)
+        self._cap = max(1, min(static_max_cap, spread))
+
+    def cap(self) -> int:
+        return self._cap
+
+
+class DecodeBatchBudget:
+    """Tracks how many decode requests have been admitted to the current
+    step's batch, shared across ``schedule()``'s running and waiting loops.
+
+    Lifecycle: one instance per ``schedule()`` call. ``admit()`` on every
+    decode added to the step; ``can_admit()`` gates further admissions in
+    both loops; ``reset()`` clears the count when a prefill evicts the
+    decode batch (the "disable mixed batching" path).
+    """
+
+    def __init__(self, cap_policy: DecodeCapPolicy, hard_cap: int) -> None:
+        self._cap_policy = cap_policy
+        # Compiled decode-bucket ceiling (max_num_seqs // pp). The batch may
+        # never exceed it or the runner has no bucket -> crash. The policy's
+        # cap() is the (<=) soft/spreading cap (== hard_cap in static mode).
+        self._hard_cap = hard_cap
+        self._count = 0
+
+    def can_admit(self, *, apply_soft_cap: bool = True) -> bool:
+        """True iff one more decode request may be admitted this step.
+
+        Two limits:
+          * hard cap (always): the compiled bucket ceiling; exceeding it
+            crashes the runner. Applies to every candidate decode join.
+          * soft cap (``apply_soft_cap``): the balance/spreading target
+            ``ceil(demand/pp)`` for the *budgeted* decode demand (running
+            decodes + ready remote-KV). Skip it (``apply_soft_cap=False``) for
+            joins not in the demand snapshot (full local prefix-cache match,
+            resumed-after-eviction) — they only face the hard limit. In static
+            mode the two caps are equal, so the flag has no effect.
+        """
+        if self._count >= self._hard_cap:
+            return False
+        # Soft (spreading) cap for the budgeted demand; skipped for
+        # demand-unbudgeted joins, which then face only the hard cap above.
+        return not (apply_soft_cap and self._count >= self._cap_policy.cap())
+
+    def admit(self, n: int = 1) -> None:
+        """Record ``n`` decode requests as admitted to this step's batch."""
+        self._count += n
+
+    def discard(self, n: int = 1) -> None:
+        """Un-admit ``n`` decode requests dropped from this step's batch.
+
+        Unlike ``reset()`` (whole batch dropped by a prefill eviction), this
+        removes only the requests that left the batch while others remain
+        admitted -- currently the PRIORITY-policy preemption in the running
+        loop, which evicts an already-scheduled decode to free KV blocks.
+        Keeping the count in step with the batch keeps the subsequent
+        ``can_admit()`` gate from stopping early on a stale (over)count.
+        """
+        self._count -= n
+
+    def reset(self) -> None:
+        """Clear the admitted count (decode batch dropped, e.g. by eviction)."""
+        self._count = 0
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    @property
+    def cap(self) -> int:
+        return self._cap_policy.cap()
+
+
+class DecodeAdmissionController:
+    """Per-scheduler factory for per-step decode-batch admission budgets.
+
+    Built once from scheduler config; produces a fresh ``DecodeBatchBudget``
+    for each ``schedule()`` call. It owns the PP decode-cap machinery — the
+    compiled per-stage batch size, the static cap policy, and the choice
+    between the static cap and the PP-balanced dynamic cap — so ``schedule()``
+    only has to supply the demand and use the returned budget.
+
+    Dynamic (demand-spread) capping applies only when ``pp_balance_decode`` is
+    enabled *and* ``pipeline_parallel_size > 1``; otherwise the fixed
+    ``max_num_seqs // pp_size`` cap is used.
+    """
+
+    def __init__(
+        self,
+        max_num_seqs: int,
+        pipeline_parallel_size: int,
+        pp_balance_decode: bool,
+    ) -> None:
+        self._pp_size = pipeline_parallel_size
+        self._max_decode_batch_size = decode_batch_size(
+            max_num_seqs, pipeline_parallel_size
+        )
+        self._static_policy = StaticDecodeCapPolicy(self._max_decode_batch_size)
+        # Demand-spread capping is only meaningful under PP.
+        self._balance = pp_balance_decode and pipeline_parallel_size > 1
+
+    def make_budget(self, demand_fn: Callable[[], int]) -> DecodeBatchBudget:
+        """Return a fresh budget for this step.
+
+        ``demand_fn`` is a zero-arg callable returning the total decode demand
+        (running decodes + ready remote-KV). It is invoked **only** when PP
+        balancing is active, so the static path pays nothing to compute it.
+        """
+        if self._balance:
+            policy: DecodeCapPolicy = DynamicDecodeCapPolicy(
+                self._max_decode_batch_size, self._pp_size, demand_fn()
+            )
+        else:
+            policy = self._static_policy
+        return DecodeBatchBudget(policy, hard_cap=self._max_decode_batch_size)

--- a/vllm_rbln/v1/core/utils.py
+++ b/vllm_rbln/v1/core/utils.py
@@ -14,13 +14,22 @@
 
 """Utility helpers for the RBLN scheduler (``rbln_scheduler.py``).
 
-A home for small, self-contained, independently-testable pieces factored
-out of ``RBLNScheduler`` so that ``schedule()`` (a large copy of upstream's
-method with RBLN-specific tweaks) stays readable. Add further scheduler
-utilities here.
+A home for small, self-contained, independently-testable pieces of RBLN
+scheduling/engine logic factored out of ``RBLNScheduler`` so that
+``schedule()`` (a large copy of upstream's method with RBLN-specific tweaks)
+stays readable. Unlike ``vllm_rbln.utils`` (general torch-tensor primitives),
+these encode engine/scheduler semantics; some are shared with the runner
+(``RBLNModelRunner``) -- e.g. ``decode_batch_size`` and the spec-decode
+``num_base_tokens`` / ``resolve_propagated_token_write`` token bookkeeping.
+Add further scheduler utilities here.
 
-Currently provides the per-step decode-batch admission budget
-(``DecodeBatchBudget`` + ``DecodeCapPolicy``):
+The speculative-decode + PP helpers -- ``should_defer_spec_step`` (running-loop
+anchor-reconciled deferral), ``num_base_tokens`` and
+``resolve_propagated_token_write`` (non-last-rank token propagation) -- live
+next to their docstrings above/below.
+
+The per-step decode-batch admission budget (``DecodeBatchBudget`` +
+``DecodeCapPolicy``):
 
 Under pipeline parallelism the engine keeps ``pipeline_parallel_size``
 microbatches in flight (one per PP stage). To bound the total in-flight
@@ -58,6 +67,99 @@ def decode_batch_size(max_num_seqs: int, pipeline_parallel_size: int) -> int:
     ``RBLNPlatform.check_and_update_config``); otherwise this floors to 0.
     """
     return max_num_seqs // pipeline_parallel_size
+
+
+def should_defer_spec_step(
+    num_spec_tokens: int,
+    spec_token_ids: list[int],
+    num_new_tokens: int,
+) -> bool:
+    """Whether ``schedule()``'s running loop must defer a speculative-decode
+    step under sync-scheduling PP because it has no reconciled BASE (anchor)
+    token to schedule yet.
+
+    Called with the RAW ``num_new_tokens`` (before the scheduler's caps). The
+    base count is ``num_new_tokens - len(spec_token_ids)``. The branch is on
+    whether the proposer currently holds drafts (``spec_token_ids``), which only
+    selects how the base is tested:
+
+    - Drafts held: ``num_new_tokens`` is draft-inflated, so gate on the base
+      itself. ``base <= 0`` means there is no fresh anchor token for the drafts
+      to verify against yet (the token-producing step has not reconciled);
+      scheduling anyway hands the non-last PP rank an empty token payload.
+    - No drafts held (just consumed, or no proposer match): ``base ==
+      num_new_tokens``, which goes negative only in the post-verify overshoot
+      (num_computed_tokens still optimistically advanced). The mundane ``== 0``
+      (no work this step) and the no-match case are left to the caller's plain
+      upstream defer.
+
+    Returns ``False`` when spec is disabled (``num_spec_tokens <= 0``), so
+    non-spec decode is untouched; also inert for pp=1, where synchronous
+    scheduling keeps the base reconciled.
+    """
+    if num_spec_tokens <= 0:
+        return False
+    if spec_token_ids:
+        return num_new_tokens - len(spec_token_ids) <= 0
+    return num_new_tokens < 0
+
+
+def num_base_tokens(
+    num_scheduled_tokens: dict[str, int],
+    scheduled_spec_decode_tokens: dict[str, list[int]],
+    req_id: str,
+) -> int:
+    """Number of non-draft (anchor / decode) tokens scheduled for ``req_id`` in
+    a step: the total scheduled tokens minus the speculative draft tokens.
+
+    This is the count that advances the request's committed sequence (the base
+    decode token plus any catch-up), as opposed to the unverified drafts. It is
+    the shared notion of "base" used by the scheduler's non-last-rank token
+    propagation and by the runner's token-write / output bookkeeping.
+    """
+    return num_scheduled_tokens.get(req_id, 0) - len(
+        scheduled_spec_decode_tokens.get(req_id, ())
+    )
+
+
+def resolve_propagated_token_write(
+    cursor: int,
+    num_computed_tokens: int,
+    base: int,
+    new_token_ids: list[int],
+) -> tuple[int, list[int]] | None:
+    """Plan the non-last PP rank's write of scheduler-propagated tokens.
+
+    Under sync-scheduling pipeline parallelism the scheduler ships
+    ``new_token_ids`` covering the request's committed-token tail (extended
+    backward by ``num_spec_tokens`` so it always spans a prior verify's
+    multi-accept lag). This rank brings its recorded-token cursor
+    (``num_tokens_no_spec``) up to
+    ``committed_tip = num_computed_tokens + base`` by writing the payload slice
+    that lands at ``[cursor, committed_tip)`` by ABSOLUTE position, idempotently
+    overwriting any mis-speculated slots.
+
+    Returns ``(committed_tip, tokens)`` where ``tokens`` is the slice to write
+    at ``token_ids_cpu[cursor:committed_tip]`` -- empty when the payload is
+    empty (e.g. the async-scheduling GPU-broadcast path), in which case only the
+    cursor advances -- or ``None`` if the cursor has already reached
+    ``committed_tip`` (nothing to write).
+    """
+    committed_tip = num_computed_tokens + base
+    if committed_tip <= cursor:
+        return None
+    span = committed_tip - cursor
+    if not new_token_ids:
+        return committed_tip, []
+    # The payload covers all_token_ids[committed_tip - len : committed_tip], so
+    # the token for absolute position `cursor` sits at offset `lo`.
+    lo = cursor - (committed_tip - len(new_token_ids))
+    if lo >= 0 and lo + span <= len(new_token_ids):
+        return committed_tip, new_token_ids[lo : lo + span]
+    # Defensive: the payload should always cover [cursor, committed_tip); if it
+    # somehow does not, fall back to its tail so the cursor still advances
+    # without an out-of-bounds slice.
+    return committed_tip, new_token_ids[-span:]
 
 
 @runtime_checkable

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -70,6 +70,7 @@ from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, Schedul
 
 from vllm_rbln.forward_context import set_forward_context
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
+from vllm_rbln.v1.core.utils import decode_batch_size
 
 if TYPE_CHECKING:
     from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
@@ -687,9 +688,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.execute_model_state: ExecuteModelState | None = None
         self.kv_connector_output: KVConnectorOutput | None = None
 
-        self.max_batch_size = (
-            self.scheduler_config.max_num_seqs
-            // self.parallel_config.pipeline_parallel_size
+        self.max_batch_size = decode_batch_size(
+            self.scheduler_config.max_num_seqs,
+            self.parallel_config.pipeline_parallel_size,
         )
         self.max_num_seqs = self.scheduler_config.max_num_seqs
         self.max_prefill_batch_size = 1

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -17,7 +17,7 @@ import itertools
 import os
 import time
 from collections import defaultdict
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Union, cast
@@ -169,10 +169,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def scrub_scheduler_output_for_no_spec(
-    scheduler_output: RBLNSchedulerOutput,
-    requests: "Mapping[str, Any]",
-) -> None:
+def scrub_scheduler_output_for_no_spec(scheduler_output: RBLNSchedulerOutput) -> None:
     """Force every scheduled DECODE request to query_len=1 for a collective
     no-spec step.
 
@@ -181,25 +178,23 @@ def scrub_scheduler_output_for_no_spec(
     drop to ``query_len=1`` and ``_prepare_inputs`` must build a uniform
     no-spec graph.
 
-    PREFILL reqs are EXCLUDED from the clamp: no-spec is a decode-only concern
-    (cross-block backfill on a decoding request). In DP/EP a rank may be running
-    chunked prefill while a *peer* decode rank trips the OR-reduce. Clamping the
-    prefill's chunk query_len to 1 would make its sampled token look like a
-    partial-prefill token (seq_lens < num_tokens), get it discarded, and lose the
-    request. A prefill keeps its full chunk length; the cross-DP query-length
-    axis is reconciled to the prefill shape by ``get_dp_padding`` (any_prefill ->
-    prefill-sized). Prefill reqs are identified by the scheduler's own
-    ``is_prefill`` definition -- ``num_computed_tokens < num_tokens - 1`` -- NOT
-    by ``num_output_tokens == 0``. The latter misclassifies a prefill/decode
-    disaggregation request that received its prompt KV from the producer and was
-    promoted to a decode (``num_computed == num_tokens - 1``, a scheduler-DECODE
-    that may carry a slide, yet no output token yet) as a prefill, leaving its
-    slide uncleared and its query_len unclamped (#390 A). A genuine multi-token
-    prefill chunk always has ``num_computed <= num_tokens - 2``, so it is never
-    misclassified.
+    no-spec is a DECODE-only concern (cross-block backfill on a decoding
+    request). In DP/EP a rank may be running chunked prefill while a *peer*
+    decode rank trips the OR-reduce; clamping the prefill's chunk query_len to 1
+    would make its sampled token look partial (seq_lens < num_tokens), get it
+    discarded, and lose the request. RBLN has no mixed batching, so a step is
+    uniformly prefill or decode: ``scheduler_output.is_prefill_step`` (stamped by
+    the scheduler from pre-advance state via ``is_prefill`` = ``num_computed <
+    num_tokens - 1``) decides it for the whole step. A prefill step is left
+    untouched; the cross-DP query-length axis is reconciled to the prefill shape
+    by ``get_dp_padding`` (any_prefill -> prefill-sized). A promoted remote-KV
+    decode (``num_computed == num_tokens - 1``) is correctly a decode here, so it
+    is clamped and its slide cleared (#390 A) -- unlike a ``num_output_tokens ==
+    0`` test, which would misclassify it as a prefill.
 
-    We zero any in-block slide and force ``num_scheduled_tokens`` to 1, but we
-    must NOT clear ``scheduled_spec_decode_tokens``: the engine's
+    On the decode step we zero the in-block slides and force
+    ``num_scheduled_tokens`` to 1, but we must NOT clear
+    ``scheduled_spec_decode_tokens``: the engine's
     ``update_from_output`` reads that dict to roll back the optimistic
     ``num_computed_tokens`` advance applied in ``_update_after_schedule``
     (``num_rejected = num_draft_tokens - num_accepted``). Clearing it here
@@ -208,67 +203,24 @@ def scrub_scheduler_output_for_no_spec(
     take the no-spec path explicitly via ``spec_decode_max_query_len=1`` rather
     than by inspecting this dict.
     """
-    # Identify prefill reqs via the scheduler's is_prefill (num_computed <
-    # num_tokens - 1), evaluated from scheduler_output's authoritative pre-step
-    # counts (num_computed / num_output) plus the static prompt length from
-    # `requests`. Reading num_computed from scheduler_output (not the mutable req
-    # state) keeps this correct regardless of any optimistic num_computed advance.
-    _cached = scheduler_output.scheduled_cached_reqs
-    _cached_num_computed = dict(zip(_cached.req_ids, _cached.num_computed_tokens))
-    _cached_num_output = dict(zip(_cached.req_ids, _cached.num_output_tokens))
-    _new_num_computed = {
-        r.req_id: r.num_computed_tokens for r in scheduler_output.scheduled_new_reqs
-    }
+    if scheduler_output.is_prefill_step:
+        # Prefill step (a peer decode rank tripped the cross-DP OR-reduce):
+        # no-spec doesn't apply, and a prefill carries no slide -- nothing to do.
+        return
 
-    def _is_prefill(req_id: str) -> bool:
-        state = requests.get(req_id)
-        if state is None:
-            return False
-        num_prompt = len(state.prompt_token_ids)
-        if req_id in _new_num_computed:
-            num_computed = _new_num_computed[req_id]
-            num_output = 0
-        else:
-            num_computed = _cached_num_computed.get(req_id, 0)
-            num_output = _cached_num_output.get(req_id, 0)
-        # num_tokens = prompt + committed output (excludes spec drafts).
-        return num_computed < (num_prompt + num_output) - 1
-
-    prefill_req_ids = {
-        req_id
-        for req_id in scheduler_output.num_scheduled_tokens
-        if _is_prefill(req_id)
-    }
-    # A slide entry only ever belongs to a scheduler-DECODE (it is written
-    # only for `not is_prefill` reqs), so drop it for every non-prefill req.
-    # A promoted remote-KV decode is now correctly a decode here, so its
-    # slide is cleared (fixing #390 A). Real prefills never carry a slide,
-    # so the map ends empty (asserted below).
-    for _rid in list(scheduler_output.spec_decode_slide_distance):
-        if _rid not in prefill_req_ids:
-            del scheduler_output.spec_decode_slide_distance[_rid]
+    # Decode step: every scheduled req is a decode.
+    scheduler_output.spec_decode_slide_distance.clear()
     for req_id in list(scheduler_output.num_scheduled_tokens):
-        # no-spec (query_len=1) is a DECODE concern. A PREFILL req must keep its
-        # chunk query_len; clamping it to 1 discards the prefill's token and
-        # loses the request.
-        if req_id in prefill_req_ids:
-            continue
         scheduler_output.num_scheduled_tokens[req_id] = 1
     scheduler_output.total_num_scheduled_tokens = sum(
         scheduler_output.num_scheduled_tokens.values()
     )
 
-    # Verify the no-spec scrub eliminated every cross-block condition for the
-    # DECODE reqs: with their slides cleared and query_len forced to 1, a
-    # backfill window can no longer span two KV blocks. Prefill reqs are
-    # intentionally left at their chunk length.
-    assert all(
-        v == 1
-        for rid, v in scheduler_output.num_scheduled_tokens.items()
-        if rid not in prefill_req_ids
-    ), (
-        f"no-spec scrub left a decode query_len != 1: "
-        f"{scheduler_output.num_scheduled_tokens}"
+    # Verify the scrub eliminated every cross-block condition: with all slides
+    # cleared and every query_len forced to 1, a backfill window can no longer
+    # span two KV blocks.
+    assert all(v == 1 for v in scheduler_output.num_scheduled_tokens.values()), (
+        f"no-spec scrub left a query_len != 1: {scheduler_output.num_scheduled_tokens}"
     )
     assert not scheduler_output.spec_decode_slide_distance, (
         "no-spec scrub left a non-empty slide map, so a cross-block "
@@ -3525,7 +3477,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # graph across DP. Runs whenever the global flag is set, even if
             # this rank had no drafts/slide locally (a peer tripped it).
             if step_no_spec_required:
-                scrub_scheduler_output_for_no_spec(scheduler_output, self.requests)
+                scrub_scheduler_output_for_no_spec(scheduler_output)
                 tokens = [scheduler_output.num_scheduled_tokens[i] for i in req_ids]
                 num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
                 num_tokens_unpadded = scheduler_output.total_num_scheduled_tokens

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -70,7 +70,11 @@ from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, Schedul
 
 from vllm_rbln.forward_context import set_forward_context
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
-from vllm_rbln.v1.core.utils import decode_batch_size
+from vllm_rbln.v1.core.utils import (
+    decode_batch_size,
+    num_base_tokens,
+    resolve_propagated_token_write,
+)
 
 if TYPE_CHECKING:
     from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
@@ -341,6 +345,10 @@ class DummyRunState(NamedTuple):
     num_input_tokens: int
     input_ids: dict[int, torch.Tensor]
     positions: dict[int, torch.Tensor]
+    # The (RBLN) scheduler output this dummy was built from. dummy_run replays
+    # it through _set_step_phase so a stale prefill/decode phase from a prior
+    # real step cannot leak into any is_prefill_phase() read on the idle rank.
+    scheduler_output: "SchedulerOutput"
     draft_attn_metadata: dict[int, dict[str, Any]] | None = None
 
 
@@ -627,7 +635,17 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # None in the first PP rank. The rest are set after load_model.
         self.prefill_intermediate_tensors: IntermediateTensors | None = None
-        self.decode_intermediate_tensors: dict[int, IntermediateTensors] = {}
+        # Keyed by (decode_batch_bucket, query_len): under spec decode the decode
+        # query window is num_spec_tokens + 1 (or 1 on the no-spec fallback), and
+        # the PP inter-stage tensor must carry batch * query_len tokens, so one
+        # template per compiled (bucket, query_len) decode graph is stored.
+        self.decode_intermediate_tensors: dict[
+            tuple[int, int], IntermediateTensors
+        ] = {}
+
+        # This step's prefill/decode classification, stashed from the scheduler
+        # output at the top of each execute_model (see is_prefill_phase()).
+        self._is_prefill_step: bool = False
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
         # Keep in int64 to avoid overflow with long context
@@ -1011,8 +1029,20 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     new_token_ids = req_data.new_token_ids[i]
                     # Add the sampled token(s) from the previous step (if any).
                     # This doesn't include "unverified" tokens like spec tokens.
+                    # NOTE(RBLN): new_token_ids is extended backward by num_spec
+                    # (multi-accept propagation) and ends at committed_tip =
+                    # num_computed + base. The number of NEW output tokens is the
+                    # committed delta, computed from base (not len(new_token_ids),
+                    # which now includes the backward-extended catch-up window).
+                    # new_token_ids[-num_new:] still takes the newest tokens
+                    # because the payload ends at committed_tip.
+                    base_out = num_base_tokens(
+                        scheduler_output.num_scheduled_tokens,
+                        scheduled_spec_tokens,
+                        req_id,
+                    )
                     num_new_tokens = (
-                        num_computed_tokens + len(new_token_ids) - req_state.num_tokens
+                        num_computed_tokens + base_out - req_state.num_tokens
                     )
                     if num_new_tokens == 1:
                         # Avoid slicing list in most common case.
@@ -1067,13 +1097,32 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # For the last rank, we don't need to update the token_ids_cpu
             # because the sampled tokens are already cached.
             if not is_last_rank:
-                # Add new_token_ids to token_ids_cpu.
-                start_token_index = num_computed_tokens
-                end_token_index = num_computed_tokens + len(new_token_ids)
-                self.input_batch.token_ids_cpu[
-                    req_index, start_token_index:end_token_index
-                ] = new_token_ids
-                self.input_batch.num_tokens_no_spec[req_index] = end_token_index
+                # NOTE(RBLN): bring this rank's recorded-token cursor
+                # (num_tokens_no_spec) up to committed_tip = num_computed + base
+                # by writing the scheduler-propagated tokens at their ABSOLUTE
+                # position. The payload is extended backward by num_spec so it
+                # spans a prior verify's multi-accept lag; the write idempotently
+                # overwrites any mis-speculated draft slots. See
+                # resolve_propagated_token_write.
+                base = num_base_tokens(
+                    scheduler_output.num_scheduled_tokens,
+                    scheduled_spec_tokens,
+                    req_id,
+                )
+                start_token_index = self.input_batch.num_tokens_no_spec[req_index]
+                write = resolve_propagated_token_write(
+                    start_token_index, num_computed_tokens, base, new_token_ids
+                )
+                if write is not None:
+                    committed_tip, tokens = write
+                    if tokens:
+                        self.input_batch.token_ids_cpu[
+                            req_index, start_token_index:committed_tip
+                        ] = tokens
+                    self.input_batch.is_token_ids[
+                        req_index, start_token_index:committed_tip
+                    ] = True
+                    self.input_batch.num_tokens_no_spec[req_index] = committed_tip
 
             # Add spec_token_ids to token_ids_cpu.
             self.input_batch.update_req_spec_token_ids(req_state, scheduled_spec_tokens)
@@ -2395,6 +2444,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             dummy_prefill_requests,
             dummy_prefill_num_scheduled_tokens,
             num_kv_cache_groups,
+            is_prefill=True,
         )
         logger.info("Warm-up: prefill (seq_len=%d)", prefill_seq_len)
         self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
@@ -2420,13 +2470,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # proposers (EAGLE/EAGLE3/MEDUSA) never cross-block (backfill only
             # fires at the block-end squeeze, where in-block past is always
             # sufficient), so they need full spec only.
-            if self.num_spec_tokens > 0:
-                if self.speculative_config.method in ("ngram", "suffix"):
-                    query_len_range = [1, self.num_spec_tokens + 1]
-                else:
-                    query_len_range = [self.num_spec_tokens + 1]
-            else:
-                query_len_range = [1]
+            query_len_range = self._decode_query_lens()
             for query_len in query_len_range:
                 dummy_decode_requests: list[NewRequestData] = []
                 dummy_decode_num_scheduled_tokens: dict[str, int] = {}
@@ -2467,7 +2511,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     step_no_spec_required=(query_len == 1 and self.num_spec_tokens > 0),
                 )
                 current_intermediate_tensors = self.decode_intermediate_tensors.get(
-                    batch_bucket_size
+                    (batch_bucket_size, query_len)
                 )
                 assert current_intermediate_tensors is not None
 
@@ -2534,7 +2578,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 decode_batch
             )
             current_intermediate_tensors = self.decode_intermediate_tensors.get(
-                batch_bucket_size
+                (batch_bucket_size, sampler_query_len)
             )
             assert current_intermediate_tensors is not None
             logger.info("Warm-up: sampler (decode_batch=%d)", decode_batch)
@@ -2583,17 +2627,18 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_kv_cache_groups: int,
         scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         step_no_spec_required: bool = False,
+        is_prefill: bool = False,
     ) -> tuple[SchedulerOutput, SchedulerOutput]:
-        # When step_no_spec_required is requested (the warmup no-spec /
-        # query_len=1 iteration for variable-length proposers), emit an
-        # RBLNSchedulerOutput carrying the flag so execute_model takes the
-        # EXACT same path the runtime cross-block no-spec fallback does:
-        # step_no_spec_required -> spec_decode_max_query_len=1 -> get_dp_padding
-        # produces num_padded = batch_bucket * 1 (maxp=8 for bucket 8). Without
-        # this the plain SchedulerOutput never trips the flag, so the no-spec
-        # decode-only graph (input (b,1), max_pads=batch_bucket) is never
-        # compiled and the runtime no-spec step / DP-idle dummy_run hot-paths.
-        sched_output_kwargs = dict(
+        # Always emit RBLNSchedulerOutput (never a plain SchedulerOutput) so the
+        # runner uniformly receives the RBLN fields:
+        #   * step_no_spec_required: on the warmup no-spec / query_len=1
+        #     iteration (variable-length proposers), so execute_model takes the
+        #     EXACT runtime cross-block no-spec path (spec_decode_max_query_len=1
+        #     -> num_padded = batch_bucket * 1) and compiles that decode-only
+        #     graph; a plain SchedulerOutput would never trip it.
+        #   * is_prefill_step: the prefill/decode classification the runner's
+        #     is_prefill_phase() reads (dummies build a known phase up front).
+        sched_output = RBLNSchedulerOutput(
             scheduled_new_reqs=requests,
             scheduled_cached_reqs=CachedRequestData.make_empty(),
             num_scheduled_tokens=num_scheduled_tokens,
@@ -2604,14 +2649,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             finished_req_ids=set(),
             free_encoder_mm_hashes=[],
             kv_connector_metadata=None,
+            step_no_spec_required=step_no_spec_required,
+            is_prefill_step=is_prefill,
         )
-        if step_no_spec_required:
-            sched_output: SchedulerOutput = RBLNSchedulerOutput(
-                **sched_output_kwargs, step_no_spec_required=True
-            )
-        else:
-            sched_output = SchedulerOutput(**sched_output_kwargs)
-        cleanup_sched_output = SchedulerOutput(
+        cleanup_sched_output = RBLNSchedulerOutput(
             scheduled_new_reqs=[],
             scheduled_cached_reqs=CachedRequestData.make_empty(),
             num_scheduled_tokens={},
@@ -2885,6 +2926,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_input_tokens=num_input_tokens,
             input_ids=input_ids_bucket,
             positions=positions_bucket,
+            scheduler_output=scheduler_output,
             draft_attn_metadata=draft_attn_metadata_bucket,
         )
 
@@ -2992,6 +3034,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     @torch.inference_mode()
     def dummy_run(self) -> None:
         assert self.dummy_run_state is not None
+        # Set the phase from the dummy's own scheduler output (decode) so a
+        # stale value from a prior real step cannot contaminate any
+        # is_prefill_phase() read while this DP-idle rank runs the dummy.
+        self._set_step_phase(self.dummy_run_state.scheduler_output)
         attn_metadata = self.dummy_run_state.attn_metadata
         num_input_tokens = self.dummy_run_state.num_input_tokens
         input_ids = self.dummy_run_state.input_ids
@@ -3076,8 +3122,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if get_pp_group().is_first_rank:
             intermediate_tensors = None
         else:
+            # Key on the actual (possibly spec-expanded) query length so the
+            # PP inter-stage tensor matches the batch * query_len token layout
+            # of bucket_input_ids for this compiled decode graph.
+            decode_query_len = bucket_input_ids.shape[1]
             intermediate_tensors = self.decode_intermediate_tensors.get(
-                batch_bucket_size
+                (batch_bucket_size, decode_query_len)
             )
             assert intermediate_tensors is not None
 
@@ -3398,6 +3448,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self._handle_kv_connector_preemptions(scheduler_output)
 
+        # NOTE(RBLN): Record this step's prefill/decode classification from the
+        # scheduler-stamped output; is_prefill_phase() reads it (see
+        # _set_step_phase). Done before the empty-batch early return below so
+        # the phase is never stale for this step.
+        self._set_step_phase(scheduler_output)
+
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("Preprocess"):
             self._update_states(scheduler_output)
@@ -3658,10 +3714,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                                 md.slot_mapping = sm
 
         # Run the model.
-        # Use persistent buffers for CUDA graphs.
         # When spec decode is enabled, defer connector finalization
-        # (wait_for_save + clear metadata) until after draft model runs.
-        defer_kv_connector_finalize = self.speculative_config is not None
+        # (wait_for_save + clear metadata) until after the draft model runs.
+        # NOTE(RBLN): gate on the last PP rank -- the deferred finalize runs in
+        # the sample path, which only the last rank reaches, so deferring on
+        # non-last ranks would drop their KV save entirely (every PP rank must
+        # finalize its own layers' KV). Only the last rank drafts, so only it
+        # needs to defer.
+        defer_kv_connector_finalize = (
+            self.speculative_config is not None and get_pp_group().is_last_rank
+        )
         with (
             set_forward_context(
                 attn_metadata,
@@ -4484,6 +4546,23 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ),
         )
 
+    def _decode_query_lens(self) -> list[int]:
+        """Decode query windows the runner compiles a graph for.
+
+        Non-spec decode is a single token (1). Spec decode pads each step to
+        num_spec_tokens + 1 via in-block query backfill; variable-length
+        proposers (ngram, suffix) additionally fall back to no-spec (1) on a
+        cross-block step, so both windows are compiled. Fixed-length proposers
+        (EAGLE/EAGLE3/MEDUSA) never cross-block and use full spec only. This is
+        the single source of truth shared by warm-up graph compilation and the
+        per-(bucket, query_len) intermediate-tensor templates.
+        """
+        if self.num_spec_tokens <= 0:
+            return [1]
+        if self.speculative_config.method in ("ngram", "suffix"):
+            return [1, self.num_spec_tokens + 1]
+        return [self.num_spec_tokens + 1]
+
     def _prepare_decode_intermediate_tensors(self, batch_bucket_size) -> None:
         def _reshape(
             batch_size: int, seq_len: int, intermediate_tensors: IntermediateTensors
@@ -4495,17 +4574,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 }
             )
 
+        # One template per compiled decode query length: the PP inter-stage
+        # tensor must carry batch * query_len tokens to match input_ids. seq_len
+        # was previously hardcoded to 1, which undersizes the tensor for spec
+        # decode (query_len == num_spec_tokens + 1) under pipeline parallelism.
         batch_size = batch_bucket_size
-        seq_len = 1
-        self.decode_intermediate_tensors[batch_bucket_size] = _reshape(
-            batch_size,
-            seq_len,
-            self.model.make_empty_intermediate_tensors(
-                batch_size=batch_size * seq_len,
-                dtype=self.model_config.dtype,
-                device=self.device,
-            ),
-        )
+        for seq_len in self._decode_query_lens():
+            self.decode_intermediate_tensors[(batch_bucket_size, seq_len)] = _reshape(
+                batch_size,
+                seq_len,
+                self.model.make_empty_intermediate_tensors(
+                    batch_size=batch_size * seq_len,
+                    dtype=self.model_config.dtype,
+                    device=self.device,
+                ),
+            )
 
     def save_tensorized_model(
         self,
@@ -5591,13 +5674,40 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return pinned.tolist()
 
     def is_prefills(self) -> np.ndarray:
+        # DEPRECATED: per-rank classification. No longer drives is_prefill_phase
+        # (that reads the scheduler stamp now); kept only for existing direct
+        # unit tests. Remove with the RBLNSchedulerOutput-unification cleanup.
         return (
             self.input_batch.num_computed_tokens_cpu
             < self.input_batch.num_tokens_no_spec - 1
         )
 
+    def _set_step_phase(self, scheduler_output: "SchedulerOutput") -> None:
+        """Record this step's prefill/decode phase from the scheduler stamp.
+
+        RBLNScheduler always emits RBLNSchedulerOutput, and the dummy builder
+        (`_make_dummy_scheduler_outputs`) does too, so every step reaching the
+        runner carries `is_prefill_step`. Assert (rather than default silently)
+        so any future path that feeds a plain SchedulerOutput fails loudly
+        instead of misclassifying the phase as decode.
+        """
+        assert isinstance(scheduler_output, RBLNSchedulerOutput), (
+            "RBLNModelRunner expects RBLNSchedulerOutput carrying is_prefill_step; "
+            f"got {type(scheduler_output).__name__}. The prefill/decode phase is "
+            "stamped by the scheduler and must be present on every step."
+        )
+        self._is_prefill_step = scheduler_output.is_prefill_step
+
     def is_prefill_phase(self) -> bool:
-        return bool(self.is_prefills()[0])
+        # The step's prefill/decode classification, stamped by the scheduler
+        # (RBLNSchedulerOutput.is_prefill_step) and stashed in execute_model.
+        # NOT re-derived from the per-rank input_batch: num_tokens_no_spec is
+        # updated on different paths on the last PP rank (sampling) vs other
+        # ranks (scheduler output), so a runner-side classification diverges
+        # across ranks under spec-decode + PP (a decode step then reads a
+        # prefill-shaped inter-stage tensor on the last rank -> hot-path
+        # recompile and wrong output). The scheduler value is rank-consistent.
+        return self._is_prefill_step
 
     def use_wrapped_compute_logits(self) -> bool:
         return not (self.lora_config is not None)

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -170,7 +170,7 @@ logger = init_logger(__name__)
 
 
 def scrub_scheduler_output_for_no_spec(
-    scheduler_output: "SchedulerOutput",
+    scheduler_output: RBLNSchedulerOutput,
     requests: "Mapping[str, Any]",
 ) -> None:
     """Force every scheduled DECODE request to query_len=1 for a collective
@@ -239,15 +239,14 @@ def scrub_scheduler_output_for_no_spec(
         for req_id in scheduler_output.num_scheduled_tokens
         if _is_prefill(req_id)
     }
-    if isinstance(scheduler_output, RBLNSchedulerOutput):
-        # A slide entry only ever belongs to a scheduler-DECODE (it is written
-        # only for `not is_prefill` reqs), so drop it for every non-prefill req.
-        # A promoted remote-KV decode is now correctly a decode here, so its
-        # slide is cleared (fixing #390 A). Real prefills never carry a slide,
-        # so the map ends empty (asserted below).
-        for _rid in list(scheduler_output.spec_decode_slide_distance):
-            if _rid not in prefill_req_ids:
-                del scheduler_output.spec_decode_slide_distance[_rid]
+    # A slide entry only ever belongs to a scheduler-DECODE (it is written
+    # only for `not is_prefill` reqs), so drop it for every non-prefill req.
+    # A promoted remote-KV decode is now correctly a decode here, so its
+    # slide is cleared (fixing #390 A). Real prefills never carry a slide,
+    # so the map ends empty (asserted below).
+    for _rid in list(scheduler_output.spec_decode_slide_distance):
+        if _rid not in prefill_req_ids:
+            del scheduler_output.spec_decode_slide_distance[_rid]
     for req_id in list(scheduler_output.num_scheduled_tokens):
         # no-spec (query_len=1) is a DECODE concern. A PREFILL req must keep its
         # chunk query_len; clamping it to 1 discards the prefill's token and
@@ -271,10 +270,10 @@ def scrub_scheduler_output_for_no_spec(
         f"no-spec scrub left a decode query_len != 1: "
         f"{scheduler_output.num_scheduled_tokens}"
     )
-    assert not getattr(scheduler_output, "spec_decode_slide_distance", {}), (
+    assert not scheduler_output.spec_decode_slide_distance, (
         "no-spec scrub left a non-empty slide map, so a cross-block "
         "backfill can still occur: "
-        f"{getattr(scheduler_output, 'spec_decode_slide_distance', {})}"
+        f"{scheduler_output.spec_decode_slide_distance}"
     )
 
 
@@ -348,7 +347,7 @@ class DummyRunState(NamedTuple):
     # The (RBLN) scheduler output this dummy was built from. dummy_run replays
     # it through _set_step_phase so a stale prefill/decode phase from a prior
     # real step cannot leak into any is_prefill_phase() read on the idle rank.
-    scheduler_output: "SchedulerOutput"
+    scheduler_output: RBLNSchedulerOutput
     draft_attn_metadata: dict[int, dict[str, Any]] | None = None
 
 
@@ -1393,6 +1392,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             logits_indices, spec_decode_metadata
         ]
         """
+        # Narrow the type for the spec_decode_slide_distance read below.
+        assert isinstance(scheduler_output, RBLNSchedulerOutput)
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         assert total_num_scheduled_tokens > 0
         num_reqs = self.input_batch.num_reqs
@@ -1409,7 +1410,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Reqs without slide stay at their scheduled length. The total
         # tensor count below (`total_query_tokens`) therefore equals
         # total_num_scheduled_tokens (logical advance) + sum(slide).
-        slide_distance_map = getattr(scheduler_output, "spec_decode_slide_distance", {})
+        slide_distance_map = scheduler_output.spec_decode_slide_distance
         if slide_distance_map:
             req_ids = self.input_batch.req_ids
             slide_arr = np.array(
@@ -2176,14 +2177,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> tuple[Any, Any | None, Any, Any, dict[Any, Any]]:
+        # Narrow the type for the spec_decode_slide_distance read below.
+        assert isinstance(scheduler_output, RBLNSchedulerOutput)
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         # Sliding window: `_prepare_inputs` prepends past tokens to decode
         # queries, inflating the flat layout beyond the scheduler's logical
         # advance. Extend `num_input_tokens` so the slice picks up the
         # past-token prefix that the runner wrote at the tail of the buffer.
-        slide_distance_map = (
-            getattr(scheduler_output, "spec_decode_slide_distance", {}) or {}
-        )
+        slide_distance_map = scheduler_output.spec_decode_slide_distance
         num_scheduled_tokens += sum(slide_distance_map.values())
 
         # TODO(RBLN): Support SP
@@ -2628,7 +2629,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         step_no_spec_required: bool = False,
         is_prefill: bool = False,
-    ) -> tuple[SchedulerOutput, SchedulerOutput]:
+    ) -> tuple[RBLNSchedulerOutput, RBLNSchedulerOutput]:
         # Always emit RBLNSchedulerOutput (never a plain SchedulerOutput) so the
         # runner uniformly receives the RBLN fields:
         #   * step_no_spec_required: on the warmup no-spec / query_len=1
@@ -2724,7 +2725,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     def _prepare_dummy_inputs(
         self,
-        scheduler_output: SchedulerOutput,
+        scheduler_output: RBLNSchedulerOutput,
         input_batch: InputBatch,
     ) -> DummyRunState:
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
@@ -3448,10 +3449,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self._handle_kv_connector_preemptions(scheduler_output)
 
-        # NOTE(RBLN): Record this step's prefill/decode classification from the
-        # scheduler-stamped output; is_prefill_phase() reads it (see
-        # _set_step_phase). Done before the empty-batch early return below so
-        # the phase is never stale for this step.
+        # Boundary guard: every step carries RBLNSchedulerOutput. Assert here
+        # (before the empty-batch early return) so the phase is stamped for this
+        # step and mypy narrows the type for the field reads below.
+        assert isinstance(scheduler_output, RBLNSchedulerOutput)
         self._set_step_phase(scheduler_output)
 
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
@@ -3460,10 +3461,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             # Process sub-block KV cache copy operations before the forward
             # pass so that partially cached blocks are populated.
-            if (
-                isinstance(scheduler_output, RBLNSchedulerOutput)
-                and scheduler_output.kv_cache_copy_ops
-            ):
+            if scheduler_output.kv_cache_copy_ops:
                 self._process_kv_cache_copy_ops(scheduler_output.kv_cache_copy_ops)
 
             if not num_scheduled_tokens:
@@ -3488,9 +3486,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # `_prepare_inputs` adds to decode queries. Downstream slicing
             # (`_preprocess`, `_get_slot_mappings`, `unpadded_to_padded`)
             # must see the post-sliding flat-token count.
-            _slide_total = sum(
-                getattr(scheduler_output, "spec_decode_slide_distance", {}).values()
-            )
+            _slide_total = sum(scheduler_output.spec_decode_slide_distance.values())
             num_tokens_unpadded = (
                 scheduler_output.total_num_scheduled_tokens + _slide_total
             )
@@ -3508,10 +3504,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # the no-drafts ranks into lookahead-allocated slots, which is
             # functionally safe (pad-position outputs are discarded by the
             # rejection sampler).
-            local_step_no_spec_required = (
-                isinstance(scheduler_output, RBLNSchedulerOutput)
-                and scheduler_output.step_no_spec_required
-            )
+            local_step_no_spec_required = scheduler_output.step_no_spec_required
             dp_size = self.vllm_config.parallel_config.data_parallel_size
             if dp_size > 1 and self.num_spec_tokens > 0:
                 dp_rank = self.vllm_config.parallel_config.data_parallel_rank
@@ -3618,9 +3611,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # scheduled + slide. `pad_speculative_draft_tokens` and the
             # remap below both rely on this length matching the size of
             # `input_ids`/`positions` written by `_prepare_inputs`.
-            _slide_distance_map = (
-                getattr(scheduler_output, "spec_decode_slide_distance", {}) or {}
-            )
+            _slide_distance_map = scheduler_output.spec_decode_slide_distance
             # Build the scheduling tensor on CPU and only `.to(device)` at
             # consumer boundaries — mirrors the non-spec path where the
             # eventual `logits_indices.to(self.device)` is the only place a
@@ -5673,29 +5664,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # self.transfer_event.synchronize()
         return pinned.tolist()
 
-    def is_prefills(self) -> np.ndarray:
-        # DEPRECATED: per-rank classification. No longer drives is_prefill_phase
-        # (that reads the scheduler stamp now); kept only for existing direct
-        # unit tests. Remove with the RBLNSchedulerOutput-unification cleanup.
-        return (
-            self.input_batch.num_computed_tokens_cpu
-            < self.input_batch.num_tokens_no_spec - 1
-        )
-
-    def _set_step_phase(self, scheduler_output: "SchedulerOutput") -> None:
-        """Record this step's prefill/decode phase from the scheduler stamp.
-
-        RBLNScheduler always emits RBLNSchedulerOutput, and the dummy builder
-        (`_make_dummy_scheduler_outputs`) does too, so every step reaching the
-        runner carries `is_prefill_step`. Assert (rather than default silently)
-        so any future path that feeds a plain SchedulerOutput fails loudly
-        instead of misclassifying the phase as decode.
-        """
-        assert isinstance(scheduler_output, RBLNSchedulerOutput), (
-            "RBLNModelRunner expects RBLNSchedulerOutput carrying is_prefill_step; "
-            f"got {type(scheduler_output).__name__}. The prefill/decode phase is "
-            "stamped by the scheduler and must be present on every step."
-        )
+    def _set_step_phase(self, scheduler_output: RBLNSchedulerOutput) -> None:
+        """Record this step's prefill/decode phase from the scheduler stamp."""
         self._is_prefill_step = scheduler_output.is_prefill_step
 
     def is_prefill_phase(self) -> bool:


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

#### Summary

Pipeline parallelism (`pipeline_parallel_size > 1`) on the vLLM-native path
(`VLLM_RBLN_USE_VLLM_MODEL=1`) worked for plain decode but broke down the moment
decode batching, speculative decoding, or disaggregated serving entered the
picture: a step's decode batch could overflow the compiled per-stage bucket,
spec-decode misclassified the prefill/decode phase inconsistently across ranks,
and the KV connector saved only part of the model's layers. This PR reorganizes
the scheduler/runner so PP is a first-class, correct, and efficient mode across
all three.

The work is one story told in four steps: give the scheduler a single PP-aware
decode-admission budget, make speculative decoding rank-consistent on top of it,
consolidate the prefill/decode phase authority onto the scheduler (removing the
now-dead per-rank classifier), and turn the batch-balancing behavior on by
default for PP.


#### What changed

##### 1. PP-aware decode-batch admission (scheduler)
Under PP the engine keeps one decode microbatch in flight per stage, so a single
step's decode batch must fit the compiled per-stage bucket
(`max_num_seqs // pp_size`). Decode requests are admitted from two places — the
running queue and, in disaggregated serving, requests whose KV transfer just
completed — so admission is centralized into **one per-step budget** shared by
both loops (`DecodeAdmissionController` / `DecodeBatchBudget` in
`v1/core/utils.py`):
- Hard cap = the compiled bucket size on every decode that joins the batch
  (exceeding it leaves the runner without a matching bucket → crash).
- Optional **demand spreading** across stages (`ceil(demand / pp_size)`) so no
  stage idles after a pipeline drain.
- Requests that become decode-ready outside the demand snapshot (full local
  prefix-cache hit, resume-after-eviction) are gated by the hard cap only.
- The admitted count stays consistent when the batch shrinks (cleared on
  whole-batch eviction, decremented on preemption of an admitted decode).

`pp_size == 1` degenerates to `max_num_seqs` — unchanged.

##### 2. Speculative decoding under PP (scheduler + runner)
Enables spec decode (ngram, EAGLE, MTP, …) together with `pp_size > 1`. RBLN runs
synchronous scheduling with `pp_size` microbatches in flight, so a verify step —
whose query spans `num_spec_tokens + 1` positions and whose anchor/accepted
tokens are produced only on the last PP rank — must stay bit-consistent on every
non-last rank one step later. Three mechanisms:
- **Uniform per-query-length bookkeeping** — the prefill/decode phase is stamped
  once on `RBLNSchedulerOutput` by the scheduler and read by every rank (never
  re-derived per-rank), PP inter-stage tensors are sized per `(bucket, query_len)`,
  and non-last ranks write propagated tokens from `num_tokens_no_spec`.
- **Anchor-reconciled scheduling** — `should_defer_spec_step` admits a verify only
  when its base token is reconciled, deciding on the base count (not the
  draft-inflated `num_new_tokens`). Gated on spec being enabled → non-spec decode
  is untouched.
- **Multi-accept token propagation** — the scheduler extends a lagging rank's
  `new_token_ids` payload back by `num_spec_tokens`; the runner writes by absolute
  position (idempotent over mis-speculated slots).

**KV-connector finalization is made PP-correct**: the deferred per-step finalize
(so draft-token KV is saved) runs in the sample path that only the last rank
reaches, so it is gated on the last rank — non-last ranks finalize in-context, so
every rank still saves its own layers' KV.

##### 3. Scheduler as the single phase authority (runner cleanup)
With `RBLNSchedulerOutput` now the unified type every step carries, the legacy
per-rank `is_prefills()` classifier (which diverged across PP ranks under spec
decode) is removed along with its test and a dangling comment. The defensive
`isinstance`/`getattr` fallbacks that hedged for a plain `SchedulerOutput` are
dropped: RBLN-only helpers are narrowed to `RBLNSchedulerOutput`, and the
base-override methods sit behind a single boundary assert that both guards the
invariant and narrows the type for direct field access.

##### 4. PP decode-batch balancing on by default
`VLLM_RBLN_PP_BALANCE_DECODE_BATCH` now defaults to **on**. The dynamic cap only
ever caps *lower* than the static one (never overflows the bucket), is floored at
1, matches the static cap at saturation, and is a **no-op for `pp_size == 1`** —
so non-PP configs are unaffected. Remains as an escape hatch: set `=0` to force
the static cap.

#### Testing

- **Unit** — new/extended coverage for the backfill/slide query-window math
  (`test_query_backfill.py`), the anchor-reconciled deferral predicate and
  multi-accept payload (`test_rbln_model_runner.py`), the PP decode-admission
  budget and demand-spread contrast (`test_scheduler.py`), and PP disaggregation
  (`test_pd_disaggregation.py`).
- `pre-commit run --hook-stage manual` clean (ruff, mypy 3.10–3.13, typos,
  license); full unit suites for runner/scheduler/pd green.

#### Risk / compatibility

- `pp_size == 1` and non-spec decode paths are untouched (predicate gated on spec;
  cap degenerates to `max_num_seqs`; balancing is a no-op).
- The default flip is confined to PP; the escape hatch preserves the old behavior.

#### Affected modules

Platform, Scheduler, Runner.


---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
