### PR TITLE
feature(observability): trace RBLN model execution

### DIFF
--- a/tests/torch_compile/unit/test_tracing.py
+++ b/tests/torch_compile/unit/test_tracing.py
@@ -1,0 +1,132 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import vllm_rbln.tracing as tracing
+from vllm_rbln.tracing import (
+    batch_span_attributes,
+    configure_batch_span_link_limit,
+    start_batch_span,
+)
+
+
+class _FakeSpanContext:
+    def __init__(self, trace_id: int, span_id: int, *, is_valid: bool = True):
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self.is_valid = is_valid
+
+
+class _FakeLink:
+    def __init__(self, context):
+        self.context = context
+
+
+def _install_fake_otel(monkeypatch, contexts):
+    tracer = MagicMock()
+    span_context_manager = object()
+    tracer.start_as_current_span.return_value = span_context_manager
+
+    fake_trace = SimpleNamespace(
+        get_current_span=lambda context: SimpleNamespace(
+            get_span_context=lambda: context
+        ),
+        get_tracer=lambda _: tracer,
+    )
+    otel_module = ModuleType("opentelemetry")
+    otel_module.__path__ = []
+    otel_module.trace = fake_trace  # type: ignore[attr-defined]
+    otel_trace_module = ModuleType("opentelemetry.trace")
+    otel_trace_module.Link = _FakeLink  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "opentelemetry", otel_module)
+    monkeypatch.setitem(sys.modules, "opentelemetry.trace", otel_trace_module)
+    monkeypatch.setattr(tracing, "is_tracing_available", lambda: True)
+    monkeypatch.setattr(
+        tracing,
+        "extract_trace_context",
+        lambda headers: contexts.get(headers["traceparent"]),
+    )
+    return tracer, span_context_manager
+
+
+def test_batch_span_attributes():
+    assert batch_span_attributes({"req-1": 4, "req-2": 2}) == {
+        "vllm.request_ids": ["req-1", "req-2"],
+        "vllm.num_requests": 2,
+        "vllm.num_scheduled_tokens": 6,
+    }
+
+
+def test_configure_batch_span_link_limit_uses_max_batch_size(monkeypatch):
+    monkeypatch.delenv("OTEL_SPAN_LINK_COUNT_LIMIT", raising=False)
+
+    configure_batch_span_link_limit(256)
+
+    assert tracing.os.environ["OTEL_SPAN_LINK_COUNT_LIMIT"] == "256"
+
+
+def test_configure_batch_span_link_limit_preserves_user_setting(monkeypatch):
+    monkeypatch.setenv("OTEL_SPAN_LINK_COUNT_LIMIT", "512")
+
+    configure_batch_span_link_limit(256)
+
+    assert tracing.os.environ["OTEL_SPAN_LINK_COUNT_LIMIT"] == "512"
+
+
+def test_start_batch_span_is_noop_when_tracing_is_disabled(monkeypatch):
+    monkeypatch.setattr(tracing, "is_tracing_available", lambda: False)
+
+    with start_batch_span(
+        "vllm.model_execute",
+        enabled=True,
+        request_trace_headers={},
+    ) as span:
+        assert span is None
+
+
+def test_start_batch_span_links_unique_request_contexts(monkeypatch):
+    first = _FakeSpanContext(1, 10)
+    second = _FakeSpanContext(2, 20)
+    invalid = _FakeSpanContext(0, 0, is_valid=False)
+    tracer, span_context_manager = _install_fake_otel(
+        monkeypatch,
+        {
+            "first": first,
+            "second": second,
+            "invalid": invalid,
+        },
+    )
+    attributes = {"vllm.num_requests": 4}
+
+    result = start_batch_span(
+        "vllm.model_execute",
+        enabled=True,
+        request_trace_headers={
+            "req-1": {"traceparent": "first"},
+            "req-2": {"traceparent": "second"},
+            "req-3": {"traceparent": "first"},
+            "req-4": {"traceparent": "invalid"},
+        },
+        attributes=attributes,
+    )
+
+    assert result is span_context_manager
+    call = tracer.start_as_current_span.call_args
+    assert call.args == ("vllm.model_execute",)
+    assert call.kwargs["attributes"] == attributes
+    assert [link.context for link in call.kwargs["links"]] == [first, second]
+    assert "context" not in call.kwargs

--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -57,6 +57,21 @@ def test_schedule():
     assert len(output.finished_req_ids) == 0
 
 
