### PR TITLE
feature(core): add VLLM_RBLN_MOE_PD_MIX to serialize cross-DP prefill/decode mixed steps

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_pd_phase_serialize.py
+++ b/tests/torch_compile/unit/v1/worker/test_pd_phase_serialize.py
@@ -1,0 +1,110 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for VLLM_RBLN_MOE_PD_MIX=0: cross-DP mixed prefill/decode steps are
+serialized into two phase-pure forwards via the _pd_phase_vote pre-vote."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_rbln.forward_context import RBLNDPMetadata
+from vllm_rbln.v1.worker.rbln_model_runner import (
+    PD_PHASE_DECODE,
+    PD_PHASE_IDLE,
+    PD_PHASE_PREFILL,
+    RBLNModelRunner,
+)
+
+
+def _stub(dp_size=2, serialize=True):
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                data_parallel_size=dp_size,
+                data_parallel_rank=0,
+            )
+        ),
+        serialize_pd_phases=serialize,
+        dummy_run=MagicMock(),
+    )
+
+
+def _patch_votes(per_rank_votes):
+    return patch.object(
+        RBLNDPMetadata,
+        "num_tokens_across_dp",
+        return_value=torch.tensor(per_rank_votes, dtype=torch.int32),
+    )
+
+
+@pytest.mark.parametrize(
+    "votes,expected_mixed",
+    [
+        ([PD_PHASE_PREFILL, PD_PHASE_DECODE], True),
+        ([PD_PHASE_PREFILL, PD_PHASE_DECODE, PD_PHASE_IDLE], True),
+        ([PD_PHASE_DECODE, PD_PHASE_DECODE], False),
+        ([PD_PHASE_PREFILL, PD_PHASE_PREFILL], False),
+        ([PD_PHASE_PREFILL, PD_PHASE_IDLE], False),
+        ([PD_PHASE_IDLE, PD_PHASE_IDLE], False),
+    ],
+)
+def test_pd_phase_vote_mixed_detection(votes, expected_mixed):
+    stub = _stub(dp_size=len(votes))
+    with _patch_votes(votes):
+        assert RBLNModelRunner._pd_phase_vote(stub, PD_PHASE_IDLE) is expected_mixed
+
+
+def test_idle_rank_runs_two_dummies_on_mixed_step():
+    stub = _stub()
+    stub._pd_phase_vote = MagicMock(return_value=True)
+    RBLNModelRunner.execute_dummy_batch(stub)
+    assert stub.dummy_run.call_count == 2
+    stub._pd_phase_vote.assert_called_once_with(PD_PHASE_IDLE)
+
+
+def test_idle_rank_runs_one_dummy_on_uniform_step():
+    stub = _stub()
+    stub._pd_phase_vote = MagicMock(return_value=False)
+    RBLNModelRunner.execute_dummy_batch(stub)
+    assert stub.dummy_run.call_count == 1
+
+
+def test_idle_rank_skips_vote_when_mix_allowed():
+    stub = _stub(serialize=False)
+    stub._pd_phase_vote = MagicMock()
+    RBLNModelRunner.execute_dummy_batch(stub)
+    stub._pd_phase_vote.assert_not_called()
+    assert stub.dummy_run.call_count == 1
+
+
+def test_prefill_rank_fires_phase2_dummy_after_sampling():
+    stub = _stub()
+    stub._pd_phase2_pending = True
+    stub._sample_tokens_impl = MagicMock(return_value="output")
+    result = RBLNModelRunner.sample_tokens(stub, None)
+    assert result == "output"
+    assert stub._pd_phase2_pending is False
+    # The dummy run (phase 2) fires after the real sampling/propose.
+    stub.dummy_run.assert_called_once()
+
+
+def test_no_phase2_dummy_when_not_pending():
+    stub = _stub()
+    stub._pd_phase2_pending = False
+    stub._sample_tokens_impl = MagicMock(return_value="output")
+    RBLNModelRunner.sample_tokens(stub, None)
+    stub.dummy_run.assert_not_called()

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -1211,7 +1211,7 @@ class TestMisc:
         worker = _create_worker()
         worker.model_runner = MagicMock()
         worker.execute_dummy_batch()
-        worker.model_runner.dummy_run.assert_called_once()
+        worker.model_runner.execute_dummy_batch.assert_called_once()
 
     def test_take_draft_token_ids(self):
         worker = _create_worker()

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_LOGITS_ALL_GATHER: bool = True
     # --- DATA PARALLEL ---
     VLLM_RBLN_DP_IMPL: str = "padded_decode"
