### PR TITLE
fix: stop hardcoding input-dependent multimodal rbln_config values

### DIFF
--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/exaone4_5.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/exaone4_5.py
@@ -22,12 +22,7 @@ def get_param_exaone4_5(
     memory_budget: float,
     prefill_chunk_size: int | None = None,
 ) -> dict:
-    param = {
-        "visual": {
-            # if tensor_parallel_size of submodule is not specified,
-            # it inherits tensor_parallel_size of main module.
-            "max_seq_len": 6400,
-        },
+    param: dict = {
         "num_devices": num_devices,
         "max_seq_len": max_model_len,
         "batch_size": batch_size,

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/paligemma.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/paligemma.py
@@ -32,7 +32,6 @@ def get_param_paligemma(
         memory_budget,
         prefill_chunk_size,
     )
-    # paligemma pins its own prefill_chunk_size; this overrides the resolved one.
-    language_model_config["prefill_chunk_size"] = 8192
+    language_model_config["prefill_chunk_size"] = max_model_len
     param = {"language_model": language_model_config}
     return param

--- a/vllm_rbln/model_executor/models/optimum/compilation/multimodal/qwen.py
+++ b/vllm_rbln/model_executor/models/optimum/compilation/multimodal/qwen.py
@@ -22,17 +22,7 @@ def get_param_qwen2_vl(
     memory_budget: float,
     prefill_chunk_size: int | None = None,
 ) -> dict:
-    # Max sequence length for Vision Transformer (ViT), representing the number of patches in an image. # noqa: E501
-    # Example: For a 224x224 pixel image with patch size 14,
-    # this produces 256 patches [(224/14) * (224/14)]. Thus, max_seq_len must be at least 256. # noqa: E501
-    # RBLN optimization processes inference per image or video frame, so set max_seq_len to # noqa: E501
-    # match the maximum expected resolution to optimize computation.
-    param = {
-        "visual": {
-            # if num_devices of submodule is not specified,
-            # it inherits num_devices of main module.
-            "max_seq_len": 6400,
-        },
+    param: dict = {
         "num_devices": num_devices,
         "max_seq_len": max_model_len,
         "batch_size": batch_size,


### PR DESCRIPTION
## What this PR does

When vLLM compiles a type1 (optimum) multimodal model, a per-model builder (`compilation/multimodal/<model>.py: get_param_*`) constructs the base `rbln_config`, and the user's `additional_config.rbln_config` is merged on top. Three builders hardcoded values that should be controlled by the caller (#832). This PR removes those hardcodes:

| File | Before | After |
|---|---|---|
| `qwen.py` (qwen2-vl / qwen2.5-vl / qwen3-vl / qwen3-vl-moe) | seeds `visual.max_seq_len = 6400` | not seeded — caller passes it |
| `exaone4_5.py` | seeds `visual.max_seq_len = 6400` | not seeded — caller passes it |
| `paligemma.py` | pins `language_model.prefill_chunk_size = 8192` | derived: `= max_model_len` |

## Why

**`visual.max_seq_len` (qwen, exaone4_5) — resolution-dependent, so no constant can be right.**
This is the ViT attention budget: the max number of patches per image/video frame, which depends on the input resolution the deployment expects. A fixed 6400 is wrong for any other resolution and gets silently baked into the compiled artifact. After this PR the caller states it explicitly:

```python
LLM(
    model="Qwen/Qwen3-VL-8B-Instruct",
    additional_config={
        "rbln_config": {
            "visual": {"max_seq_len": [16384]},  # match your max input resolution
        }
    },
)
```

If it is missing, compile fails immediately with optimum-rbln's `ValueError: 'max_seq_len' must be specified.` — an explicit error instead of a silently wrong-sized artifact. (`visual` is already declared user-overridable via `get_overridable()`, and a key absent from the base config is never an override conflict, so the explicit value merges cleanly.)

**`prefill_chunk_size` (paligemma) — an invariant, so it is derived instead of pinned.**
PaliGemma's language model prefills with bidirectional attention over the whole image+prompt prefix, and the RBLN prefill is bidirectional only within a single chunk — so `prefill_chunk_size` must equal `max_seq_len`. The literal 8192 satisfied this only because PaliGemma's `max_position_embeddings` happens to be 8192; deriving it from `max_model_len` (which the builder already uses as `max_seq_len`) keeps the invariant for every `--max-model-len`. optimum-rbln side hardening for non-vLLM callers: rebellions-sw/optimum-rbln#646.

## Impact on existing callers

- Compiling Qwen-VL / EXAONE-4.5 **with** an explicit `visual.max_seq_len` (as above): works as before — the override now takes effect without competing with a seeded default.
- Compiling Qwen-VL / EXAONE-4.5 **without** `visual.max_seq_len`: previously got a silent 6400 artifact, now gets the compile-time error above. This is the intended behavior change.
- PaliGemma with `--max-model-len 8192`: identical artifact as before. Other lengths now compile a correctly sized prefill.
- Other multimodal builders (blip2 / llava / gemma3 / idefics3): untouched.

## Incidental

- `param: dict` annotations added in `qwen.py` / `exaone4_5.py` (same style as `common.py`): with the `visual` sub-dict removed, mypy narrows the dict value type to `float` and rejects the later `attn_impl` str assignment.

## Note for `main`

`main`'s `qwen.py` still spells the seed with the removed alias `max_seq_lens` (plural), which breaks every Qwen-VL compile on optimum-rbln ≥ 0.11.0 regardless of overrides (`_deep_merge` never removes a stale seeded key). If `main` needs a fix before its next sync from `dev`, cherry-pick/adapt this change.

## Verification

- `ruff format --check` / `ruff check` pass on the changed files.
- `mypy --python-version 3.10 --follow-imports=skip` passes on the changed files.
- No unit tests reference the removed seed values.

Fixes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)