### PR TITLE
fix(optimum): exclude empty rbln_config from the compile-cache hash

### DIFF
--- a/vllm_rbln/utils/optimum/converter/dispatch.py
+++ b/vllm_rbln/utils/optimum/converter/dispatch.py
@@ -75,8 +75,11 @@ def _generate_model_path_name(
         "num_devices": num_devices,
         "memory_budget": memory_budget,
     }
-    if additional_config:
-        config_dict["rbln_config"] = _strip_runtime_only_keys(additional_config)
+    stripped_config = (
+        _strip_runtime_only_keys(additional_config) if additional_config else {}
+    )
+    if stripped_config:
+        config_dict["rbln_config"] = stripped_config
 
     config_json = json.dumps(config_dict, sort_keys=True, default=str)
     config_hash = hashlib.sha256(config_json.encode()).hexdigest()[:16]


### PR DESCRIPTION
## Problem

`_generate_model_path_name` (the optimum compile-cache path/hash) added
`"rbln_config"` to the hashed `config_dict` whenever the caller passed a
non-empty `additional_config["rbln_config"]`, but stored the value **after**
stripping runtime-only keys:

```python
if additional_config:
    config_dict["rbln_config"] = _strip_runtime_only_keys(additional_config)
```

A **compile** call that passes only runtime-only knobs — e.g.
`{"create_runtimes": False}` — strips to `{}`, yet still hashes as
`{..., "rbln_config": {}}`. An **inference** call that passes no `rbln_config`
omits the key entirely (`{...}`). Same artifact, two different hashes → two
different `compiled_models/<name>_<hash>/` paths → the inference call misses the
compile's artifact and **silently recompiles**.

Observed in the optimum executor CI:
- compile wrote `compiled_models/meta-llama_Llama-3.2-3B-Instruct_63e30e86…`
- inference looked for `…_f5aa8074…` → miss → recompile (both dirs present).

## Fix

Strip first, and add `rbln_config` to the hash only when it is **non-empty after
stripping**, so a runtime-only-only config doesn't perturb the key:

```python
stripped_config = _strip_runtime_only_keys(additional_config) if additional_config else {}
if stripped_config:
    config_dict["rbln_config"] = stripped_config
```

## Verify

`_generate_model_path_name` now yields the **same** path for a compile config
`{"create_runtimes": False}` and an inference config with no `rbln_config`
(both `…_f5aa8074471f9b2d`) — so compile and inference resolve to one cache
path and inference reuses the compiled artifact instead of recompiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
