### PR TITLE
fix(optimum): let rbln_overrides override vision-encoder submodule defaults

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
@@ -48,22 +48,33 @@ def _deep_merge(base: dict, overrides: dict) -> None:
             base[key] = value
 
 
-def _find_conflicts(base: dict, overrides: dict, _prefix: str = "") -> list[str]:
+def _find_conflicts(
+    base: dict,
+    overrides: dict,
+    overridable: frozenset[str] = frozenset(),
+    _prefix: str = "",
+) -> list[str]:
     """Return dotted paths where ``overrides`` would overwrite an existing
     value in ``base`` with a different one.
 
     Mirrors ``_deep_merge``'s traversal: nested dicts recurse, leaves compare
     by value. A key present only in ``overrides`` is not a conflict (the user
-    is adding a new knob, not clobbering a derived field).
+    is adding a new knob, not clobbering a derived field). A path in
+    ``overridable`` is skipped along with everything under it — the model
+    declared that submodule user-overridable via its ``get_overridable``.
     """
     conflicts: list[str] = []
     for key, value in overrides.items():
+        path = f"{_prefix}{key}"
+        if path in overridable:
+            continue
         if key not in base:
             continue
-        path = f"{_prefix}{key}"
         existing = base[key]
         if isinstance(value, dict) and isinstance(existing, dict):
-            conflicts.extend(_find_conflicts(existing, value, f"{path}."))
+            conflicts.extend(
+                _find_conflicts(existing, value, overridable, f"{path}.")
+            )
         elif existing != value:
             conflicts.append(f"{path} (compiled={existing!r}, override={value!r})")
     return conflicts
@@ -93,6 +104,10 @@ class RBLNCompileSpec:
 
     model_cls: Any
     rbln_config: dict[str, Any]
