### PR TITLE
fix(optimum): pin gemma3 prefill_chunk_size to mm_tokens_per_image

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
@@ -243,6 +243,16 @@ class RBLNCompileSpec:
             )
         model_cls = getattr(optimum.rbln, model_cls_name)
         assert model_cls is not None
+        # gemma3 forces image_prefill_chunk_size == mm_tokens_per_image and then
+        # requires text prefill_chunk_size == image_prefill_chunk_size, else it
+        # raises "Not implemented for different prefill chunk sizes ...". So the
+        # text chunk is dictated by the model; pin it to mm_tokens_per_image
+        # rather than the vllm-derived default. (gemma4 buckets image prefill
+        # independently, so it is unaffected.)
+        if model_name == "gemma3":
+            prefill_chunk_size = getattr(
+                config, "mm_tokens_per_image", prefill_chunk_size
+            )
         # Pass the resolved prefill_chunk_size so each compile_fn pins it on the
         # compiled model, keeping it in sync with the KV-cache block padding.
         rbln_config = compile_fn(


### PR DESCRIPTION
## Problem
Compiling `gemma3` multimodal models fails with:

```
NotImplementedError: Not implemented for different prefill chunk sizes
between text and image prefill.
```

optimum-rbln forces `image_prefill_chunk_size == mm_tokens_per_image`
and then requires the text `prefill_chunk_size` to equal it. The text
chunk is therefore dictated by the model, but vllm-rbln forwarded its
own resolved `prefill_chunk_size` (defaulting to 128) into the gemma3
language-model config, which diverged from `mm_tokens_per_image` (256)
and tripped the check.

## Fix
In `_for_multimodal`, for `gemma3` pin the text `prefill_chunk_size` to
`config.mm_tokens_per_image` before building the compile config, so text
and image prefill agree. Guarded by architecture; `gemma4` buckets image
prefill independently and is left unchanged.

## Verify
- `py_compile` on `compilation/__init__.py`.
- gemma3 compile now uses `prefill_chunk_size == mm_tokens_per_image`,
  matching the forced `image_prefill_chunk_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