+def test_schedule_propagates_trace_headers():
+    scheduler = create_scheduler(max_num_seqs=1)
+    request = create_requests(num_requests=1)[0]
+    trace_headers = {
+        "traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    }
+    request.trace_headers = trace_headers
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.request_trace_headers == {request.request_id: trace_headers}
+    assert output.request_trace_headers[request.request_id] is not trace_headers
+
+
 def test_schedule_chunked_prefill():
     scheduler = create_scheduler(max_num_batched_tokens=256)
     request = create_requests(num_requests=1, num_tokens=500)[0]

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -125,6 +125,7 @@ def _make_vllm_config(
         scheduler_config=_make_scheduler_config(),
         device_config=SimpleNamespace(device=torch.device("cpu"), device_type="cpu"),
         kv_transfer_config=None,
+        observability_config=SimpleNamespace(collect_model_execute_time=False),
         instance_id="test-instance",
     )
 
@@ -1008,6 +1009,8 @@ class TestExecuteModel:
     def _make_scheduler_output(self, total_tokens=10):
         so = MagicMock()
         so.total_num_scheduled_tokens = total_tokens
+        so.num_scheduled_tokens = {"req-0": total_tokens} if total_tokens else {}
+        so.request_trace_headers = {}
         return so
 
     def test_basic_forward(self):
@@ -1032,6 +1035,58 @@ class TestExecuteModel:
             result = worker.execute_model(self._make_scheduler_output(0))
 
         assert result is None
+
+    def test_detailed_trace_wraps_model_execute(self):
+        worker = _create_worker(rank=3)
+        worker.vllm_config.observability_config.collect_model_execute_time = True
+        worker.model_runner = MagicMock()
+        output = MagicMock(spec=ModelRunnerOutput)
+        events = []
+
+        def _record_execute(*_):
+            events.append("execute")
+            return output
+
+        worker.model_runner.execute_model.side_effect = _record_execute
+        scheduler_output = self._make_scheduler_output(7)
+        scheduler_output.request_trace_headers = {
+            "req-0": {
+                "traceparent": (
+                    "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+                )
+            }
+        }
+
+        class RecordingSpan:
+            def __enter__(self):
+                events.append("span-enter")
+
+            def __exit__(self, *_):
+                events.append("span-exit")
+
+        with (
+            patch("vllm_rbln.v1.worker.rbln_worker.get_pp_group") as pp,
+            patch(
+                "vllm_rbln.v1.worker.rbln_worker.start_batch_span",
+                return_value=RecordingSpan(),
+            ) as start_span,
+        ):
+            pp.return_value.is_first_rank = True
+            result = worker.execute_model(scheduler_output)
+
+        assert result is output
+        assert events == ["span-enter", "execute", "span-exit"]
+        start_span.assert_called_once_with(
+            "vllm.model_execute",
+            enabled=True,
+            request_trace_headers=scheduler_output.request_trace_headers,
+            attributes={
+                "vllm.request_ids": ["req-0"],
+                "vllm.num_requests": 1,
+                "vllm.num_scheduled_tokens": 7,
+                "vllm.worker_rank": 3,
+            },
+        )
 
     def test_not_first_rank_receives_tensors(self):
         worker = _create_worker()

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -33,6 +33,7 @@ from vllm.utils.torch_utils import _StreamPlaceholder
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
+from vllm_rbln.tracing import configure_batch_span_link_limit
 from vllm_rbln.utils.optimum.predicates import is_qwen3_pooling
 from vllm_rbln.utils.optimum.registry import (
     is_enc_dec_arch,
@@ -342,6 +343,13 @@ class RblnPlatform(Platform):
             from vllm_rbln.utils.optimum.converter import sync_vllm_and_optimum
 
             sync_vllm_and_optimum(vllm_config)
+
+        observability_config = vllm_config.observability_config
+        if (
+            observability_config.collect_model_execute_time
+            or observability_config.collect_model_forward_time
+        ):
+            configure_batch_span_link_limit(scheduler_config.max_num_seqs)
 
         if (
             parallel_config.distributed_executor_backend is not None

--- a/vllm_rbln/tracing.py
+++ b/vllm_rbln/tracing.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any
+
+from vllm.tracing import extract_trace_context, is_tracing_available
+
+SpanAttribute = str | bool | int | float | Sequence[str]
+
+
+def configure_batch_span_link_limit(max_num_seqs: int) -> None:
+    # The OTel SDK defaults to 128 links. RBLN batches can be larger, so size
+    # the worker tracer before vLLM initializes its TracerProvider.
+    os.environ.setdefault("OTEL_SPAN_LINK_COUNT_LIMIT", str(max_num_seqs))
+
+
+def batch_span_attributes(
+    num_scheduled_tokens: Mapping[str, int],
+) -> dict[str, SpanAttribute]:
+    return {
+        "vllm.request_ids": list(num_scheduled_tokens),
+        "vllm.num_requests": len(num_scheduled_tokens),
+        "vllm.num_scheduled_tokens": sum(num_scheduled_tokens.values()),
+    }
+
+
+def start_batch_span(
+    span_name: str,
+    *,
+    enabled: bool,
+    request_trace_headers: Mapping[str, Mapping[str, str]],
+    attributes: Mapping[str, SpanAttribute] | None = None,
+) -> AbstractContextManager[Any]:
+    if not enabled or not is_tracing_available():
+        return nullcontext()
+
+    from opentelemetry import trace
+    from opentelemetry.trace import Link
+
+    links = []
+    seen_span_contexts: set[tuple[int, int]] = set()
+    for headers in request_trace_headers.values():
+        context = extract_trace_context(headers)
+        if context is None:
+            continue
+
+        span_context = trace.get_current_span(context).get_span_context()
+        span_key = (span_context.trace_id, span_context.span_id)
+        if not span_context.is_valid or span_key in seen_span_contexts:
+            continue
+
+        seen_span_contexts.add(span_key)
+        links.append(Link(span_context))
+
+    return trace.get_tracer(__name__).start_as_current_span(
+        span_name,
+        attributes=attributes,
+        links=links,
+    )

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -171,6 +171,7 @@ class RBLNSchedulerOutput(SchedulerOutput):
     # positions' logits are discarded; past KV gets idempotently
     # re-written. Empty / missing key => slide_distance is 0 (no slide).
     spec_decode_slide_distance: dict[str, int] = field(default_factory=dict)
+    request_trace_headers: dict[str, dict[str, str]] = field(default_factory=dict)
 
 
 def is_prefill(request: Request) -> bool:
@@ -1228,6 +1229,11 @@ class RBLNScheduler(Scheduler):
             new_block_ids_to_zero=new_block_ids_to_zero,
             step_no_spec_required=step_no_spec_required,
             spec_decode_slide_distance=spec_decode_slide_distance,
+            request_trace_headers={
+                req_id: dict(trace_headers)
+                for req_id in num_scheduled_tokens
+                if (trace_headers := self.requests[req_id].trace_headers) is not None
+            },
         )
 
         # Drain pending copy ops from the KV cache manager.

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -69,6 +69,7 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
 
 from vllm_rbln.forward_context import set_forward_context
+from vllm_rbln.tracing import batch_span_attributes, start_batch_span
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
 
 if TYPE_CHECKING:
@@ -3739,7 +3740,23 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 LoRAInputs.set_sampler_indices_padded(sampler_indices_padded)
 
             model_start_time = time.perf_counter()
-            with capture_ctx as reports:
+            span_attributes = batch_span_attributes(
+                scheduler_output.num_scheduled_tokens
+            )
+            span_attributes["vllm.execution_phase"] = (
+                "prefill" if is_prefill_phase else "decode"
+            )
+            with (
+                capture_ctx as reports,
+                start_batch_span(
+                    "vllm.model_forward",
+                    enabled=self.observability_config.collect_model_forward_time,
+                    request_trace_headers=getattr(
+                        scheduler_output, "request_trace_headers", {}
+                    ),
+                    attributes=span_attributes,
+                ),
+            ):
                 model_output = self.model_executable(
                     input_ids=input_ids,
                     positions=positions,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -65,6 +65,7 @@ from vllm_rbln.distributed.kv_transfer.kv_connector.v1.utils import (
     finalize_kv_cache_registrations,
 )
 from vllm_rbln.logger import init_logger
+from vllm_rbln.tracing import batch_span_attributes, start_batch_span
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.v1.worker.utils import (
     estimate_available_memory,
@@ -579,7 +580,22 @@ class RBLNWorker(WorkerBase):
                 get_pp_group().recv_tensor_dict()
             )
 
-        output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)
+        span_attributes = batch_span_attributes(scheduler_output.num_scheduled_tokens)
+        span_attributes["vllm.worker_rank"] = self.rank
+        with start_batch_span(
+            "vllm.model_execute",
+            enabled=(
+                forward_pass
+                and self.vllm_config.observability_config.collect_model_execute_time
+            ),
+            request_trace_headers=getattr(
+                scheduler_output, "request_trace_headers", {}
+            ),
+            attributes=span_attributes,
+        ):
+            output = self.model_runner.execute_model(
+                scheduler_output, intermediate_tensors
+            )
         if isinstance(output, ModelRunnerOutput | NoneType):
             return output
 


### PR DESCRIPTION
### Summary of Changes

- Propagate per-request W3C trace headers from both RBLN schedulers to workers.
- Emit `vllm.model_execute` and nested `vllm.model_forward` spans for the vLLM-native and Optimum execution paths.
- Model batched execution with Span Links to every request context instead of selecting an incorrect single parent.
- Size the default OTel link limit from `max_num_seqs` before worker tracer initialization so large batches keep all correlations.
- Keep tracing optional and add NPU-free coverage for propagation, link construction, no-op behavior, and worker span boundaries.

---

### Related Issues / Tickets

* Resolves #785

---

### Type of Change

* [x] Feature (`feature`)
* [x] Core engine changes (`core`)

---

### How to Test

1. Run `TORCH_DEVICE_BACKEND_AUTOLOAD=0 uv run pytest -q tests/torch_compile/unit/test_tracing.py tests/v1/core/test_scheduler.py tests/torch_compile/unit/v1/core/test_scheduler.py tests/torch_compile/unit/v1/worker/test_rbln_worker.py`.
2. Run `TORCH_DEVICE_BACKEND_AUTOLOAD=0 uv run pytest -q tests/torch_compile/unit/test_platform.py tests/v1/worker/test_rebel_optimum_model_runner.py`.
3. Verify all scheduler, worker, tracing, platform, and Optimum runner tests pass.

---

### Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (not applicable; this implements existing vLLM CLI flags)

---

### Notes

A physical model execution can serve multiple requests, so the batch span intentionally starts without choosing a request parent and carries one Span Link per unique request context. `vllm.model_forward` inherits `vllm.model_execute` as its parent.