+    # Submodules/paths the user may override despite the builder setting a default
+    # (compile-only knobs vllm never reads back). Declared per-model by the
+    # model's ``get_overridable``; consulted by ``_find_conflicts``.
+    overridable: frozenset[str] = frozenset()
 
     @classmethod
     def for_architecture(
@@ -153,9 +168,13 @@ class RBLNCompileSpec:
         # rbln_overrides must not overwrite fields vllm derives from its own
         # config (batch_size, max_seq_len, memory_budget, ...); a silent
         # mismatch would compile a model that disagrees with the runtime. Adding
-        # a new key not set by the builder is allowed.
+        # a new key not set by the builder is allowed, as is overwriting anything
+        # under a per-model overridable submodule (``spec.overridable``, e.g. a
+        # vision encoder's ``visual`` — knobs vllm never reads back).
         if rbln_overrides:
-            conflicts = _find_conflicts(spec.rbln_config, rbln_overrides)
+            conflicts = _find_conflicts(
+                spec.rbln_config, rbln_overrides, overridable=spec.overridable
+            )
             if conflicts:
                 raise ValueError(
                     "rbln_overrides conflict with vllm-derived compile config: "
@@ -253,7 +272,16 @@ class RBLNCompileSpec:
             memory_budget,
             prefill_chunk_size,
         )
-        return cls(model_cls=model_cls, rbln_config=rbln_config)
+        # A model may declare submodules the user can freely override via a
+        # ``get_overridable()`` defined in its builder module (e.g. qwen exposes
+        # ``visual``); forward that set so the conflict check lets them win.
+        get_overridable = compile_fn.__globals__.get("get_overridable")
+        overridable = get_overridable() if get_overridable else frozenset()
+        return cls(
+            model_cls=model_cls,
+            rbln_config=rbln_config,
+            overridable=overridable,
+        )
 
     @classmethod
     def _for_enc_dec(

--- a/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/__init__.py
@@ -72,9 +72,7 @@ def _find_conflicts(
             continue
         existing = base[key]
         if isinstance(value, dict) and isinstance(existing, dict):
-            conflicts.extend(
-                _find_conflicts(existing, value, overridable, f"{path}.")
-            )
+            conflicts.extend(_find_conflicts(existing, value, overridable, f"{path}."))
         elif existing != value:
             conflicts.append(f"{path} (compiled={existing!r}, override={value!r})")
     return conflicts

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/exaone4_5.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/exaone4_5.py
@@ -43,3 +43,13 @@ def get_param_exaone4_5(
     if prefill_chunk_size is not None:
         param["prefill_chunk_size"] = prefill_chunk_size
     return param
+
+
+def get_overridable() -> frozenset[str]:
+    """Submodules whose fields a user may override (see ``_find_conflicts``).
+
+    The ``visual`` (vision encoder) submodule is compile-only — vllm never reads
+    it back to size the runtime — so any of its fields may be overridden without
+    desyncing vllm and the compiled model.
+    """
+    return frozenset({"visual"})

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/llava.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/llava.py
@@ -39,3 +39,14 @@ def get_param_llava(
 
 
 get_param_llava_next = get_param_llava
+
+
+def get_overridable() -> frozenset[str]:
+    """Submodules whose fields a user may override (see ``_find_conflicts``).
+
+    ``vision_tower`` is the vision encoder — compile-only, never read back by
+    vllm — so its fields are overridable. ``language_model`` is intentionally
+    NOT listed: vllm derives its batch_size / max_seq_len / block_size from that
+    submodule (see params.py), so those must stay protected.
+    """
+    return frozenset({"vision_tower"})

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/qwen.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/qwen.py
@@ -53,3 +53,13 @@ def get_param_qwen2_vl(
 get_param_qwen2_5_vl = get_param_qwen2_vl
 get_param_qwen3_vl = get_param_qwen2_vl
 get_param_qwen3_vl_moe = get_param_qwen2_vl
+
+
+def get_overridable() -> frozenset[str]:
+    """Submodules whose fields a user may override (see ``_find_conflicts``).
+
+    The ``visual`` (vision encoder) submodule is compile-only — vllm never reads
+    it back to size the runtime — so any of its fields may be overridden without
+    desyncing vllm and the compiled model.
+    """
+    return frozenset({"visual"})


### PR DESCRIPTION
## Problem

The multimodal compile path (`RBLNCompileSpec.for_architecture` → `_find_conflicts`) rejects any `rbln_override` that differs from a builder-set value. This blocks legitimate overrides of vision-encoder knobs.

For example, compiling qwen3-vl with `additional_config={"rbln_config": {"visual": {"max_seq_len": [16384]}}}` fails:

```
ValueError: rbln_overrides conflict with vllm-derived compile config:
visual.max_seq_len (compiled=6400, override=[16384])
```

The builder (`get_param_qwen2_vl`) hardcodes `visual.max_seq_len = 6400` as a default, and the conflict check treats it the same as a genuinely vllm-derived field.

## Why this is safe to allow

The conflict check exists to stop a compiled model from disagreeing with the vllm runtime — i.e. to protect fields vllm derives from its own config (`batch_size ↔ max_num_seqs`, `max_seq_len ↔ max_model_len`, `num_devices`, block / KV-cache settings). Those are read back in `params.py` and drive the scheduler and KV-cache sizing, so a mismatch would silently break inference.

Vision-encoder submodules (`visual`, `vision_tower`) are **never** read back by `params.py` — they only affect the compiled vision encoder. Overriding any of their fields therefore cannot desync vllm and the compiled model. (The compile-cache key already includes these fields, so a different value produces a distinct artifact.)

This is compile-path only: when loading an already-compiled model the conflict check does not run and the compiled artifact's values are authoritative.

## Change

Each model declares, via a `get_overridable()` function in its own builder module, the submodules whose fields the user may override:

- `qwen.py` (qwen2 / qwen2.5 / qwen3-vl, incl. moe aliases) and `exaone4_5.py` → `{"visual"}`
- `llava.py` (llava / llava_next) → `{"vision_tower"}` — its `language_model` submodule stays protected

`_for_multimodal` looks this up from the builder's own module and forwards it as `RBLNCompileSpec.override_wins`. `_find_conflicts` skips those subtrees entirely (the whole submodule), so the override wins and `_deep_merge` applies it. Models without `get_overridable()` are unchanged — every builder-set field stays protected.

Opening a submodule for a future model is a one-line `get_overridable()` in that model's file; there is no central registry to update.

## Testing

Verified against the real source (builders plus `_find_conflicts` / `_deep_merge`):

- **qwen**: overriding the whole `visual` submodule (`max_seq_len`, `device`, ...) passes; `batch_size` still conflicts.
- **llava**: `vision_tower` override passes; `language_model.batch_size` still conflicts.
- **models without `get_overridable()`**: strict behavior unchanged.

> Note: a full end-to-end import in `venv_optimum` is currently blocked by an unrelated `rebel._C` ABI skew in that environment, so verification was done by executing the actual source of the changed functions directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
