### PR TITLE
fix(optimum): drop memory_budget from pooling/encoder compile config

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
@@ -207,8 +207,6 @@ class RBLNCompileSpec:
         model_cls = getattr(optimum.rbln, model_cls_name)
         assert model_cls is not None
 
-        # NOTE: memory_budget is a decoder-only knob. Pooling/encoder RBLN
-        # configs reject it ("Unexpected arguments"), so it is omitted here.
         rbln_config: dict[str, Any] = {
             "num_devices": num_devices,
             "batch_size": batch_size,

--- a/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
@@ -124,7 +124,6 @@ class RBLNCompileSpec:
                 block_size,
                 max_model_len,
                 num_devices,
-                memory_budget,
             )
         elif is_multi_modal(config):
             spec = cls._for_multimodal(
@@ -203,17 +202,17 @@ class RBLNCompileSpec:
         block_size: int,
         max_model_len: int,
         num_devices: int,
-        memory_budget: float,
     ) -> "RBLNCompileSpec":
         _, model_cls_name = get_rbln_model_info(config)
         model_cls = getattr(optimum.rbln, model_cls_name)
         assert model_cls is not None
 
+        # NOTE: memory_budget is a decoder-only knob. Pooling/encoder RBLN
+        # configs reject it ("Unexpected arguments"), so it is omitted here.
         rbln_config: dict[str, Any] = {
             "num_devices": num_devices,
             "batch_size": batch_size,
             "max_seq_len": max_model_len,
-            "memory_budget": memory_budget,
         }
         # FIXME: We need a more generalized logic to specify block sizes
         # as the number of supported models continues to grow.


### PR DESCRIPTION
## Problem
Compiling pooling / encoder-only models (e.g. `bge-*`) fails with:

```
ValueError: Unexpected arguments: dict_keys(['memory_budget'])
```

`memory_budget` (wired from `gpu_memory_utilization` in #810) is a
decoder-only knob. The pooling/encoder RBLN config classes do not accept
it, so passing it into `from_pretrained` aborts compilation. The
enc-dec (Whisper) path already omits it; only the pooling path still
forwarded it.

## Fix
Drop `memory_budget` from `_for_pooling`'s `rbln_config` (and from its
signature / call site). Decoder and multimodal paths are unchanged and
keep passing it.

## Verify
- `py_compile` on `compilation/__init__.py`.
- Pooling compile no longer builds a config containing `memory_budget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
