### PR TITLE
fix(nixl): create RBLN NIXL backend via ensure_rbln_backend (host-bounce)

### DIFF
--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl_connector.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl_connector.py
@@ -241,6 +241,41 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
 
         self.use_host_buffer = self.kv_buffer_device == "cpu"
 
+        # Route NIXL transport through the RBLN backend when the nixl-rbln
+        # adapter is installed. Upstream's default backend ("UCX") cannot
+        # register RBLN host/device buffers, so `register_memory` must target
+        # "RBLN". Set nixl_backends here (after super().__init__ built the
+        # agent with the upstream default) rather than via the agent config:
+        # the agent config would eagerly create the RBLN backend with no
+        # customParams and fail with NIXL_ERR_BACKEND ("'listen_ip'
+        # customParam is required"). Instead the backend is created in
+        # register_kv_caches() through nixl_rbln.ensure_rbln_backend(), which
+        # supplies listen_ip="auto" + rbln_ctx_ptr.
+        try:
+            import nixl_rbln  # noqa: F401
+
+            self._use_rbln_nixl_backend = True
+        except ImportError:
+            self._use_rbln_nixl_backend = False
+
+        if self._use_rbln_nixl_backend:
+            self.nixl_backends = ["RBLN"]
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
+        """Create the RBLN NIXL backend before upstream registers memory.
+
+        Upstream's `register_memory(..., backends=["RBLN"])` (called by the
+        base `register_kv_caches`) requires the "RBLN" backend to already
+        exist on the agent. `nixl_rbln.ensure_rbln_backend` creates it
+        idempotently with the required listen_ip="auto" + rbln_ctx_ptr
+        customParams (the generic agent-config path omits these).
+        """
+        if self._use_rbln_nixl_backend:
+            import nixl_rbln
+
+            nixl_rbln.ensure_rbln_backend(self.nixl_wrapper, device_id=0)
+        super().register_kv_caches(kv_caches)
+
     def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
         """
         Initialize transfer buffer in CPU mem for accelerators


### PR DESCRIPTION
## Problem
`RblnNixlConnectorWorker` (single-file `rbln_nixl_connector.py`) relies entirely on the upstream `NixlConnectorWorker` for NIXL backend creation. On a fresh 2-worker PD serving run (kv_buffer_device forced to `cpu` — `_NIXL_SUPPORTED_DEVICE['rbln']==('cpu',)`), this fails:

- default `backends=["UCX"]` → `KeyError: 'UCX'` at `register_memory` (no UCX transport), or
- forcing `backends=["RBLN"]` via config → the agent config eagerly creates RBLN with no customParams → `[NIXL_RBLN ERROR] RBLN backend: 'listen_ip' customParam is required` → `NIXL_ERR_BACKEND`.

The RBLN-specific backend wiring present in the old `rbln_nixl/worker.py` was dropped in the single-file refactor.

## Fix
Restore it (host-bounce `cpu` path):
- `__init__`: import `nixl_rbln`; set `self.nixl_backends = ["RBLN"]` **after** `super().__init__` (so the agent isn't eagerly created with a paramless RBLN backend).
- `register_kv_caches`: call `nixl_rbln.ensure_rbln_backend(self.nixl_wrapper, device_id=0)` before `super().register_kv_caches(...)`. `ensure_rbln_backend` supplies the required `listen_ip="auto"` + `rbln_ctx_ptr` customParams.

Guarded on `nixl_rbln` importability — upstream (UCX) behavior unchanged when the adapter is absent. Ports the proven logic from the pre-refactor `rbln_nixl/worker.py`.

## Verified (live, 2-worker PD on REBEL CR03)
Built into an rbln-serve image (rblness `on-cd-dispatch`, `versions.vllm-rbln` = this branch, `ref=main` incl. rblness #108) and deployed to a 2-worker NIXL PD cluster (prefill / decode on separate physical nodes):

- `create_backend("RBLN")` is reached **without** any `NIXL_PLUGIN_DIR` override (rblness #108 plugin-discovery working) — the pre-#108 `NIXL_ERR_NOT_FOUND` is gone.
- With this fix the RBLN backend is created via `ensure_rbln_backend`: `RBLN backend ready: listener *:PORT, data NICs [<RoCE VF IP>] (DRAM + VRAM)`, `listen_ip="auto"` resolved to the RoCE VF IP, KV memory registered (`registerMem DRAM … lkey/rkey`).
- Both prefill + decode reach **Ready** and serve qwen3-4b correctly (`"The capital of France is"` → `" Paris. …"`).
- Cross-check: the pre-refactor v7 vllm-rbln (`0eb7d696`), whose `rbln_nixl/worker.py` has the same wiring, behaves identically end-to-end — confirming this is a faithful port.

### Out of scope (separate blockers, not this connector fix)
- `ibv_reg_mr` (host memory registration) needs the pod's `CAP_IPC_LOCK`/`CAP_SYS_RESOURCE` to be **effective** — added caps are ineffective for a non-root container (CapEff=0 → memlock stays 8 MiB → `ENOMEM`); fixed at the deploy manifest with `runAsUser: 0`.
- The actual cross-node KV **transfer** is currently blocked by a **physical RoCE VF fabric** issue (ARP fails between the two workers' rail VFs on the same subnet → NIXL ZMQ side-channel handshake `sock.recv → zmq.error.Again`), independent of this fix. The NIXL PD software path (backend create → MR register → `do_remote_decode` KV produce + transfer-param return → decode `do_remote_prefill` handshake initiation) is exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
