### PR TITLE
other(deps): require uv >= 0.11.25 and bump pre-commit uv to 0.11.31

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 #     exclude: '.*\.inc\.md'
 #     stages: [manual] # Only run in CI
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.1
+  rev: 0.11.31  # keep >= tool.uv.required-version in pyproject.toml
   hooks:
     - id: uv-lock
       args: ["--check"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,6 +3,7 @@
 Requirements:
 - Linux x86_64 with access to the internal network (Nexus / internal PyPI)
 - Python **3.12** for this dev workflow (`rebel-compiler` nightly wheels are currently cp312-only; the package itself targets 3.10-3.13)
+- uv **>= 0.11.25** (`uv self update`) — enforced via `required-version` in `pyproject.toml`. Older uv writes `uv.lock` in a different serialization (repeats the `tool.uv.environments` marker on every dependency), so re-locking with it produces a ~900-line noise diff.
 
 Internal indexes require your **LDAP account** credentials (set once, e.g. in your shell profile):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ check_untyped_defs = true
 follow_imports = "silent"
 
 [tool.uv]
+# 0.11.25 changed lockfile serialization (redundant `environments` markers factored
+# out into `supported-markers`, astral-sh/uv#19933); older uv re-locking writes them
+# all back inline, producing a ~900-line noise diff. Gate every uv command on >= 0.11.25.
+required-version = ">=0.11.25"
 environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'"
 ]


### PR DESCRIPTION
### 🚀 Summary of Changes

uv 0.11.25 changed lockfile serialization: the `tool.uv.environments` marker (`platform_machine == 'x86_64' and sys_platform == 'linux'`) is no longer repeated on every dependency edge — it is factored out into the lock header's `supported-markers` (astral-sh/uv#19933, astral-sh/uv#19969).

Consequence: re-locking with an **older** uv (e.g. 0.10.5 in #813) rewrites all those markers back inline, producing a ~900-line noise diff that is semantically identical. `uv lock --check` cannot catch this — it only verifies resolution freshness, not serialization style (verified empirically with 0.11.8 vs 0.11.31).

Changes:
- **pyproject.toml** — add `tool.uv.required-version = ">=0.11.25"`. This is the actual lint: any uv command (`lock`, `sync`, …) run with an older uv fails fast with `error: Required uv version '>=0.11.25' does not match the running version '0.10.5'`, so a stale uv can never silently rewrite `uv.lock` in the old serialization.
- **.pre-commit-config.yaml** — bump `astral-sh/uv-pre-commit` `0.9.1` → `0.11.31` (current stable) so the `uv-lock --check` hook env also satisfies `required-version`.
- **DEVELOPMENT.md** — document the requirement (`uv self update`).

---

### 📌 Related Issues / Tickets

* Related to #813

---

### ✅ Type of Change

* [x] ❓ Other (`other`): dependency tooling / dev environment

---

### 🧪 How to Test

1. With uv < 0.11.25: `uv lock --check` → fails with `error: Required uv version '>=0.11.25' does not match the running version '...'` (verified with 0.11.8)
2. With uv >= 0.11.25: `uv lock --check` → passes, lockfile untouched (verified with 0.11.31)
3. `pre-commit run --all-files` → `uv-lock` hook passes with rev 0.11.31

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

- `required-version` gates **every** uv command in this repo, so all devs must run `uv self update` once (>= 0.11.25).
- CI installs uv unpinned (`pip install uv` / `astral-sh/setup-uv@v5` → latest), so CI already satisfies the floor. If a self-hosted runner's index ever serves an older uv, `uv sync --locked` will fail with the same clear version error instead of misbehaving silently.
- Floor is 0.11.25 (the serialization boundary), not 0.11.31 — no need to force everyone onto the very latest patch.