### PR TITLE
fix(ci): bump optimum-rbln via targeted uv lock (not full uv add)

### DIFF
--- a/.github/workflows/pkg_create_pr.yaml
+++ b/.github/workflows/pkg_create_pr.yaml
@@ -33,13 +33,25 @@ jobs:
       - name: Update Optimum Version in uv
         id: uv-update-optimum-rbln
         run: |
+          set -euo pipefail
           VERSION="${{ inputs.optimum-version }}"
           VERSION="${VERSION#v}"
+
+          # 1) Bump ONLY the optimum-rbln constraint in pyproject.toml.
+          sed -i -E "s|\"optimum-rbln[^\"]*\"|\"optimum-rbln>=${VERSION}\"|" pyproject.toml
+          grep -q "\"optimum-rbln>=${VERSION}\"" pyproject.toml \
+            || { echo "::error::failed to patch optimum-rbln in pyproject.toml"; exit 1; }
+          echo "pyproject.toml -> optimum-rbln>=${VERSION}"
+
+          # 2) Refresh uv.lock for ONLY optimum-rbln (targeted upgrade). Everything
+          #    else — notably rebel-compiler (runtime extra) — stays at its locked
+          #    version, so we skip the full re-resolve that made `uv add` fail on the
+          #    missing rebel-compiler cp313 wheel for Python 3.13.
           for i in {1..6}; do
-            uv add "optimum-rbln>=${VERSION}" --no-cache && exit 0
+            uv lock --upgrade-package "optimum-rbln==${VERSION}" --no-cache && exit 0
             sleep 10
           done
-          echo "All retries with --cache-dir failed."
+          echo "::error::uv lock failed after retries"
           exit 1
 
       - name: Create PR for updated files
@@ -50,6 +62,7 @@ jobs:
           token: ${{ secrets.GIT_PAT }}
           add-paths: |
             pyproject.toml
+            uv.lock
           commit-message: "other: update optimum-rbln to ${{ inputs.optimum-version }}"
           title: "other: auto-update optimum-rbln to ${{ inputs.optimum-version }}"
           body: "Updated optimum-rbln to ${{ inputs.optimum-version }}."

--- a/.github/workflows/pkg_create_pr.yaml
+++ b/.github/workflows/pkg_create_pr.yaml
@@ -43,10 +43,7 @@ jobs:
             || { echo "::error::failed to patch optimum-rbln in pyproject.toml"; exit 1; }
           echo "pyproject.toml -> optimum-rbln>=${VERSION}"
 
-          # 2) Refresh uv.lock for ONLY optimum-rbln (targeted upgrade). Everything
-          #    else — notably rebel-compiler (runtime extra) — stays at its locked
-          #    version, so we skip the full re-resolve that made `uv add` fail on the
-          #    missing rebel-compiler cp313 wheel for Python 3.13.
+          # 2) Refresh uv.lock for ONLY optimum-rbln (targeted upgrade).
           for i in {1..6}; do
             uv lock --upgrade-package "optimum-rbln==${VERSION}" --no-cache && exit 0
             sleep 10


### PR DESCRIPTION
## Problem
The Pkg-Update automation's **"Update Optimum Version in uv"** step runs
`uv add "optimum-rbln>=X"`, which re-locks the **entire** dependency graph.
`uv lock` resolves optional-dependencies too, so it must satisfy the `runtime`
extra's `rebel-compiler` across **all** supported Python versions
(`requires-python = ">=3.10,<3.14"`).

Recent `rebel-compiler` `0.11.1.dev` builds ship **cp312-only** wheels (cp313
stopped at `dev431`), so the py3.13 split has no `rebel-compiler` wheel →
`No solution found` → the step exits 1 and no PR is created.
Failing run: [`29900965527`](https://github.com/RBLN-SW/vllm-rbln/actions/runs/29900965527), job `update-pkg / vllm-rbln-pr / create-pr`.

## Fix
Bump **only** `optimum-rbln`, without re-resolving everything else:

1. `sed` the `optimum-rbln` constraint in `pyproject.toml` to `>=${VERSION}`.
2. `uv lock --upgrade-package "optimum-rbln==${VERSION}"` — a *targeted* lock
   update that holds every other package (notably `rebel-compiler`) at its
   currently-locked version (`dev304`, which has a cp313 wheel), so the full
   re-resolve that tripped over the missing cp313 wheel is skipped.

Also add `uv.lock` to the create-PR `add-paths`: previously only
`pyproject.toml` was committed, so the lock change would be dropped and the PR
would fail CI's `uv sync --locked` on pyproject/lock drift.

## Limitation
This avoids the failure only while `optimum-rbln` does not transitively require
a `rebel-compiler` newer than the locked one. If a future `optimum-rbln` forces
a newer compiler, resolution hits the same cp313 gap — the real fix there is for
`rebel-compiler` to publish cp313 (and cp310/cp311) wheels for recent
`0.11.1.dev` builds. (`0.11.1a4` coexists fine with `dev304` today.)

## Test
- `pkg_create_pr.yaml` parses as valid YAML.
- No `uv add` command remains; targeted `uv lock --upgrade-package` is in place;
  `uv.lock` added to `add-paths`.