+    VLLM_RBLN_MOE_PD_MIX: bool = True
     # --- MOE ---
     VLLM_RBLN_SPECIALIZE_MOE_DECODE: bool = True
     VLLM_RBLN_USE_MOE_TOKENS_MASK: bool = True
@@ -354,6 +355,17 @@ environment_variables = {
     # --- DATA PARALLEL ---
     # DP implementation, see choices in get_dp_impl
     "VLLM_RBLN_DP_IMPL": get_dp_impl,
+    # If true (default), a DP step may mix prefill on one rank with padded
+    # decode on the others, so MoE kernels see prefill and decode tokens in
+    # the same forward. If false, such mixed steps are serialized into two
+    # phase-pure forwards: prefill runs first (decode ranks join collectives
+    # via a dummy run), then decode runs on the specialized decode path
+    # (prefill ranks join via a dummy run).
+    "VLLM_RBLN_MOE_PD_MIX": (
+        lambda: (
+            os.environ.get("VLLM_RBLN_MOE_PD_MIX", "True").lower() in ("true", "1")
+        )
+    ),
     # --- MOE ---
     # If true, it specializes the cases where all instances are at decode stage
     "VLLM_RBLN_SPECIALIZE_MOE_DECODE": (

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -163,6 +163,12 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# Per-rank phase codes for the serialize_pd_phases pre-vote collective
+# (see RBLNModelRunner._pd_phase_vote).
+PD_PHASE_IDLE = 0
+PD_PHASE_DECODE = 1
+PD_PHASE_PREFILL = 2
+
 
 def scrub_scheduler_output_for_no_spec(
     scheduler_output: "SchedulerOutput",
@@ -344,6 +350,10 @@ class DummyRunState(NamedTuple):
 
 
 class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
+    # Class-level default so sample_tokens() is safe even on instances built
+    # without __init__ (tests); real value is set per-step in execute_model.
+    _pd_phase2_pending = False
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -719,6 +729,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.specialized_moe_decode = (
             parallel_config.data_parallel_size > 1
             and envs.VLLM_RBLN_SPECIALIZE_MOE_DECODE
+        )
+
+        # VLLM_RBLN_MOE_PD_MIX=0: serialize cross-DP mixed prefill/decode
+        # steps into two phase-pure forwards (see _pd_phase_vote).
+        self.serialize_pd_phases = (
+            parallel_config.data_parallel_size > 1 and not envs.VLLM_RBLN_MOE_PD_MIX
         )
 
     def _enable_performance_tracker(self):
@@ -3109,6 +3125,28 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 batch_bucket_size=batch_bucket_size,
             )
 
+    def _pd_phase_vote(self, local_phase: int) -> bool:
+        """Cross-DP pre-vote run once per step by EVERY rank (busy or idle)
+        when serialize_pd_phases is on. Returns True when this step is mixed
+        (some rank prefills while another decodes), i.e. it must be
+        serialized into a prefill phase and a decode phase.
+        """
+        votes = RBLNDPMetadata.num_tokens_across_dp(
+            local_phase,
+            self.vllm_config.parallel_config.data_parallel_size,
+            self.vllm_config.parallel_config.data_parallel_rank,
+        )
+        return bool((votes == PD_PHASE_PREFILL).any()) and bool(
+            (votes == PD_PHASE_DECODE).any()
+        )
+
+    def execute_dummy_batch(self) -> None:
+        """Entry point for a DP-idle rank's step (called by the worker)."""
+        if self.serialize_pd_phases and self._pd_phase_vote(PD_PHASE_IDLE):
+            # Mixed step: peers run two phase-pure forwards; join both.
+            self.dummy_run()
+        self.dummy_run()
+
     def _bookkeeping_sync(
         self,
         scheduler_output: "SchedulerOutput",
@@ -3421,6 +3459,24 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     "prompt tokens, tokens, please disable it when the requests"
                     " need prompt logprobs"
                 )
+
+            if self.serialize_pd_phases:
+                local_prefill = self.is_prefill_phase()
+                mixed = self._pd_phase_vote(
+                    PD_PHASE_PREFILL if local_prefill else PD_PHASE_DECODE
+                )
+                if mixed and local_prefill:
+                    # Phase 1 is this rank's real prefill; the decode-phase
+                    # dummy run fires at the end of sample_tokens(), after
+                    # the real drafter propose (collective ordering).
+                    self._pd_phase2_pending = True
+                elif mixed:
+                    # Join the peers' prefill phase with a dummy run, then
+                    # fall through to run the real decode as phase 2. The
+                    # phase-2 shape collective below then sees no prefill
+                    # rank (prefill peers vote idle via their own dummy
+                    # run), so decode takes the specialized unmixed path.
+                    self.dummy_run()
 
             num_reqs = self.input_batch.num_reqs
             req_ids = self.input_batch.req_ids
@@ -3891,6 +3947,18 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     @torch.inference_mode()
     def sample_tokens(
+        self, grammar_output: "GrammarOutput | None"
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
+        try:
+            return self._sample_tokens_impl(grammar_output)
+        finally:
+            if self._pd_phase2_pending:
+                # Serialized mixed step, prefill rank: phase 1 (real prefill
+                # + propose) is done; join the peers' decode phase.
+                self._pd_phase2_pending = False
+                self.dummy_run()
+
+    def _sample_tokens_impl(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         if self.execute_model_state is None:

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -628,7 +628,7 @@ class RBLNWorker(WorkerBase):
 
     def execute_dummy_batch(self) -> None:
         self._ensure_rbln_host_threads_before_compile()
-        self.model_runner.dummy_run()
+        self.model_runner.execute_dummy_batch()
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)


### PR DESCRIPTION
### 🚀 Summary of Changes

Adds `VLLM_RBLN_MOE_PD_MIX` (default `True` = current behavior). Setting it to `0` serializes a DP step that mixes prefill on one rank with padded decode on the others into **two phase-pure forwards**, so MoE kernels never see prefill and decode tokens in the same forward.

How it works when `VLLM_RBLN_MOE_PD_MIX=0`:

* Every rank (busy or idle) runs a per-step **phase pre-vote** collective (`_pd_phase_vote`) so all ranks detect a mixed step deterministically before any other collective.
* On a mixed step:
  * **Decode ranks** first join the peers' prefill phase via the existing `dummy_run()`, then run their real decode. The phase-2 shape collective then sees no prefill rank, so decode takes the specialized unmixed decode path.
  * **Prefill ranks** run their real prefill, then join the decode phase via `dummy_run()` at the end of `sample_tokens()` — after the real drafter propose — preserving per-rank DP collective ordering (fwd → propose per phase).
  * **Idle ranks** run two dummy runs.
* Non-mixed steps and the default (`=1`) are unchanged.

Reuses the existing DP dummy-run infrastructure and already warmed-up graphs (padded-decode graph for phase-1 dummies, decode bucket graphs for phase-2 dummies); no new compilation is required. Cost when disabled: one extra dummy forward per rank per mixed step, plus one small CPU pre-vote all-reduce per step.

---

### 📌 Related Issues / Tickets

* Related to #

---

### ✅ Type of Change

* [x] ✨ Feature (`feature`)
* [x] 🧬 Core engine changes (`core`)

---

### 🧪 How to Test

1. Run `pytest tests/torch_compile/unit/v1/worker/test_pd_phase_serialize.py` — covers mixed-step detection in the pre-vote, the idle rank's double dummy run, and the prefill rank's deferred phase-2 dummy after sampling.
2. Run a DP≥2 MoE serving workload with `VLLM_RBLN_MOE_PD_MIX=0` and mixed prefill/decode traffic; verify identical outputs vs default and that decode steps overlapping a peer prefill hit the specialized decode runtime (no padded-mix `MODEL+SAMPLER` entries under `VLLM_RBLN_METRICS=1`).
3. Edge case tested: spec decode (drafter propose ordering), idle DP ranks, warm-up (phase-uniform steps never trigger serialization).

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

* The scheduler cannot synchronize phases across DP ranks (per-rank engine processes), so serialization is done at the runner level using the existing dummy-run collective-participation machinery. All pairwise graph/collective alignments used here (real prefill ↔ dummy padded decode, real specialized decode ↔ dummy decode) already occur in production today with idle ranks.
* Unit suite: targeted worker/DP tests pass (353 passed locally). Full `tests/torch_compile/unit` run on this machine shows some pre-existing environment-dependent failures/errors unrelated to this change; the two failures introduced during development (stub without `__init__`, worker delegation assert) were fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)