### PR TITLE
model: register Qwen3.5 (Qwen3_5ForConditionalGeneration) for RBLN Optimum

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/__init__.py
@@ -38,6 +38,7 @@ from .paligemma import RBLNOptimumPaliGemmaForConditionalGeneration  # noqa: F40
 from .qwen_vl import (  # noqa: F401
     RBLNOptimumQwen2_5_VLForConditionalGeneration,
     RBLNOptimumQwen2VLForConditionalGeneration,
+    RBLNOptimumQwen3_5ForConditionalGeneration,
     RBLNOptimumQwen3VLForConditionalGeneration,
     RBLNOptimumQwen3VLMoeForConditionalGeneration,
 )

--- a/vllm_rbln/model_executor/models/optimum/qwen_vl.py
+++ b/vllm_rbln/model_executor/models/optimum/qwen_vl.py
@@ -643,3 +643,16 @@ class RBLNOptimumQwen3VLMoeForConditionalGeneration(
     """
 
     pass
+
+
+class RBLNOptimumQwen3_5ForConditionalGeneration(
+    RBLNOptimumQwen3VLForConditionalGeneration
+):
+    """
+    Qwen3.5 (architecture ``Qwen3_5ForConditionalGeneration``) is natively
+    multimodal. This wrapper assumes it shares the Qwen3-VL input structure and
+    inherits from RBLNOptimumQwen3VLForConditionalGeneration unchanged; if the
+    optimum-rbln implementation diverges, override the input-builder hooks here.
+    """
+
+    pass

--- a/vllm_rbln/utils/optimum/registry.py
+++ b/vllm_rbln/utils/optimum/registry.py
@@ -63,6 +63,10 @@ _RBLN_MULTIMODAL_MODELS = {
         "qwen3_vl_moe",
         "RBLNQwen3VLMoeForConditionalGeneration",
     ),
+    "Qwen3_5ForConditionalGeneration": (
+        "qwen3_5",
+        "RBLNQwen3_5ForConditionalGeneration",
+    ),
     "Exaone4_5_ForConditionalGeneration": (
         "exaone4_5",
         "RBLNExaone4_5_ForConditionalGeneration",


### PR DESCRIPTION
## Summary

Registers the **Qwen3.5** architecture (`Qwen3_5ForConditionalGeneration`) in the RBLN Optimum supported-class registry so vLLM can dispatch it as a multimodal model. Qwen3.5 is natively multimodal and shares its architecture with Qwen3.6, so this one entry covers both.

Companion to [optimum-rbln#631](https://github.com/RBLN-SW/optimum-rbln/pull/631), which adds the `RBLNQwen3_5ForConditionalGeneration` class this registry points at.

## Changes

- **`vllm_rbln/utils/optimum/registry.py`** — `_RBLN_MULTIMODAL_MODELS` gains `"Qwen3_5ForConditionalGeneration" → ("qwen3_5", "RBLNQwen3_5ForConditionalGeneration")`. Because `_RBLN_SUPPORTED_MODELS` merges `**_RBLN_MULTIMODAL_MODELS`, the entry reaches both consumers: `get_rbln_model_info()` (→ `getattr(optimum.rbln, "RBLNQwen3_5ForConditionalGeneration")` in `model_base.py`) and the `_RBLN_OPTIMUM_MULTIMODAL_MODELS` wrapper map.
- **`vllm_rbln/model_executor/models/optimum/qwen_vl.py`** — adds the `RBLNOptimumQwen3_5ForConditionalGeneration` wrapper.
- **`vllm_rbln/model_executor/models/optimum/__init__.py`** — imports the wrapper so `globals()["RBLNOptimumQwen3_5ForConditionalGeneration"]` resolves in the `_RBLN_OPTIMUM_MULTIMODAL_MODELS` comprehension.

## ⚠️ Draft — gated on optimum-rbln#631

`tests/optimum_compile/test_registry.py::test_registered_class_exists_in_optimum[Qwen3_5ForConditionalGeneration]` runs in CI (`pytest tests/optimum_compile`) and asserts `getattr(optimum.rbln, "RBLNQwen3_5ForConditionalGeneration")` exists. It stays **red until the pinned `optimum-rbln` exports the class** (i.e. after #631 lands and the version bump reaches this repo). Kept as a draft until then. If the currently pinned `optimum-rbln` (v0.11.1a4) already includes #631, that test passes and this can be marked ready as-is.

## ⚠️ Verify the wrapper against #631

`RBLNOptimumQwen3_5ForConditionalGeneration` is scaffolded as a **thin subclass of the Qwen3-VL wrapper** (mirroring how `RBLNOptimumQwen3VLMoeForConditionalGeneration` inherits with `pass`), on the assumption that Qwen3.5 shares Qwen3-VL's multimodal input structure. **This assumption is not verified against #631's implementation.** If Qwen3.5's pixel/video input builders or config differ, override the relevant hooks in this wrapper. Please confirm during review.

## Test plan / verification

- `ruff check` (full config: E/F/UP/B/SIM/I/G) — **clean** on all 3 files; import order correct (`Qwen3_5` sorts before `Qwen3VL` under isort's case-insensitive order).
- `ruff format --check` — **clean**.
- `python -m py_compile` — **OK**.
- Registry wiring confirmed by loading `registry.py` standalone: entry present in both `_RBLN_MULTIMODAL_MODELS` and `_RBLN_SUPPORTED_MODELS`; `get_rbln_model_info(architectures=["Qwen3_5ForConditionalGeneration"])` returns `('qwen3_5', 'RBLNQwen3_5ForConditionalGeneration')`.
- Import-safe before #631: the wrapper is a pure subclass with no eager `optimum.rbln.RBLNQwen3_5*` reference, and the registry tuple is plain strings — the optimum class is resolved lazily at serve time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
