### PR TITLE
fix(sampler): disable caching sampler

### DIFF
--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
@@ -80,6 +81,7 @@ def compile(
     mode: str | list[str] = "",
     use_global_ctx: bool | None = None,
     global_device_id: int | None = None,
+    use_cache: bool = True,
     cache_dir: str = "",
 ) -> CompiledTarget:
     _ensure_torch_dynamo_configured()
@@ -104,9 +106,8 @@ def compile(
     set_option("mode", mode)
     set_option("use_global_ctx", use_global_ctx)
     set_option("global_device_id", global_device_id)
-    # if not envs.VLLM_DISABLE_COMPILE_CACHE:
-    #     set_option("cache_dir",
-    # cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
+    if use_cache and not envs.VLLM_DISABLE_COMPILE_CACHE:
+        set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
 
     return cast(
         CompiledTarget,

--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -105,8 +105,8 @@ def compile(
     set_option("mode", mode)
     set_option("use_global_ctx", use_global_ctx)
     set_option("global_device_id", global_device_id)
-    if not envs.VLLM_DISABLE_COMPILE_CACHE:
-        set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
+    # if not envs.VLLM_DISABLE_COMPILE_CACHE:
+    #     set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
 
     return cast(
         CompiledTarget,

--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
@@ -106,7 +105,8 @@ def compile(
     set_option("use_global_ctx", use_global_ctx)
     set_option("global_device_id", global_device_id)
     # if not envs.VLLM_DISABLE_COMPILE_CACHE:
-    #     set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
+    #     set_option("cache_dir",
+    # cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
 
     return cast(
         CompiledTarget,

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Callable
 from typing import Any
 
 import rebel
@@ -25,7 +26,7 @@ from vllm.v1.sample.sampler import Sampler as VLLMSampler
 import vllm_rbln.envs as envs
 from vllm_rbln.compilation import compile, create_compile_context
 from vllm_rbln.logger import init_logger
-from vllm_rbln.platform import HAS_TORCH_RBLN, USE_DEVICE_TENSOR
+from vllm_rbln.platform import USE_DEVICE_TENSOR
 from vllm_rbln.v1.sample.ops.logprobs import batched_count_greater_than
 from vllm_rbln.v1.sample.ops.penalties import (
     apply_all_penalties as rbln_apply_all_penalties,
@@ -59,6 +60,32 @@ def rbln_greedy_sample(logits: torch.Tensor) -> torch.Tensor:
     return torch.ops.rbln.argmax(logits)
 
 
+def compile_sampler(
+    op: Callable[..., torch.Tensor],
+    compile_context: rebel.CompileContext | None,
+) -> Callable[..., torch.Tensor]:
+    compile_context = (
+        compile_context
+        or create_compile_context(
+            use_global_ctx=True,
+        )
+        if not USE_DEVICE_TENSOR
+        else None
+    )
+    return compile(
+        op,
+        dynamic=False,
+        fullgraph=True,
+        compile_context=compile_context,
+        num_devices=1,
+        model_trace_method="export" if USE_DEVICE_TENSOR else "",
+        mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
+        use_global_ctx=None if USE_DEVICE_TENSOR else True,
+        global_device_id=None if USE_DEVICE_TENSOR else 0,
+        use_cache=False,
+    )
+
+
 class RBLNTopKTopPSampler(nn.Module):
     def __init__(
         self,
@@ -82,16 +109,8 @@ class RBLNTopKTopPSampler(nn.Module):
             if not USE_DEVICE_TENSOR
             else None
         )
-        self._compiled_rbln_topk_topp_sampler = compile(
-            rbln_top_k_top_p_sample,
-            dynamic=False,
-            fullgraph=True,
-            compile_context=compile_context,
-            num_devices=1 if USE_DEVICE_TENSOR or HAS_TORCH_RBLN else None,
-            model_trace_method="export" if USE_DEVICE_TENSOR else "",
-            mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
-            use_global_ctx=True if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
-            global_device_id=0 if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
+        self._compiled_rbln_topk_topp_sampler = compile_sampler(
+            rbln_top_k_top_p_sample, compile_context
         )
 
     @torch.compiler.disable
@@ -143,13 +162,8 @@ class RBLNSampler(VLLMSampler):
                 "Using native sampler instead."
             )
 
-        self._compiled_greedy_sample = compile(
-            rbln_greedy_sample,
-            dynamic=False,
-            fullgraph=True,
-            compile_context=compile_context,
-            num_devices=1 if USE_DEVICE_TENSOR or HAS_TORCH_RBLN else None,
-            mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
+        self._compiled_greedy_sample = compile_sampler(
+            rbln_greedy_sample, compile_context
         )
 
     @torch.compiler.disable

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -82,6 +82,8 @@ def compile_sampler(
         mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
         use_global_ctx=True if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
         global_device_id=0 if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
+        # FIXME: Currently, sampler ops do not support caching.
+        # Reusing seed buffer is not supported when the compiled sampler is loaded.
         use_cache=False,
     )
 

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -101,14 +101,6 @@ class RBLNTopKTopPSampler(nn.Module):
             "RBLN Sampling does not support returning logits/logprobs"
         )
 
-        compile_context = (
-            compile_context
-            or create_compile_context(
-                use_global_ctx=True,
-            )
-            if not USE_DEVICE_TENSOR
-            else None
-        )
         self._compiled_rbln_topk_topp_sampler = compile_sampler(
             rbln_top_k_top_p_sample, compile_context
         )

--- a/vllm_rbln/v1/sample/rbln_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_sampler.py
@@ -26,7 +26,7 @@ from vllm.v1.sample.sampler import Sampler as VLLMSampler
 import vllm_rbln.envs as envs
 from vllm_rbln.compilation import compile, create_compile_context
 from vllm_rbln.logger import init_logger
-from vllm_rbln.platform import USE_DEVICE_TENSOR
+from vllm_rbln.platform import HAS_TORCH_RBLN, USE_DEVICE_TENSOR
 from vllm_rbln.v1.sample.ops.logprobs import batched_count_greater_than
 from vllm_rbln.v1.sample.ops.penalties import (
     apply_all_penalties as rbln_apply_all_penalties,
@@ -77,11 +77,11 @@ def compile_sampler(
         dynamic=False,
         fullgraph=True,
         compile_context=compile_context,
-        num_devices=1,
+        num_devices=1 if USE_DEVICE_TENSOR or HAS_TORCH_RBLN else None,
         model_trace_method="export" if USE_DEVICE_TENSOR else "",
         mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
-        use_global_ctx=None if USE_DEVICE_TENSOR else True,
-        global_device_id=None if USE_DEVICE_TENSOR else 0,
+        use_global_ctx=True if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
+        global_device_id=0 if HAS_TORCH_RBLN and not USE_DEVICE_TENSOR else None,
         use_cache=False,
     )
 

--- a/vllm_rbln/v1/worker/optimum_model_runner.py
+++ b/vllm_rbln/v1/worker/optimum_model_runner.py
@@ -1007,6 +1007,9 @@ class RBLNOptimumModelRunner(
         pass
 
     def dummy_sampler_run(self):
+        if self.is_pooling_model:
+            logger.info("Skip dummy sampler run for pooling model.")
+            return
         if not self.use_rbln_sampler:
             logger.info(
                 "Skip dummy sampler run since it is only used in RBLN_SAMPLER=1"


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

1. Skip caching sampler
    - The common `compile` method triggers caching sampler.
2. Refactor the parameters of `compile`
    - It is better to use same parameters for greedy op and topk_topp_sampler.
3. Skip sampler warm-up in pooler models

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
4. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
