### PR TITLE
feature: add persistent swa_attn_masks buffer for vaddr reuse

### DIFF
--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -1072,6 +1072,7 @@ class RBLNFlashAttentionMetadataBuilder(
 
         self._swa_cache_seq_lens_buf: torch.Tensor | None = None
         self._swa_cache_offsets_buf: torch.Tensor | None = None
+        self._swa_attn_masks_buf: torch.Tensor | None = None
 
     def _to_device_inplace(
         self, cpu_tensor: torch.Tensor, attr_name: str
@@ -1244,7 +1245,9 @@ class RBLNFlashAttentionMetadataBuilder(
             local_block_tables=local_block_tables.to(self.device)
             if local_block_tables is not None
             else None,
-            swa_attn_masks=swa_attn_masks.to(self.device)
+            swa_attn_masks=self._to_device_inplace(
+                swa_attn_masks, "_swa_attn_masks_buf"
+            )
             if swa_attn_masks is not None
             else None,
         )


### PR DESCRIPTION
## Background
`swa_attn_masks` was rebuilt as a new device tensor on every decode step, allocating a fresh device buffer (vaddr) each time — an unnecessary per-step overhead.

## Change
Route `swa_attn_masks` through a persistent reused buffer (`_swa_attn_masks_buf`, via `_to_device_inplace`) — the same pattern already used for `cache_seq_lens` / `cache_offsets`.

## Effect
Removes the per-step fresh device allocation for `swa_attn_masks`. Applies only to decode with batch size > 1 (`swa_attn_masks` is built only when `b_size > 1`).

## Reviewer
* **Primary**: (지정 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
