### PR TITLE
docs: add rebel-compiler version update policy to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,6 +49,39 @@ Rules of thumb:
 - CI installs with `uv sync --locked`, which fails if `uv.lock` doesn't match `pyproject.toml`.
 - Never edit `uv.lock` by hand.
 
+### rebel-compiler version policy
+
+**Who updates:** whoever needs it (need-driven). The team merging a feature
+that requires a newer compiler includes the bump in that PR, as a separate
+commit (easy to revert), e.g. `chore(deps): bump rebel-compiler to 0.11.1.devXXX`.
+
+**Version eligibility:**
+- Only builds that **passed the compiler nightly CI** may be pinned in
+  `uv.lock` or referenced in `pyproject.toml`. Builds from compiler feature
+  branches are for local/CI experiments only — never commit them to the lock.
+- On `main`, only **official release versions** are pinned. Dev builds
+  (`*.devNNN`) are allowed on `dev` only; they are replaced with a release
+  version when merging/releasing to `main`.
+
+**Lock update vs dependency update — decide separately:**
+- **`uv.lock` only** — the new build's features/bugfixes are needed, but the
+  code still works with older compiler versions in the allowed range
+  (e.g. `dev304` → `dev350`): `uv lock --upgrade-package rebel-compiler`.
+- **`pyproject.toml` + `uv.lock` together** — the code is no longer
+  compatible with older compiler versions, i.e. it depends on something that
+  does not exist below a certain compiler version (e.g. a new custom op that
+  only exists from `0.11.2.dev0`): raise the lower bound in `pyproject.toml`
+  (`~=0.11.1.dev0` → `~=0.11.2.dev0`) and regenerate `uv.lock` in the same
+  PR. Bumping only the lock leaves the declared range permitting older
+  versions that no longer work — other environments can still resolve a
+  broken combination.
+- Version-line change (`0.11.x` → `0.12.x`) is a release-level decision:
+  always `pyproject.toml` + `uv.lock`, with API/compatibility review.
+
+**Testing a specific build without touching the lock:** use the
+`rebel_compiler_version` input of the CI workflow — it installs that version
+as an override and leaves `uv.lock` unchanged.
+
 To bump `rebel-compiler` to the latest nightly (do not edit `pyproject.toml`):
 
 ```bash


### PR DESCRIPTION
### 🚀 Summary of Changes

> Documents the rebel-compiler version update policy in `DEVELOPMENT.md`

The new `rebel-compiler version policy` section covers:

* **Who updates**: need-driven — the team merging a feature that requires a newer compiler includes the bump in that PR, as a separate commit (easy to revert)
* **Version eligibility**:
  * Only builds that passed the compiler nightly CI may be pinned in `uv.lock` / `pyproject.toml` (builds from compiler feature branches are forbidden)
  * `main` pins official release versions only — dev builds (`*.devNNN`) are allowed on `dev` only
* **Lock update vs dependency update — decided separately**:
  * New build's features/bugfixes needed, still compatible with older versions → `uv.lock` only
  * Code depends on something that does not exist below a certain compiler version (e.g. a new custom op) → raise the lower bound in `pyproject.toml` and regenerate `uv.lock` in the same PR
  * Version-line change (`0.11.x` → `0.12.x`) is a release-level decision
* **Escape hatch**: the CI `rebel_compiler_version` input installs a specific build without touching `uv.lock`

The weekly auto-bump workflow is intentionally excluded — it will be added separately once Integration CI is enabled.

---

### 📌 Related Issues / Tickets

* Related to #809

---

### ✅ Type of Change

* [x] 📄 Documentation (`docs`)

---

### 🧪 How to Test

1. Review the rendered `DEVELOPMENT.md` (documentation-only change, no code touched)

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

The policy details (especially the lock-only vs dependency+lock criteria) reflect what was agreed in the Slack thread.