### PR TITLE
fix(worker): dump final performance stats before shutdown teardown

### DIFF
--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -594,13 +594,21 @@ class RBLNWorker(WorkerBase):
         return
 
     def shutdown(self) -> None:
+        # Dump the final performance stats FIRST, before any teardown. EngineCore
+        # is shut down with a zero-second grace period, so this method runs inside
+        # a window where the worker process may be reaped at any moment.
+        # print_stats() only reads already-collected host-side counters (no device
+        # / KV / model access), so it is safe to run before the teardown steps
+        # below. Running blocking teardown such as ensure_kv_transfer_shutdown()
+        # ahead of it consumed the whole grace window and truncated (or fully
+        # dropped, for P/D engines) the dump.
+        self.model_runner.performance_ctx.print_stats()
+
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:
             ensure_kv_transfer_shutdown()
         if self.profiler is not None:
             self.profiler.shutdown()
-
-        self.model_runner.performance_ctx.print_stats()
 
     def _ensure_rbln_host_threads_before_compile(self) -> None:
         """Set OpenMP / torch / numba threads before ``warm_up_model()`` without


### PR DESCRIPTION
### 🚀 Summary of Changes

`RBLNWorker.shutdown()` (the vLLM-native path worker, `VLLM_RBLN_USE_VLLM_MODEL=1`) ran `ensure_kv_transfer_shutdown()` and the profiler shutdown **before** `self.model_runner.performance_ctx.print_stats()`. EngineCore is torn down with a **zero-second grace period**, so the teardown consumed the whole window and the final performance-stats dump was **truncated — or, for P/D-disaggregated engines, dropped entirely**.

This moves `print_stats()` **ahead of** the teardown. It only reads already-collected host-side counters (no device / KV / model access), so it is safe to run first.

```python
def shutdown(self) -> None:
    self.model_runner.performance_ctx.print_stats()   # FIRST — survives the zero-grace window
    if ensure_kv_transfer_shutdown is not None:
        ensure_kv_transfer_shutdown()
    if self.profiler is not None:
        self.profiler.shutdown()
```

### 📌 Context

Re-authored against the refactored `dev` (metrics_v2 `performance_ctx`). This **supersedes the earlier closed PR #748**, whose commit was lost when `dev` was overwritten by the refactor branch. Same root cause (shutdown-race), adapted to the new `performance_ctx.print_stats()` API.

Used by the daily gpt-oss-120b regression harness (fsw-inference #366) to capture static perf across serve shutdown.

### ✅ Type of Change
* [x] 🛠 Bug fix (`fix`)

### 🧪 How to Test
1. Serve on the vLLM-native path (`VLLM_RBLN_USE_VLLM_MODEL=1`), run a bench, then stop.
2. Confirm the `PERFORMANCE STATISTICS [runner]` block (MODEL PREFILL/DECODE, SAMPLER) appears complete in the worker log at shutdown — previously it was truncated/missing under P/D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)