### PR TITLE
feature(metrics): rework metrics_v2 performance reporting

### DIFF
--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_ENABLE_WARM_UP: bool = True
     VLLM_RBLN_METRICS: bool = False
     VLLM_RBLN_METRICS_FILE: str = ""
+    VLLM_RBLN_METRICS_DIR: str = ""
     VLLM_RBLN_NUMA: bool = True
 
     # ====================================================================
@@ -223,6 +224,8 @@ environment_variables = {
     # The worker pid is appended before the extension to keep TP/DP workers
     # from clobbering each other. Empty disables file output.
     "VLLM_RBLN_METRICS_FILE": lambda: os.environ.get("VLLM_RBLN_METRICS_FILE", ""),
+    # Directory for per-worker JSON performance reports (empty disables).
+    "VLLM_RBLN_METRICS_DIR": lambda: os.environ.get("VLLM_RBLN_METRICS_DIR", ""),
     # Enable NUMA-based CPU affinity binding for OpenMP threads
     "VLLM_RBLN_NUMA": (
         lambda: os.environ.get("VLLM_RBLN_NUMA", "True").lower() in ("true", "1")

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -284,9 +284,15 @@ def _write_metrics_json(
     }
 
     try:
+        payload_str = json.dumps(payload, indent=2)
+    except (TypeError, ValueError) as e:
+        logger.warning("Failed to serialize metrics JSON: %s", e)
+        return
+
+    try:
         os.makedirs(envs.VLLM_RBLN_METRICS_DIR, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(payload, f, indent=2)
+            f.write(payload_str)
     except OSError as e:
         logger.warning("Failed to write metrics JSON to %s: %s", path, e)
 

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -146,11 +146,15 @@ class _TimingSpan:
     def __exit__(self, *args):
         # Record time before closing capture_ctx to exclude any internal
         # synchronization overhead inside rebel from the measured latency.
-        latency = time.perf_counter() - self._start
+        end = time.perf_counter()
+        latency = end - self._start
         self._capture_ctx.__exit__(*args)
         host, device, ccl, prepare = _parse_reports(self._reports)
         self._ctx._submit(
-            _Sample(latency, host, device, ccl, prepare, self._phase), self._is_sampler
+            _Sample(latency, host, device, ccl, prepare, self._phase),
+            self._is_sampler,
+            self._start,
+            end,
         )
         return False
 
@@ -171,6 +175,8 @@ class _PerformanceContext:
         self.rank_tag = _rank_tag()
         self._metrics: dict[bool, Metrics] = defaultdict(Metrics)
         self._pending: _Sample | None = None
+        self._e2e_start: float | None = None
+        self._e2e: dict[bool, Metrics] = defaultdict(Metrics)
 
     def profile_model(self, is_prefill: bool) -> _TimingSpan:
         # A prior model step with no sampler (intermediate chunked prefill,
@@ -181,19 +187,26 @@ class _PerformanceContext:
     def profile_sampler(self) -> _TimingSpan:
         return _TimingSpan(self, phase=None, is_sampler=True)
 
-    def _submit(self, sample: _Sample, is_sampler: bool) -> None:
+    def _submit(
+        self, sample: _Sample, is_sampler: bool, start: float, end: float
+    ) -> None:
         if not is_sampler:
             self._pending = sample  # model: stash, wait for the sampler
+            self._e2e_start = start
             return
         if self._pending is None:
             return  # sampler with no preceding model step; ignore
         self._record(self._pending.merged(sample))
+        if self._e2e_start is not None:
+            self._e2e[bool(self._pending.phase)].record(end - self._e2e_start)
         self._pending = None
+        self._e2e_start = None
 
     def _flush_pending(self) -> None:
         if self._pending is not None:
             self._record(self._pending)
             self._pending = None
+        self._e2e_start = None
 
     def _record(self, s: _Sample) -> None:
         self._metrics[bool(s.phase)].record(
@@ -202,10 +215,11 @@ class _PerformanceContext:
 
     def print_stats(self) -> None:
         self._flush_pending()  # record the final step if it had no sampler
-        sections = {
-            ("PREFILL + SAMPLE" if phase else "DECODE + SAMPLE"): m
-            for phase, m in sorted(self._metrics.items(), key=lambda x: not x[0])
-        }
+        sections: dict[str, Metrics] = {}
+        for phase, m in sorted(self._metrics.items(), key=lambda x: not x[0]):
+            sections["PREFILL + SAMPLE" if phase else "DECODE + SAMPLE"] = m
+        for phase, m in sorted(self._e2e.items(), key=lambda x: not x[0]):
+            sections["PREFILL E2E" if phase else "DECODE E2E"] = m
         name = f"{self.name} | {self.rank_tag}" if self.rank_tag else self.name
         _report_metrics(name, sections)
         _write_metrics_json(self.name, self.rank_tag, sections)

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -18,7 +18,6 @@ import time
 from collections import defaultdict
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import TypeVar
 
 import numpy as np
@@ -89,6 +88,31 @@ class Metrics:
         return stats
 
 
+@dataclass
+class _Sample:
+    """One span's timing, summable across model+sampler within a step."""
+
+    latency: float
+    host: int | None = None
+    device: int | None = None
+    ccl: int | None = None
+    prepare: int | None = None
+    phase: bool | None = None  # True=prefill, False=decode (set by the model span)
+
+    def merged(self, other: "_Sample") -> "_Sample":
+        def _add(a: int | None, b: int | None) -> int | None:
+            return None if a is None and b is None else (a or 0) + (b or 0)
+
+        return _Sample(
+            latency=self.latency + other.latency,
+            host=_add(self.host, other.host),
+            device=_add(self.device, other.device),
+            ccl=_add(self.ccl, other.ccl),
+            prepare=_add(self.prepare, other.prepare),
+            phase=self.phase,  # keep the model step's phase
+        )
+
+
 try:
     import rebel  # type: ignore
 
@@ -98,10 +122,14 @@ except ImportError:
 
 
 class _TimingSpan:
-    __slots__ = ("_metrics", "_reports", "_start", "_capture_ctx")
+    __slots__ = ("_ctx", "_phase", "_is_sampler", "_reports", "_start", "_capture_ctx")
 
-    def __init__(self, metrics: Metrics) -> None:
-        self._metrics = metrics
+    def __init__(
+        self, ctx: "_PerformanceContext", phase: bool | None, is_sampler: bool
+    ) -> None:
+        self._ctx = ctx
+        self._phase = phase
+        self._is_sampler = is_sampler
         self._reports: list[dict] | None = None
         self._start = 0.0
 
@@ -121,7 +149,9 @@ class _TimingSpan:
         latency = time.perf_counter() - self._start
         self._capture_ctx.__exit__(*args)
         host, device, ccl, prepare = _parse_reports(self._reports)
-        self._metrics.record(latency, host, device, ccl, prepare)
+        self._ctx._submit(
+            _Sample(latency, host, device, ccl, prepare, self._phase), self._is_sampler
+        )
         return False
 
 
@@ -135,42 +165,46 @@ class _NoopSpan:
         return False
 
 
-class ProfileSection(Enum):
-    MODEL = ("model", True)  # tracked separately per phase (prefill / decode)
-    SAMPLER = ("sampler", False)  # phase-agnostic; recorded into a single bucket
-
-    def __init__(self, label: str, split_phase: bool) -> None:
-        self.label = label
-        self.split_phase = split_phase
-
-
 class _PerformanceContext:
     def __init__(self, name: str | None = None) -> None:
         self.name = name
         self.rank_tag = _rank_tag()
-        self._metrics: dict[tuple[ProfileSection, bool | None], Metrics] = defaultdict(
-            Metrics
+        self._metrics: dict[bool, Metrics] = defaultdict(Metrics)
+        self._pending: _Sample | None = None
+
+    def profile_model(self, is_prefill: bool) -> _TimingSpan:
+        # A prior model step with no sampler (intermediate chunked prefill,
+        # non-last PP rank) leaves a pending report; record it model-only here.
+        self._flush_pending()
+        return _TimingSpan(self, phase=is_prefill, is_sampler=False)
+
+    def profile_sampler(self) -> _TimingSpan:
+        return _TimingSpan(self, phase=None, is_sampler=True)
+
+    def _submit(self, sample: _Sample, is_sampler: bool) -> None:
+        if not is_sampler:
+            self._pending = sample  # model: stash, wait for the sampler
+            return
+        if self._pending is None:
+            return  # sampler with no preceding model step; ignore
+        self._record(self._pending.merged(sample))
+        self._pending = None
+
+    def _flush_pending(self) -> None:
+        if self._pending is not None:
+            self._record(self._pending)
+            self._pending = None
+
+    def _record(self, s: _Sample) -> None:
+        self._metrics[bool(s.phase)].record(
+            s.latency, s.host, s.device, s.ccl, s.prepare
         )
 
-    def profile(
-        self,
-        is_prefill: bool = False,
-        section: ProfileSection = ProfileSection.MODEL,
-    ) -> _TimingSpan:
-        phase = is_prefill if section.split_phase else None
-        return _TimingSpan(self._metrics[(section, phase)])
-
     def print_stats(self) -> None:
-        def _label(section: ProfileSection, phase: bool | None) -> str:
-            if phase is None:
-                return section.label.upper()
-            return f"{section.label.upper()} {'PREFILL' if phase else 'DECODE'}"
-
+        self._flush_pending()  # record the final step if it had no sampler
         sections = {
-            _label(s, p): m
-            for (s, p), m in sorted(
-                self._metrics.items(), key=lambda x: (x[0][0].value, not x[0][1])
-            )
+            ("PREFILL + SAMPLE" if phase else "DECODE + SAMPLE"): m
+            for phase, m in sorted(self._metrics.items(), key=lambda x: not x[0])
         }
         name = f"{self.name} | {self.rank_tag}" if self.rank_tag else self.name
         _report_metrics(name, sections)
@@ -181,7 +215,10 @@ class _NoopPerformanceContext:
     def __init__(self, name: str | None = None) -> None:
         pass
 
-    def profile(self, *args, **kwargs) -> _NoopSpan:
+    def profile_model(self, *args, **kwargs) -> _NoopSpan:
+        return _NoopSpan()
+
+    def profile_sampler(self, *args, **kwargs) -> _NoopSpan:
         return _NoopSpan()
 
     def print_stats(self) -> None:

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import time
 from collections import defaultdict
@@ -19,6 +20,8 @@ from contextlib import nullcontext
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TypeVar
+
+import numpy as np
 
 from vllm_rbln import envs
 from vllm_rbln.logger import init_logger
@@ -30,7 +33,6 @@ T = TypeVar("T", int, float)
 @dataclass
 class Metrics:
     latencies: list[float] = field(default_factory=list)
-    token_counts: list[int] = field(default_factory=list)
     host_times: list[int] = field(default_factory=list)
     device_times: list[int] = field(default_factory=list)
     ccl_times: list[int] = field(default_factory=list)
@@ -39,14 +41,12 @@ class Metrics:
     def record(
         self,
         latency: float,
-        token_count: int,
         host_time: int | None = None,
         device_time: int | None = None,
         ccl_time: int | None = None,
         prepare_time: int | None = None,
     ) -> None:
         self.latencies.append(latency)
-        self.token_counts.append(token_count)
         if host_time is not None:
             self.host_times.append(host_time)
         if device_time is not None:
@@ -60,40 +60,33 @@ class Metrics:
     def call_count(self) -> int:
         return len(self.latencies)
 
-    def _drop_outlier(self, values: list[T]) -> list[T]:
-        if len(values) <= 1:
-            return values
-        mean = sum(values) / len(values)
-        worst = max(range(len(values)), key=lambda i: abs(values[i] - mean))
-        return [v for i, v in enumerate(values) if i != worst]
+    def mean_latency_ms(self) -> float:
+        return _mean(self.latencies) * 1000
 
-    def _avg(self, values: list[T], drop_outlier: bool = True) -> float:
-        if drop_outlier:
-            values = self._drop_outlier(values)
-        return sum(values) / len(values) if values else 0.0
+    def latency_percentiles_ms(
+        self, percentiles: tuple[float, ...] = (50.0, 90.0, 99.0)
+    ) -> dict[str, float]:
+        if not self.latencies:
+            return {}
+        arr = np.asarray(self.latencies, dtype=float) * 1000.0
+        return {f"p{p:g}": float(np.percentile(arr, p)) for p in percentiles}
 
-    def avg_latency_ms(self, drop_outlier: bool = True) -> float:
-        return self._avg(self.latencies, drop_outlier) * 1000
-
-    def avg_throughput(self, drop_outlier: bool = True) -> float:
-        lats = self._drop_outlier(self.latencies) if drop_outlier else self.latencies
-        toks = (
-            self._drop_outlier(self.token_counts) if drop_outlier else self.token_counts
+    def to_dict(self) -> dict:
+        stats: dict = {
+            "call_count": self.call_count,
+            "mean_latency_ms": self.mean_latency_ms(),
+            "latency_percentiles_ms": self.latency_percentiles_ms(),
+        }
+        timings = (
+            ("mean_host_time_us", self.host_times),
+            ("mean_device_time_us", self.device_times),
+            ("mean_ccl_time_us", self.ccl_times),
+            ("mean_prepare_time_us", self.prepare_times),
         )
-        t = sum(lats)
-        return sum(toks) / t if t > 0 else 0.0
-
-    def avg_host_time_us(self, drop_outlier: bool = True) -> float:
-        return self._avg(self.host_times, drop_outlier)
-
-    def avg_device_time_us(self, drop_outlier: bool = True) -> float:
-        return self._avg(self.device_times, drop_outlier)
-
-    def avg_ccl_time_us(self, drop_outlier: bool = True) -> float:
-        return self._avg(self.ccl_times, drop_outlier)
-
-    def avg_prepare_time_us(self, drop_outlier: bool = True) -> float:
-        return self._avg(self.prepare_times, drop_outlier)
+        for key, values in timings:
+            if values:
+                stats[key] = _mean(values)
+        return stats
 
 
 try:
@@ -105,11 +98,10 @@ except ImportError:
 
 
 class _TimingSpan:
-    __slots__ = ("_metrics", "_token_count", "_reports", "_start", "_capture_ctx")
+    __slots__ = ("_metrics", "_reports", "_start", "_capture_ctx")
 
-    def __init__(self, metrics: Metrics, token_count: int) -> None:
+    def __init__(self, metrics: Metrics) -> None:
         self._metrics = metrics
-        self._token_count = token_count
         self._reports: list[dict] | None = None
         self._start = 0.0
 
@@ -129,7 +121,7 @@ class _TimingSpan:
         latency = time.perf_counter() - self._start
         self._capture_ctx.__exit__(*args)
         host, device, ccl, prepare = _parse_reports(self._reports)
-        self._metrics.record(latency, self._token_count, host, device, ccl, prepare)
+        self._metrics.record(latency, host, device, ccl, prepare)
         return False
 
 
@@ -155,6 +147,7 @@ class ProfileSection(Enum):
 class _PerformanceContext:
     def __init__(self, name: str | None = None) -> None:
         self.name = name
+        self.rank_tag = _rank_tag()
         self._metrics: dict[tuple[ProfileSection, bool | None], Metrics] = defaultdict(
             Metrics
         )
@@ -163,10 +156,9 @@ class _PerformanceContext:
         self,
         is_prefill: bool = False,
         section: ProfileSection = ProfileSection.MODEL,
-        token_count: int = 0,
     ) -> _TimingSpan:
         phase = is_prefill if section.split_phase else None
-        return _TimingSpan(self._metrics[(section, phase)], token_count)
+        return _TimingSpan(self._metrics[(section, phase)])
 
     def print_stats(self) -> None:
         def _label(section: ProfileSection, phase: bool | None) -> str:
@@ -180,7 +172,9 @@ class _PerformanceContext:
                 self._metrics.items(), key=lambda x: (x[0][0].value, not x[0][1])
             )
         }
-        _report_metrics(self.name, sections)
+        name = f"{self.name} | {self.rank_tag}" if self.rank_tag else self.name
+        _report_metrics(name, sections)
+        _write_metrics_json(self.name, self.rank_tag, sections)
 
 
 class _NoopPerformanceContext:
@@ -194,23 +188,56 @@ class _NoopPerformanceContext:
         pass
 
 
-def _metrics_file_path() -> str | None:
-    if not envs.VLLM_RBLN_METRICS_FILE:
-        return None
-
-    root, ext = os.path.splitext(envs.VLLM_RBLN_METRICS_FILE)
-    return f"{root}.{os.getpid()}{ext}"
-
-
-def _write_metrics_file(lines: list[str]) -> None:
-    if (path := _metrics_file_path()) is None:
-        return
+def _rank_tag() -> str:
+    """Rank tag including only parallelism axes with degree > 1; '' if none."""
+    parts = []
     try:
-        with open(path, "a", encoding="utf-8") as f:
-            f.write("\n".join(lines))
-            f.write("\n")
+        from vllm.distributed import get_pp_group, get_tp_group
+
+        tp = get_tp_group()
+        if tp.world_size > 1:
+            parts.append(f"TP{tp.rank_in_group}")
+        pp = get_pp_group()
+        if pp.world_size > 1:
+            parts.append(f"PP{pp.rank_in_group}")
+    except Exception:
+        return ""
+    try:
+        from vllm.distributed import get_dp_group
+
+        dp = get_dp_group()
+        if dp.world_size > 1:
+            parts.append(f"DP{dp.rank_in_group}")
+    except Exception:
+        pass  # DP group may not be initialized
+    return " ".join(parts)
+
+
+def _write_metrics_json(
+    name: str | None, rank_tag: str, sections: dict[str, Metrics]
+) -> None:
+    if not envs.VLLM_RBLN_METRICS_DIR:
+        return
+
+    suffix = rank_tag.replace(" ", "_").lower()
+    filename = f"metrics_{suffix}.json" if suffix else "metrics.json"
+    path = os.path.join(envs.VLLM_RBLN_METRICS_DIR, filename)
+    payload = {
+        "name": name,
+        "rank": rank_tag,
+        "sections": {label: m.to_dict() for label, m in sections.items()},
+    }
+
+    try:
+        os.makedirs(envs.VLLM_RBLN_METRICS_DIR, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
     except OSError as e:
-        logger.warning("Failed to write metrics to file %s: %s", path, e)
+        logger.warning("Failed to write metrics JSON to %s: %s", path, e)
+
+
+def _mean(values: list[T]) -> float:
+    return sum(values) / len(values) if values else 0.0
 
 
 def _render_metrics(label: str, m: Metrics) -> list[str]:
@@ -219,50 +246,47 @@ def _render_metrics(label: str, m: Metrics) -> list[str]:
 
     lines = [
         f"{label} METRICS:",
-        f"  Total call counts  : {m.call_count}",
-        f"  Average latency    : {m.avg_latency_ms():.2f} ms",
+        f"  {'Total call counts':<25}: {m.call_count}",
+        f"  {'Mean latency (ms)':<25}: {m.mean_latency_ms():.2f}",
     ]
-    if sum(m.token_counts) > 0:
-        lines.extend(
-            [
-                f"  Total tokens       : {sum(m.token_counts)}",
-                f"  Avg throughput     : {m.avg_throughput():.2f} tok/s",
-            ]
-        )
-    if m.host_times:
-        lines.append(f"  Avg host time     : {m.avg_host_time_us():.2f} us")
-    if m.device_times:
-        lines.append(f"  Avg device time   : {m.avg_device_time_us():.2f} us")
-    if m.ccl_times:
-        lines.append(f"  Avg ccl time      : {m.avg_ccl_time_us():.2f} us")
-    if m.prepare_times:
-        lines.append(f"  Avg prepare time  : {m.avg_prepare_time_us():.2f} us")
+
+    pct = m.latency_percentiles_ms()
+    for key, value in pct.items():
+        stat = "Median" if key == "p50" else key.upper()
+        metric_label = f"{stat} latency (ms)"
+        lines.append(f"  {metric_label:<25}: {value:.2f}")
+
+    runtime_timings = [
+        ("Mean host time (us)", m.host_times),
+        ("Mean device time (us)", m.device_times),
+        ("Mean ccl time (us)", m.ccl_times),
+        ("Mean prepare time (us)", m.prepare_times),
+    ]
+    for runtime_label, values in runtime_timings:
+        if values:
+            lines.append(f"  {runtime_label:<25}: {_mean(values):.2f}")
 
     return lines
 
 
 def _render_metrics_report(name: str | None, sections: dict[str, Metrics]) -> list[str]:
     lines = [
-        "=" * 40,
+        "=" * 50,
         f"PERFORMANCE STATISTICS{f' [{name}]' if name else ''}",
-        "=" * 40,
+        "=" * 50,
     ]
 
     for label, metrics in sections.items():
         lines.extend(_render_metrics(label, metrics))
-        lines.append("-" * 40)
+        lines.append("-" * 50)
 
-    lines.append("=" * 40)
+    lines.append("=" * 50)
     return lines
 
 
 def _report_metrics(name: str | None, sections: dict[str, Metrics]) -> None:
     lines = _render_metrics_report(name, sections)
-
-    for line in lines:
-        logger.info("%s", line)
-
-    _write_metrics_file(lines)
+    logger.info("%s", "\n".join(lines))
 
 
 def _parse_reports(

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -241,26 +241,30 @@ class _NoopPerformanceContext:
 
 def _rank_tag() -> str:
     """Rank tag including only parallelism axes with degree > 1; '' if none."""
-    parts = []
-    try:
-        from vllm.distributed import get_pp_group, get_tp_group
 
-        tp = get_tp_group()
-        if tp.world_size > 1:
-            parts.append(f"TP{tp.rank_in_group}")
-        pp = get_pp_group()
-        if pp.world_size > 1:
-            parts.append(f"PP{pp.rank_in_group}")
-    except Exception:
+    def get_rank_info(group_name: str, get_group_func) -> str:
+        try:
+            group = get_group_func()
+            if group.world_size > 1:
+                return f"{group_name}{group.rank_in_group}"
+        except Exception:
+            return ""
         return ""
-    try:
-        from vllm.distributed import get_dp_group
 
-        dp = get_dp_group()
-        if dp.world_size > 1:
-            parts.append(f"DP{dp.rank_in_group}")
-    except Exception:
-        pass  # DP group may not be initialized
+    parts = []
+
+    from vllm.distributed import get_dp_group, get_ep_group, get_pp_group, get_tp_group
+
+    for group_name, get_group_func in [
+        ("TP", get_tp_group),
+        ("PP", get_pp_group),
+        ("DP", get_dp_group),
+        ("EP", get_ep_group),
+    ]:
+        rank_info = get_rank_info(group_name, get_group_func)
+        if rank_info:
+            parts.append(rank_info)
+
     return " ".join(parts)
 
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -126,7 +126,7 @@ from vllm_rbln.v1.spec_decode.eagle import RBLNEagleProposer
 from vllm_rbln.v1.spec_decode.medusa import RBLNMedusaProposer
 from vllm_rbln.v1.worker.bucketing import get_bucketing_manager
 from vllm_rbln.v1.worker.input_stager import InputLayout, InputStager, StagedModelInputs
-from vllm_rbln.v1.worker.metrics_v2 import PerformanceContext, ProfileSection
+from vllm_rbln.v1.worker.metrics_v2 import PerformanceContext
 from vllm_rbln.v1.worker.utils import (
     get_kv_cache_names,
     prepare_kernel_block_sizes,
@@ -1207,7 +1207,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
-        with self.performance_ctx.profile(section=ProfileSection.SAMPLER):
+        with self.performance_ctx.profile_sampler():
             if spec_decode_metadata is None:
                 bucket = logits.shape[0]
                 num_reqs = self.input_batch.num_reqs
@@ -1431,12 +1431,12 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 num_padded_tokens=num_tokens_padded,
                 **build_kv_cache_forward_context_kwargs(self.kv_cache_bases),
             ),
-            self.performance_ctx.profile(self.is_prefill, section=ProfileSection.MODEL),
             record_function_or_nullcontext("rbln_model_runner: forward"),
             self.maybe_get_kv_connector_output(
                 scheduler_output,
                 defer_finalize=defer_kv_connector_finalize,
             ) as kv_connector_output,
+            self.performance_ctx.profile_model(self.is_prefill),
         ):
             model_output = self.model_executable(
                 **staged_model_inputs.as_kwargs(),

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1207,10 +1207,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
-        with self.performance_ctx.profile(
-            section=ProfileSection.SAMPLER,
-            token_count=logits.shape[0],
-        ):
+        with self.performance_ctx.profile(section=ProfileSection.SAMPLER):
             if spec_decode_metadata is None:
                 bucket = logits.shape[0]
                 num_reqs = self.input_batch.num_reqs
@@ -1434,11 +1431,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 num_padded_tokens=num_tokens_padded,
                 **build_kv_cache_forward_context_kwargs(self.kv_cache_bases),
             ),
-            self.performance_ctx.profile(
-                self.is_prefill,
-                section=ProfileSection.MODEL,
-                token_count=num_scheduled_tokens,
-            ),
+            self.performance_ctx.profile(self.is_prefill, section=ProfileSection.MODEL),
             record_function_or_nullcontext("rbln_model_runner: forward"),
             self.maybe_get_kv_connector_output(
                 scheduler_output,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -594,13 +594,13 @@ class RBLNWorker(WorkerBase):
         return
 
     def shutdown(self) -> None:
+        self.model_runner.performance_ctx.print_stats()
+
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:
             ensure_kv_transfer_shutdown()
         if self.profiler is not None:
             self.profiler.shutdown()
-
-        self.model_runner.performance_ctx.print_stats()
 
     def _ensure_rbln_host_threads_before_compile(self) -> None:
         """Set OpenMP / torch / numba threads before ``warm_up_model()`` without


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Reworks worker-level performance reporting in `metrics_v2.py`. Building on #769 (latency percentiles + removal of single-outlier averaging) and #731 (model+sampler), this PR applies those changes to `metrics_v2.py` and overhauls how metrics are computed, labeled, logged, and persisted.

#### Statistics

- Replace the unstable "drop one outlier, then average" logic with `mean | p50 | p90 | p99` latency reporting, following #769.
- Drop token count & throughput — misleading at the worker layer (padded device work, padded sampler bucket, spec-decode proposed-vs-accepted tokens) and not aggregatable across ranks.

#### Model + sampler per step

- Remove the standalone SAMPLER section; report `PREFILL + SAMPLE` / `DECODE + SAMPLE`, split by the model step's phase.
- Stash each model step as a pending report and merge the following sampler timing into it.
- Replace `ProfileSection`-based `profile()` with `profile_model()` / `profile_sampler()`.

#### End-to-end latency

- Report `PREFILL E2E` / `DECODE E2E` (latency only).
- Measured from the model span start to the sampler span and, so it captures the overhead between the two spans that the summed metric misses - hence `E2E >= (model + sampler)`.

#### Multi-worker reporting

- Tag each report with a per-worker rank covering TP/PP/DP/EP, including only the axes whose degree > 1 (e.g. a TP=2 run shows `[runner | TP0]` / `[runner | TP1]`; a single worker shows no tag). Each axis is probed independently, so an uninitialized group (e.g. EP when not used) is simply omitted rather than dropping the whole tag.
- The tag is captured at context initialization (after distributed init), so it is stable and survives distributed-group teardown at shutdown.
- Emit the console report as a single atomic `logger.info`, so the log prefix appears once and multi-rank blocks stay intact instead of interleaving line-by-line across workers.

#### File output

- Redesign file output as per-work JSON via the new `VLLM_RBLN_METRICS_DIR` (a directory). Each worker writes `metrics_<rank>.json` (`metrics.json` when not distributed), with `name` / `rank` / per-section stats separated for easy cross-rank aggregation. Console stays human-readable; the file is machine-readable. This replaces the pid-suffixed text file for v2; `VLLM_RBLN_METRICS_FILE` is kept for v1 (`metrics.py`).

#### Cleanups

- Extract a module-level `_mean` helper, add `Metrics.to_dict()` for serialization, rename `avg_* -> mean_*`, and drive the percentile render loop from the returned dict (no hardcoded keys).

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): please describe

---

### 🧪 How to Test

Run a short inference with metrics enabled and inspect the output.

```bash
# Console only
VLLM_RBLN_METRICS=1 RBLN_RUNTIME_TIMER=1 python <offline inference script>

# Console + per-worker JSON files
VLLM_RBLN_METRICS=1 VLLM_RBLN_METRICS_DIR=/tmp/metrics RBLN_RUNTIME_TIMER=1 \
  python <offline inference script>
```

Check:
1. Console shows 4 sections per run - `PREFILL + SAMPLE`, `DECODE + SAMPLE`, `PREFILL E2E`, `DECODE E2E` - each with Mean / Median / P90 / P99 latency. With parallelism, the header carries the rank tag (e.g. `[runner | ]`).
2. For each phase, E2E latency >= (+ SAMPLE) latency (the gap is the inter-span overhead).
3. When `VLLM_RBLN_METRICS_DIR` is set, `/tmp/metrics/` contains one JSON file per worker (e.g. `metrics_tp0.json`, or `metrics.json` on a single worker) with the same statistics in structured form.

> Unit tests are not included in this PR and will be added in a follow-up.

Output sample:
```
==================================================
PERFORMANCE STATISTICS [runner | TP1]
==================================================
PREFILL + SAMPLE METRICS:
  Total call counts        : ..
  Mean latency (ms)        : ..
  Median latency (ms)      : ..
  P90 latency (ms)         : ..
  P99 latency (ms)         : ..
  Mean host time (us)      : ..
  Mean device time (us)    : ..
  Mean ccl time (us)       : ..
  Mean prepare time (us)   : ..
--------------------------------------------------
DECODE + SAMPLE METRICS:
  Total call counts        : ..
  Mean latency (ms)        : ..
  Median latency (ms)      : ..
  P90 latency (ms)         : ..
  P99 latency (ms)         : ..
  Mean host time (us)      : ..
  Mean device time (us)    : ..
  Mean ccl time (us)       : ..
  Mean prepare time (us)   : ..
--------------------------------------------------
PREFILL E2E METRICS:
  Total call counts        : ..
  Mean latency (ms)        : ..
  Median latency (ms)      : ..
  P90 latency (ms)         : ..
  P99 latency (ms)         : ..
--------------------------------------------------
DECODE E2E METRICS:
  Total call counts        : ..
  Mean latency (ms)        : ..
  Median latency (ms)      : ..
  P90 latency (ms)         : ..
  P99 latency (ms)         : ..
--------------------------------------------------
==================================================
```

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
