### PR TITLE
feature(pp): pipeline parallelism across the RBLN scheduler, runner, and NIXL KV-cache transfer

### DIFF
--- a/tests/torch_compile/unit/test_forward_context.py
+++ b/tests/torch_compile/unit/test_forward_context.py
@@ -46,3 +46,62 @@ def test_forward_context(vllm_config, attn_metadata_mock: MagicMock):
             f"Expected 'dp_metadata' class name is RBLNDPMetadata, \
                     got {get_forward_context().dp_metadata.__class__.__name__}"
         )
+
+
+def test_num_tokens_and_reqs_across_dp_bit_pack(monkeypatch):
+    """Round-trip the bit-packed (num_tokens, num_reqs, is_prefill, is_idle)
+    all-reduce. Intercepts the inner all-gather so no real DP group is needed,
+    and checks each field unpacks correctly -- including the new is_idle mask
+    and the (prefill -> num_reqs None) behavior."""
+    from vllm_rbln.forward_context import RBLNDPMetadata
+
+    token_bits = 16
+
+    def peer_encoded(num_tokens, num_reqs):
+        return num_tokens | (num_reqs << token_bits)
+
+    def make_fake_inner(peer_value):
+        def fake_inner(encoded, dp_size, dp_rank):
+            arr = [0, 0]
+            arr[dp_rank] = encoded
+            arr[1 - dp_rank] = peer_value
+            return torch.tensor(arr, dtype=torch.int32)
+
+        return fake_inner
+
+    # Decode: this rank (rank0) = idle (num_tokens=1, num_reqs=1, is_idle);
+    # peer (rank1) = busy (num_tokens=8, num_reqs=2).
+    monkeypatch.setattr(
+        RBLNDPMetadata,
+        "num_tokens_across_dp",
+        staticmethod(make_fake_inner(peer_encoded(8, 2))),
+    )
+    tokens, reqs, idle = RBLNDPMetadata.num_tokens_and_reqs_across_dp(
+        num_tokens=1,
+        num_reqs=1,
+        dp_size=2,
+        dp_rank=0,
+        is_prefill=False,
+        is_idle=True,
+    )
+    assert tokens.tolist() == [1, 8]
+    assert reqs is not None and reqs.tolist() == [1, 2]
+    assert idle.tolist() == [1, 0]
+
+    # Prefill on this rank -> num_reqs_across_dp is None; is_idle stays 0.
+    monkeypatch.setattr(
+        RBLNDPMetadata,
+        "num_tokens_across_dp",
+        staticmethod(make_fake_inner(peer_encoded(8, 2))),
+    )
+    tokens, reqs, idle = RBLNDPMetadata.num_tokens_and_reqs_across_dp(
+        num_tokens=5,
+        num_reqs=1,
+        dp_size=2,
+        dp_rank=0,
+        is_prefill=True,
+        is_idle=False,
+    )
+    assert tokens.tolist() == [5, 8]
+    assert reqs is None
+    assert idle.tolist() == [0, 0]

--- a/tests/torch_compile/unit/v1/core/test_decode_batch_size.py
+++ b/tests/torch_compile/unit/v1/core/test_decode_batch_size.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``decode_batch_size`` -- the single source of truth for the
+per-PP-stage (compiled) decode batch, shared by the runner's bucketing and the
+scheduler's decode admission cap.
+"""
+
+import pytest
+
+from vllm_rbln.v1.core.utils import decode_batch_size
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "pp_size", "expected"),
+    [
+        (16, 1, 16),  # non-PP: unchanged
+        (16, 2, 8),
+        (16, 4, 4),
+        (2, 2, 1),  # small batch splits down to 1 per stage
+        (4, 2, 2),
+    ],
+)
+def test_decode_batch_size_divides_by_pp(max_num_seqs, pp_size, expected):
+    assert decode_batch_size(max_num_seqs, pp_size) == expected
+
+
+def test_decode_batch_size_pp1_is_identity():
+    """pp_size == 1 (non-PP) returns max_num_seqs unchanged."""
+    for n in (1, 2, 8, 37, 256):
+        assert decode_batch_size(n, 1) == n

--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -669,6 +669,9 @@ def _build_connector_worker(
 
     vllm_config = MagicMock()
     vllm_config.cache_config = CacheConfig(block_size=block_size)
+    # _check_pp_constraints compares pipeline_parallel_size <= 1; give it a real
+    # int (MagicMock would raise TypeError). 1 == the non-PP default these tests assume.
+    vllm_config.parallel_config.pipeline_parallel_size = 1
     kv_cache_config = MagicMock()
     kv_cache_config.num_blocks = num_blocks
     if kv_cache_specs is not None:
@@ -685,6 +688,9 @@ def _build_connector_worker(
         self.kv_cache_config = kv_cache_config_
         self.kv_buffer_device = kv_buffer_device
         self._block_size = {}
+        # The real NixlConnectorWorker.__init__ sets this to None; register_kv_caches
+        # reads it after super().register_kv_caches(). Stub it so the harness matches.
+        self.xfer_handshake_metadata = None
 
     modules_patch = (
         # Mask `nixl_rbln` from sys.modules so `import nixl_rbln` raises

--- a/tests/torch_compile/unit/v1/core/test_rbln_nixl_handshake_pp.py
+++ b/tests/torch_compile/unit/v1/core/test_rbln_nixl_handshake_pp.py
@@ -1,0 +1,691 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage: RBLN NIXL PP-aware consumer handshake fan-out.
+
+Exercises RblnNixlConnectorWorker._nixl_handshake with the ZMQ side-channel and
+add_remote_agent mocked, so it needs neither a live NIXL peer nor nixl-rbln.
+"""
+
+from collections import defaultdict
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import msgspec
+import pytest
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    NixlHandshakePayload,
+)
+
+import vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.worker as W
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.worker import (
+    RblnNixlConnectorWorker,
+)
+
+
+def _encode_payload(
+    pp_rank,
+    pp_size,
+    *,
+    engine_id="eng",
+    compat="HASH",
+    layers_per_stage=1,
+    layer_names=None,
+):
+    if layer_names is None:
+        layer_names = [
+            f"layer.{pp_rank * layers_per_stage + j}" for j in range(layers_per_stage)
+        ]
+    meta = RblnNixlAgentMetadata(
+        engine_id=engine_id,
+        agent_metadata=b"agent",
+        kv_caches_base_addr=[0x1000],
+        device_id=0,
+        num_blocks=4,
+        block_lens=[8192],
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="RBLN",
+        physical_blocks_per_logical_kv_block=1,
+        pp_rank=pp_rank,
+        pp_size=pp_size,
+        registered_layer_names=list(layer_names),
+    )
+    payload = NixlHandshakePayload(
+        compatibility_hash=compat,
+        agent_metadata_bytes=msgspec.msgpack.Encoder().encode(meta),
+    )
+    return msgspec.msgpack.Encoder().encode(payload)
+
+
+class _FakeSock:
+    """ZMQ REQ stand-in: replies to (GET_META_MSG, rank) with rank's payload.
+
+    TP is 1 in these tests, so global_rank == pp_rank."""
+
+    def __init__(
+        self,
+        pp_size,
+        *,
+        engine_id="eng",
+        compat="HASH",
+        layers_per_stage=1,
+        stage_layers=None,
+    ):
+        self.pp_size = pp_size
+        self.engine_id = engine_id
+        self.compat = compat
+        self.layers_per_stage = layers_per_stage
+        # Optional per-stage layer-name lists (for uneven splits); indexed by
+        # global_rank. When None, stages advertise a uniform layers_per_stage.
+        self.stage_layers = stage_layers
+        self.queried = []
+        self._last = None
+
+    def setsockopt(self, *a):
+        pass
+
+    def send(self, msg):
+        _, rank = msgspec.msgpack.decode(msg)
+        self.queried.append(rank)
+        self._last = rank
+
+    def recv(self):
+        return _encode_payload(
+            self._last,
+            self.pp_size,
+            engine_id=self.engine_id,
+            compat=self.compat,
+            layers_per_stage=self.layers_per_stage,
+            layer_names=(
+                self.stage_layers[self._last] if self.stage_layers is not None else None
+            ),
+        )
+
+
+def _make_worker(*, tp_target_ranks=(0,), sw_ratio=None, compat="HASH"):
+    w = object.__new__(RblnNixlConnectorWorker)
+    w.use_host_buffer = True  # skip current_platform.set_device
+    w.transfer_topo = MagicMock()
+    w.transfer_topo.handshake_target_ranks.return_value = list(tp_target_ranks)
+    w.compat_hash = compat
+    w.enforce_compat_hash = True
+    w._sw_ratio = sw_ratio
+    w._remote_shard_layer_names = defaultdict(dict)
+    w._remote_pp_size = {}
+    w._overlapping_ranks = defaultdict(list)
+    # Full-model consumer: owns every producer stage's layer, so every stage
+    # overlaps (the fan-out default). _FakeSock advertises stage i as "layer.i".
+    w.local_seen_layer_names = ["layer.0", "layer.1", "layer.2"]
+    w.add_remote_agent = MagicMock(side_effect=lambda meta, rank, tps: f"agent-{rank}")
+    # Per-shard local handle building is exercised in TestShardLocalRegions;
+    # stub it here so the fan-out tests stay focused on stage enumeration.
+    w._register_shard_read_state = MagicMock()
+    return w
+
+
+@contextmanager
+def _patched_socket(sock):
+    @contextmanager
+    def fake_zmq_ctx(_type, _path):
+        yield sock
+
+    with (
+        patch.object(W, "zmq_ctx", fake_zmq_ctx),
+        patch.object(W, "make_zmq_path", lambda *a: "tcp://x"),
+        patch.object(W, "current_platform", MagicMock()),
+    ):
+        yield
+
+
+def _handshake(worker, sock, *, remote_tp_size=1, engine_id="eng"):
+    with _patched_socket(sock):
+        return worker._nixl_handshake("h", 1234, remote_tp_size, engine_id)
+
+
+class TestPpHandshakeFanout:
+    def test_single_stage_matches_base_shape(self):
+        """pp_size == 1: one shard queried, keyed by tp_rank (global_rank)."""
+        w = _make_worker()
+        sock = _FakeSock(pp_size=1)
+        result = _handshake(w, sock)
+        assert result == {0: "agent-0"}
+        assert sock.queried == [0]  # bootstrap only
+        assert w.add_remote_agent.call_count == 1
+        assert dict(w._remote_shard_layer_names["eng"]) == {0: ("layer.0",)}
+
+    def test_pp_fans_out_over_stages(self):
+        """pp_size == 2: both stages queried and registered by global_rank."""
+        w = _make_worker()
+        sock = _FakeSock(pp_size=2)
+        result = _handshake(w, sock)
+        assert result == {0: "agent-0", 1: "agent-1"}
+        # rank 0 bootstrap (reused), rank 1 queried once.
+        assert sock.queried == [0, 1]
+        ranks = sorted(c.args[1] for c in w.add_remote_agent.call_args_list)
+        assert ranks == [0, 1]
+        assert dict(w._remote_shard_layer_names["eng"]) == {
+            0: ("layer.0",),
+            1: ("layer.1",),
+        }
+        assert w._remote_pp_size["eng"] == 2
+
+    def test_bootstrap_reuses_first_query(self):
+        """The pp_rank-0 shard is queried exactly once (bootstrap reused)."""
+        w = _make_worker()
+        sock = _FakeSock(pp_size=3)
+        _handshake(w, sock)
+        assert sock.queried == [0, 1, 2]
+        assert sock.queried.count(0) == 1
+
+    def test_handshake_registers_only_overlapping_stages(self):
+        """Decode-PP: this rank owns only layer.1, so of the two producer stages
+        only stage 1 overlaps -> only it is handshaked (add_remote_agent) and
+        registered for reading. The non-overlapping stage 0 is skipped BEFORE
+        add_remote_agent so its base FA-remote build never runs (it would index
+        the local block_len_per_layer out of range under an uneven split);
+        its layer names are still recorded during enumeration."""
+        w = _make_worker()
+        w.local_seen_layer_names = ["layer.1"]  # this decode rank's band
+        sock = _FakeSock(pp_size=2)
+        result = _handshake(w, sock)
+        # Only the overlapping stage (1) is handshaked and read.
+        assert result == {1: "agent-1"}
+        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
+        assert set(w._remote_shard_layer_names["eng"]) == {0, 1}  # both enumerated
+        assert w._overlapping_ranks["eng"] == [1]
+        assert w._register_shard_read_state.call_count == 1
+
+    def test_multiple_ratio_registers_k_stages(self):
+        """prefill_pp=4, decode_pp=2 (k=2): this decode rank owns 2 producer
+        stages' layers, so only those 2 are handshaked/registered; the other
+        two non-overlapping stages are skipped before add_remote_agent."""
+        w = _make_worker()
+        w.local_seen_layer_names = ["layer.0", "layer.1"]  # this rank's band
+        sock = _FakeSock(pp_size=4)  # stages advertise layer.0..layer.3
+        _handshake(w, sock)
+        assert sorted(c.args[1] for c in w.add_remote_agent.call_args_list) == [0, 1]
+        assert w._overlapping_ranks["eng"] == [0, 1]  # only owned stages read
+        assert w._register_shard_read_state.call_count == 2
+
+    def test_symmetric_uneven_skips_larger_nonoverlapping_peer(self):
+        """Symmetric PP with an uneven layer split (e.g. 5 layers / 2 = [3, 2]):
+        this decode rank is the *smaller* last stage and owns only its own
+        layers. The peer producer stage is *larger* and does not overlap, so it
+        must be skipped entirely -- add_remote_agent (and hence the base
+        FA-remote build, which indexes the local block_len_per_layer by the
+        remote region position) never runs on it. Regression for the
+        symmetric-uneven PP4-PP4 handshake out-of-range crash."""
+        w = _make_worker()
+        # stage 0 = 3 layers (larger), stage 1 = 2 layers (this rank, smaller).
+        stage_layers = [["layer.0", "layer.1", "layer.2"], ["layer.3", "layer.4"]]
+        w.local_seen_layer_names = ["layer.3", "layer.4"]  # this rank's own stage
+        sock = _FakeSock(pp_size=2, stage_layers=stage_layers)
+        result = _handshake(w, sock)
+        # Only this rank's own (overlapping) stage is handshaked/registered; the
+        # larger non-overlapping peer (stage 0) is skipped, not crashed.
+        assert result == {1: "agent-1"}
+        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
+        assert w._overlapping_ranks["eng"] == [1]
+        assert w._register_shard_read_state.call_count == 1
+
+    def test_partial_overlap_raises(self):
+        """Prefill pipeline size not an integer multiple of the decode pipeline
+        size: a producer stage's layer band straddles this decode rank's band
+        (partial overlap) -> reject."""
+        w = _make_worker()
+        # Producer: 2 stages x 2 layers -> stage0=[layer.0,layer.1],
+        # stage1=[layer.2,layer.3]. This decode rank owns a misaligned band
+        # [layer.1, layer.2], so stage0 partially overlaps (owns layer.1 only).
+        w.local_seen_layer_names = ["layer.1", "layer.2"]
+        sock = _FakeSock(pp_size=2, layers_per_stage=2)
+        with pytest.raises(RuntimeError, match="partially overlaps"):
+            _handshake(w, sock)
+
+    def test_swa_plus_pp_raises(self):
+        w = _make_worker(sw_ratio=0.5)
+        sock = _FakeSock(pp_size=2)
+        with pytest.raises(RuntimeError, match="sliding-window"):
+            _handshake(w, sock)
+
+    def test_tp_plus_pp_raises(self):
+        w = _make_worker(tp_target_ranks=(0,))
+        sock = _FakeSock(pp_size=2)
+        with pytest.raises(RuntimeError, match="tensor parallel"):
+            _handshake(w, sock, remote_tp_size=2)
+
+    def test_compat_hash_mismatch_raises(self):
+        w = _make_worker(compat="LOCAL")
+        sock = _FakeSock(pp_size=1, compat="REMOTE")
+        with pytest.raises(RuntimeError, match="compatibility hash"):
+            _handshake(w, sock)
+
+    def test_engine_id_mismatch_raises(self):
+        w = _make_worker()
+        sock = _FakeSock(pp_size=1, engine_id="other")
+        with pytest.raises(RuntimeError, match="engine ID"):
+            _handshake(w, sock, engine_id="eng")
+
+
+class TestLocalRegionIndicesForLayerNames:
+    """Name-based matching of a producer shard's layers to local region
+    indices."""
+
+    @staticmethod
+    def _worker(local_names):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = list(local_names)
+        return w
+
+    def test_contiguous_shard(self):
+        w = self._worker(["l0", "l1", "l2", "l3"])
+        assert w._local_region_indices_for_layer_names(["l2", "l3"]) == [2, 3]
+        assert w._local_region_indices_for_layer_names(["l0", "l1"]) == [0, 1]
+
+    def test_full_model_consumer_maps_all(self):
+        names = [f"l{i}" for i in range(4)]
+        w = self._worker(names)
+        assert w._local_region_indices_for_layer_names(names) == [0, 1, 2, 3]
+
+    def test_repeated_names_resolved_by_occurrence(self):
+        """HMA pools can register a name more than once; match by occurrence."""
+        w = self._worker(["a", "a", "b"])
+        assert w._local_region_indices_for_layer_names(["a", "b", "a"]) == [0, 2, 1]
+
+    def test_zero_overlap_returns_empty(self):
+        """A producer stage entirely outside this rank's band -> empty: the
+        stage is read by whichever rank owns it, not here."""
+        w = self._worker(["l0", "l1"])
+        assert w._local_region_indices_for_layer_names(["l2"]) == []
+
+    def test_decode_shard_maps_only_owned_band(self):
+        """Decode-PP rank owns layers [l4..l7]: producer stages outside its band
+        map empty; stages inside map to this rank's local indices."""
+        w = self._worker(["l4", "l5", "l6", "l7"])
+        assert w._local_region_indices_for_layer_names(["l0", "l1"]) == []
+        assert w._local_region_indices_for_layer_names(["l4", "l5"]) == [0, 1]
+        assert w._local_region_indices_for_layer_names(["l6", "l7"]) == [2, 3]
+
+
+class TestShardLocalRegions:
+    """Layer-name -> local region-index expansion and the per-shard local
+    xfer handle (region subset)."""
+
+    @staticmethod
+    def _worker(local_names, num_regions):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = list(local_names)
+        w.num_regions = num_regions
+        return w
+
+    def test_regions_per_layer(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
+        assert w._regions_per_layer() == 2  # K/V split
+        w2 = self._worker(["l0", "l1"], num_regions=2)
+        assert w2._regions_per_layer() == 1
+
+    def test_regions_per_layer_non_divisible_raises(self):
+        w = self._worker(["l0", "l1", "l2"], num_regions=8)
+        with pytest.raises(AssertionError, match="not divisible"):
+            w._regions_per_layer()
+
+    def test_shard_local_region_ids_kv_split(self):
+        """rpl=2: layer L -> regions [2L, 2L+1] (layer-major)."""
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
+        assert w._shard_local_region_ids(("l2", "l3")) == [4, 5, 6, 7]
+        assert w._shard_local_region_ids(("l0",)) == [0, 1]
+
+    def test_shard_local_region_ids_no_split(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=4)
+        assert w._shard_local_region_ids(("l1", "l2")) == [1, 2]
+
+    def test_register_shard_local_xfer_handler_covers_subset(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)  # rpl=2
+        w.block_size = 16
+        w.num_blocks = 4
+        w.device_id = 0
+        w.engine_id = "eng"
+        w.tp_rank = 0
+        w._has_mamba = False
+        w.nixl_memory_type = "DRAM"
+        w.kv_caches_base_addr = {"eng": {0: [1000 * i for i in range(8)]}}
+        w.block_len_per_layer = [64] * 8
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.is_kv_layout_blocks_first = False
+        w.get_backend_aware_kv_block_len = MagicMock(return_value=64)
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.prep_xfer_dlist.return_value = 42
+
+        handle, blocks = w._register_shard_local_xfer_handler(16, ("l2", "l3"))
+
+        assert handle == 42
+        # shard regions [4,5,6,7] x num_blocks 4 = 16 descriptors.
+        assert len(blocks) == 16
+        # first desc: region 4 base addr (4000), block 0.
+        assert blocks[0] == (4000, 64, 0)
+        # block 1 of region 4: base + 1*stride(64).
+        assert blocks[1] == (4000 + 64, 64, 0)
+        # regions used are exactly the shard's (no addr below 4000).
+        assert min(a for a, _, _ in blocks) == 4000
+
+
+class TestShardReadPath:
+    """Per-stage read loop + shard descriptor ids."""
+
+    def test_get_block_descs_ids_for_shard(self):
+        """0-based descs over the shard's regions; group_id picks the block
+        group. Single group -> region_id * num_blocks + block_ids[0]."""
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._shard_region_group_ids = {("eng", 1): (0, 0, 0, 0)}  # 4 regions, group 0
+        descs = w._get_block_descs_ids_for_shard(
+            "eng", 1, num_blocks=10, block_ids=[[2, 5]]
+        )
+        # region r contributes r*10 + [2,5]: [2,5, 12,15, 22,25, 32,35]
+        assert list(descs) == [2, 5, 12, 15, 22, 25, 32, 35]
+
+    def test_get_block_descs_ids_for_shard_empty_group(self):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._shard_region_group_ids = {("eng", 0): (0, 0)}
+        descs = w._get_block_descs_ids_for_shard("eng", 0, num_blocks=4, block_ids=[[]])
+        assert descs.size == 0
+
+    @staticmethod
+    def _read_worker(pp_size):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._remote_pp_size = {"eng": pp_size}
+        # Full-model decode: every stage overlaps. Decode-PP subsets this (see
+        # test_reads_only_overlapping_stages).
+        w._overlapping_ranks = {"eng": list(range(pp_size))}
+        w._has_mamba = False  # non-Mamba scope: _apply_prefix_caching end-trims
+        w.world_size = 1
+        w.num_blocks = 8
+        w.dst_num_blocks = {"eng": 8}
+        w._recving_transfers = defaultdict(list)
+        # single group, 2 regions per shard
+        w._shard_region_group_ids = {("eng", r): (0, 0) for r in range(pp_size)}
+        w.src_xfer_handles_by_remote = {("eng", r, 16): 100 + r for r in range(pp_size)}
+        w.dst_xfer_side_handles = {"eng": {r: 200 + r for r in range(pp_size)}}
+        w._remote_agents = {"eng": {r: f"agent{r}" for r in range(pp_size)}}
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(
+            remote_tp_size=1, remote_block_size=16, remote_physical_blocks_per_logical=1
+        )
+        topo.tp_ratio.return_value = 1
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        w._logical_to_remote_kernel_block_ids = lambda ids, _n: ids
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.make_prepped_xfer.side_effect = lambda *a, **k: object()
+        return w
+
+    def _meta(self, local_ids, remote_ids):
+        remote = MagicMock()
+        remote.engine_id = "eng"
+        remote.request_id = "r0"
+        remote.block_ids = remote_ids
+        meta = MagicMock()
+        meta.remote = remote
+        meta.local_physical_block_ids = local_ids
+        return meta
+
+    def test_reads_every_stage(self):
+        """pp_size=2 -> one prepped READ per stage, each with its own shard
+        handles; the request accrues one transfer handle per stage."""
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # stage 0 uses local handle 100 / remote 200; stage 1 -> 101 / 201.
+        calls = w.nixl_wrapper.make_prepped_xfer.call_args_list
+        assert calls[0].args[1] == 100 and calls[0].args[3] == 200
+        assert calls[1].args[1] == 101 and calls[1].args[3] == 201
+        # completion: one handle per stage -> req done only when both finish.
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_prefix_hit_notifies_each_stage_no_read(self):
+        """Full prefix hit (empty local list): no read, one notif per stage."""
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 0
+        assert w.nixl_wrapper.send_notif.call_count == 2
+        assert len(w._recving_transfers["r0"]) == 0
+
+    def test_partial_prefix_hit_trims_remote_per_stage(self):
+        """Partial hit: D allocated only the uncached suffix (1 block) while the
+        remote prompt is 3 blocks, so the remote is end-trimmed to the last
+        block -> local/remote desc counts match per stage and the read fires."""
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([[7]], [[3, 4, 7]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        for c in w.nixl_wrapper.make_prepped_xfer.call_args_list:
+            local_descs, remote_descs = c.args[2], c.args[4]
+            assert len(local_descs) == len(remote_descs)
+            # 2 regions per shard x 1 (trimmed) block = 2 descriptors.
+            assert len(remote_descs) == 2
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_reads_only_overlapping_stages(self):
+        """Decode-PP (m=4, n=2): this rank owns 2 of the 4 producer stages, so
+        it READs only its overlapping stages; the other two are neither read
+        nor notified (another decode rank owns and notifies them)."""
+        w = self._read_worker(pp_size=4)
+        w._overlapping_ranks = {"eng": [0, 1]}  # this rank's band = stages 0,1
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # only stages 0,1 local handles used (100, 101); never 102/103.
+        used = {c.args[1] for c in w.nixl_wrapper.make_prepped_xfer.call_args_list}
+        assert used == {100, 101}
+        assert w.nixl_wrapper.send_notif.call_count == 0
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_prefix_hit_notifies_only_overlapping_stages(self):
+        """Full prefix hit under decode-PP: notify only this rank's stages."""
+        w = self._read_worker(pp_size=4)
+        w._overlapping_ranks = {"eng": [0, 1]}
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 0
+        assert w.nixl_wrapper.send_notif.call_count == 2  # only stages 0,1
+        notified = {c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list}
+        assert notified == {"agent0", "agent1"}
+
+
+class TestValidateRemoteAgentHandshake:
+    """PP-aware handshake validation. The base
+    ``_validate_remote_agent_handshake`` asserts matching P/D region counts
+    (`len(remote.kv_caches_base_addr) == len(self.block_len_per_layer)`), which
+    a layer-sharded PP producer necessarily violates against a full-model
+    consumer. Regression for that end-to-end AssertionError."""
+
+    @staticmethod
+    def _consumer(*, num_layers=28, dst_num_blocks=8):
+        # Full-model host-bounce consumer: num_regions = num_layers * 2 (K/V),
+        # so regions-per-layer = 2.
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = [f"l{i}" for i in range(num_layers)]
+        w.num_regions = num_layers * 2
+        w.block_len_per_layer = [64] * (num_layers * 2)
+        w.dst_num_blocks = {"eng": dst_num_blocks}
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(remote_tp_size=1)
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        return w
+
+    @staticmethod
+    def _meta(*, pp_size, n_regions, num_blocks=8, block_size=16):
+        m = MagicMock()
+        m.pp_size = pp_size
+        m.engine_id = "eng"
+        m.kv_caches_base_addr = [1000 * i for i in range(n_regions)]
+        m.num_blocks = num_blocks
+        m.block_size = block_size
+        return m
+
+    def test_pp_shard_wellformed_passes(self):
+        # 28-layer model, PP2 -> each stage owns 14 layers = 28 regions,
+        # a valid sub-multiple of the local 56. Base assert would fire (28!=56).
+        w = self._consumer(num_layers=28)
+        w._validate_remote_agent_handshake(
+            self._meta(pp_size=2, n_regions=28), remote_tp_size=1
+        )  # no raise
+
+    def test_pp_shard_region_count_not_multiple_of_rpl_raises(self):
+        w = self._consumer(num_layers=28)  # regions-per-layer = 2
+        with pytest.raises(AssertionError, match="sub-multiple"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=27), remote_tp_size=1
+            )
+
+    def test_pp_shard_larger_than_full_model_raises(self):
+        w = self._consumer(num_layers=28)  # full model = 56 regions
+        with pytest.raises(AssertionError, match="sub-multiple"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=58), remote_tp_size=1
+            )
+
+    def test_pp_with_tp_raises(self):
+        w = self._consumer()
+        w.transfer_topo.get_engine_info.return_value = MagicMock(remote_tp_size=2)
+        with pytest.raises(AssertionError, match="TP=1"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28), remote_tp_size=2
+            )
+
+    def test_pp_block_size_mismatch_raises(self):
+        w = self._consumer()
+        w.transfer_topo.block_size_ratio.return_value = 2
+        with pytest.raises(AssertionError, match="block sizes"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28), remote_tp_size=1
+            )
+
+    def test_pp_num_blocks_mismatch_raises(self):
+        w = self._consumer(dst_num_blocks=8)
+        with pytest.raises(AssertionError):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28, num_blocks=16), remote_tp_size=1
+            )
+
+    def test_non_pp_delegates_to_base(self):
+        # pp_size == 1 must fall through to the upstream validation untouched.
+        w = self._consumer()
+        base = RblnNixlConnectorWorker.__bases__[0]
+        with patch.object(base, "_validate_remote_agent_handshake") as base_val:
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=1, n_regions=56), remote_tp_size=1
+            )
+        base_val.assert_called_once()
+
+
+class TestPpConstraints:
+    """Reject PP + unsupported features early."""
+
+    @staticmethod
+    def _worker(*, pp_size, cross_layers=False, has_mamba=False, sw_ratio=None):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = pp_size
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.cross_layers_blocks = cross_layers
+        w._has_mamba = has_mamba
+        w._sw_ratio = sw_ratio
+        return w
+
+    def test_no_pp_is_noop(self):
+        # pp_size == 1: even with otherwise-unsupported features, no raise.
+        self._worker(
+            pp_size=1, cross_layers=True, has_mamba=True, sw_ratio=2
+        )._check_pp_constraints()
+
+    def test_plain_pp_ok(self):
+        self._worker(pp_size=2)._check_pp_constraints()
+
+    def test_cross_layers_pp_raises(self):
+        with pytest.raises(RuntimeError, match="cross-layer-blocks"):
+            self._worker(pp_size=2, cross_layers=True)._check_pp_constraints()
+
+    def test_mamba_pp_raises(self):
+        with pytest.raises(RuntimeError, match="Mamba"):
+            self._worker(pp_size=2, has_mamba=True)._check_pp_constraints()
+
+    def test_swa_pp_raises(self):
+        with pytest.raises(RuntimeError, match="sliding-window"):
+            self._worker(pp_size=2, sw_ratio=2)._check_pp_constraints()
+
+
+class TestPublishPpHandshakeMetadata:
+    """The shared producer-side helper used by BOTH the D2D and the
+    host-bounce paths, so PP metadata is advertised regardless of transport."""
+
+    @staticmethod
+    def _base_meta():
+        return NixlAgentMetadata(
+            engine_id="eng",
+            agent_metadata=b"agent",
+            kv_caches_base_addr=[0x1000, 0x2000],
+            device_id=0,
+            num_blocks=4,
+            block_lens=[8192, 8192],
+            kv_cache_layout="HND",
+            block_size=16,
+            ssm_sizes=(0, 0),
+            attn_backend_name="RBLN",
+            physical_blocks_per_logical_kv_block=1,
+        )
+
+    def _publish(self, *, pp_rank, pp_size, layer_names):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.compat_hash = "BASE"
+        # _check_pp_constraints reads these; a plain PP producer passes.
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = pp_size
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.cross_layers_blocks = False
+        w._has_mamba = False
+        w._sw_ratio = None
+        pp_group = MagicMock()
+        pp_group.rank_in_group = pp_rank
+        pp_group.world_size = pp_size
+        with patch.object(W, "get_pp_group", return_value=pp_group):
+            w._publish_pp_handshake_metadata(self._base_meta(), layer_names)
+        return w
+
+    def test_wraps_base_and_folds_compat(self):
+        w = self._publish(pp_rank=1, pp_size=2, layer_names=["l7", "l8"])
+        # compat hash folded with the RBLN PP version and mirrored into payload.
+        assert w.compat_hash == rbln_pp_compat_hash("BASE")
+        assert w.xfer_handshake_metadata.compatibility_hash == w.compat_hash
+        decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            w.xfer_handshake_metadata.agent_metadata_bytes
+        )
+        # base fields preserved ...
+        assert decoded.engine_id == "eng"
+        assert decoded.block_lens == [8192, 8192]
+        assert decoded.kv_caches_base_addr == [0x1000, 0x2000]
+        # ... and PP fields populated.
+        assert (decoded.pp_rank, decoded.pp_size) == (1, 2)
+        assert decoded.registered_layer_names == ["l7", "l8"]
+
+    def test_single_stage_defaults(self):
+        """pp_size == 1 still folds compat but advertises no-PP layer fields."""
+        w = self._publish(pp_rank=0, pp_size=1, layer_names=["l0"])
+        decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            w.xfer_handshake_metadata.agent_metadata_bytes
+        )
+        assert (decoded.pp_rank, decoded.pp_size) == (0, 1)

--- a/tests/torch_compile/unit/v1/core/test_rbln_nixl_metadata.py
+++ b/tests/torch_compile/unit/v1/core/test_rbln_nixl_metadata.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for the RBLN NIXL PP metadata extension.
+
+Self-contained: exercises only ``rbln_nixl.metadata`` (base vLLM NIXL +
+msgspec + hash), so it does not require the ``nixl-rbln`` install or a worker.
+"""
+
+import msgspec
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RBLN_NIXL_PP_VERSION,
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
+
+_BASE_FIELDS = dict(
+    engine_id="engine-0",
+    agent_metadata=b"agent-bytes",
+    kv_caches_base_addr=[0x1000, 0x2000],
+    device_id=0,
+    num_blocks=64,
+    block_lens=[8192, 8192],
+    kv_cache_layout="HND",
+    block_size=16,
+    ssm_sizes=(0, 0),
+    attn_backend_name="RBLN_FLASH_ATTN",
+    physical_blocks_per_logical_kv_block=1,
+)
+
+
+def _make(**pp):
+    return RblnNixlAgentMetadata(**_BASE_FIELDS, **pp)
+
+
+class TestRblnNixlAgentMetadata:
+    def test_defaults_are_single_stage(self):
+        """Omitting PP fields yields the pp_size==1 (no-PP) values."""
+        m = _make()
+        assert (m.pp_rank, m.pp_size) == (0, 1)
+        assert m.registered_layer_names == []
+
+    def test_roundtrip_preserves_pp_fields(self):
+        """msgspec encode→decode with the RBLN type preserves PP descriptors."""
+        m = _make(
+            pp_rank=1,
+            pp_size=2,
+            registered_layer_names=["model.layers.14", "model.layers.15"],
+        )
+        enc = msgspec.msgpack.Encoder().encode(m)
+        back = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(enc)
+        assert back == m
+        assert back.pp_rank == 1
+        assert back.pp_size == 2
+        assert back.registered_layer_names == [
+            "model.layers.14",
+            "model.layers.15",
+        ]
+
+    def test_base_consumer_ignores_pp_fields(self):
+        """A blob encoded with the RBLN type decodes cleanly as the base
+        ``NixlAgentMetadata`` (PP fields ignored) — backward compatible."""
+        enc = msgspec.msgpack.Encoder().encode(_make(pp_rank=1, pp_size=2))
+        base = msgspec.msgpack.Decoder(NixlAgentMetadata).decode(enc)
+        assert base.engine_id == "engine-0"
+        assert base.num_blocks == 64
+        assert base.block_lens == [8192, 8192]
+        assert not hasattr(base, "pp_rank")
+
+    def test_registered_layer_names_order_preserved(self):
+        names = [f"model.layers.{i}" for i in range(14, 28)]
+        m = _make(pp_rank=1, pp_size=2, registered_layer_names=names)
+        back = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            msgspec.msgpack.Encoder().encode(m)
+        )
+        assert back.registered_layer_names == names
+
+
+class TestRblnPpCompatHash:
+    def test_deterministic(self):
+        assert rbln_pp_compat_hash("BASE") == rbln_pp_compat_hash("BASE")
+
+    def test_differs_from_base(self):
+        """Folding the PP version must change the hash, so a PP-aware producer
+        and a PP-unaware peer (base hash) do not match."""
+        assert rbln_pp_compat_hash("BASE") != "BASE"
+
+    def test_distinguishes_base_hashes(self):
+        assert rbln_pp_compat_hash("hash-a") != rbln_pp_compat_hash("hash-b")
+
+    def test_version_is_folded(self, monkeypatch):
+        """Bumping RBLN_NIXL_PP_VERSION changes the hash (gates schema drift)."""
+        from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl import (
+            metadata as md,
+        )
+
+        h1 = md.rbln_pp_compat_hash("BASE")
+        monkeypatch.setattr(md, "RBLN_NIXL_PP_VERSION", RBLN_NIXL_PP_VERSION + 1)
+        assert md.rbln_pp_compat_hash("BASE") != h1

--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -15,6 +15,7 @@
 from vllm.v1.request import RequestStatus
 
 from .utils import (
+    advance_to_decode,
     create_requests,
     create_runner_output,
     create_scheduler,
@@ -394,3 +395,185 @@ def _check_invariant(sched_out, req_id):
     assert n == 1 + len(spec), (
         f"req {req_id}: num_scheduled_tokens={n} but 1+spec={1 + len(spec)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Decode-cap machinery: DecodeBatchBudget / DynamicDecodeCapPolicy /
+# StaticDecodeCapPolicy / DecodeAdmissionController. Ported from
+# feat/nixl-pp-kv-transfer -- the refactor carried the classes over but dropped
+# their direct coverage (discard()/soft-vs-hard-cap are hard to verify by
+# reading alone, and PP decode-cap bugs kept surfacing on device, not in CI).
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_decode_cap_policy():
+    """DynamicDecodeCapPolicy spreads active decodes across PP stages:
+    cap = max(1, min(static_max, ceil(active / pp_size)))."""
+    import math
+
+    from vllm_rbln.v1.core.utils import DynamicDecodeCapPolicy
+
+    # static_max = 8 (e.g. max_num_seqs=16, pp=2)
+    # Few active -> spread below the static ceiling (avoids collapse).
+    assert DynamicDecodeCapPolicy(8, 2, 6).cap() == math.ceil(6 / 2) == 3
+    assert DynamicDecodeCapPolicy(8, 2, 1).cap() == 1
+    # No active -> floored at 1 (never 0, which would break the budget).
+    assert DynamicDecodeCapPolicy(8, 2, 0).cap() == 1
+    # ceil(15/2)=8 reaches the ceiling.
+    assert DynamicDecodeCapPolicy(8, 2, 15).cap() == 8
+    # Clamp: never exceed static_max (the compiled bucket ceiling).
+    assert DynamicDecodeCapPolicy(8, 2, 100).cap() == 8
+    # Non-divisible max_num_seqs: ceil(33/2)=17 clamps down to static_max 16.
+    assert DynamicDecodeCapPolicy(16, 2, 33).cap() == 16
+    # pp_size == 1: cap = min(static_max, active) -> no-op vs static.
+    assert DynamicDecodeCapPolicy(16, 1, 5).cap() == 5
+    assert DynamicDecodeCapPolicy(16, 1, 20).cap() == 16
+
+
+def test_decode_budget_hard_vs_soft_cap():
+    """DecodeBatchBudget.can_admit: the hard cap (compiled bucket ceiling)
+    always applies; the soft (spreading) cap applies only when apply_soft_cap.
+    Demand-unbudgeted joins (apply_soft_cap=False -- full local prefix match /
+    resumed-after-eviction) fill up to the hard cap, not the soft one."""
+    from vllm_rbln.v1.core.utils import (
+        DecodeBatchBudget,
+        DynamicDecodeCapPolicy,
+        StaticDecodeCapPolicy,
+    )
+
+    # Balance: hard=8, soft=ceil(4/2)=2.
+    b = DecodeBatchBudget(DynamicDecodeCapPolicy(8, 2, 4), hard_cap=8)
+    b.admit(2)  # count == soft
+    assert not b.can_admit()  # budgeted: gated at soft (2)
+    assert b.can_admit(apply_soft_cap=False)  # unbudgeted: hard (8) has room
+    b.admit(6)  # count == hard
+    assert not b.can_admit(apply_soft_cap=False)  # hard cap reached
+    assert not b.can_admit()
+
+    # Static: soft == hard, so apply_soft_cap makes no difference.
+    b2 = DecodeBatchBudget(StaticDecodeCapPolicy(8), hard_cap=8)
+    b2.admit(8)
+    assert not b2.can_admit()
+    assert not b2.can_admit(apply_soft_cap=False)
+
+
+def test_decode_budget_discard():
+    """discard() un-admits decodes dropped from the step (PRIORITY-policy
+    preemption of an already-scheduled decode) so the can_admit() gate is
+    not stopped early on a stale over-count. Unlike reset() it only removes
+    the dropped ones, leaving the still-admitted decodes counted."""
+    from vllm_rbln.v1.core.utils import DecodeBatchBudget, StaticDecodeCapPolicy
+
+    b = DecodeBatchBudget(StaticDecodeCapPolicy(2), hard_cap=2)
+    b.admit(2)  # batch full at the cap
+    assert not b.can_admit()  # gate closed
+    b.discard()  # a scheduled decode is preempted -> one slot freed
+    assert b.count == 1
+    assert b.can_admit()  # gate reopens for another admit
+    # reset() would instead zero the whole count (whole-batch eviction).
+    b.reset()
+    assert b.count == 0
+
+
+def test_priority_preemption_discards_admitted_decode(monkeypatch):
+    """When the PRIORITY policy preempts an ALREADY-SCHEDULED decode to free KV
+    blocks, the scheduler un-admits it from the per-step decode budget via
+    `discard()`, keeping the admitted count in step with the batch so the
+    `can_admit()` gate is not stopped early on a stale over-count.
+
+    Two decodes each need a fresh block this step but only one block is free,
+    so scheduling the trigger preempts the victim (higher priority value =
+    lower scheduling importance). The victim was already scheduled this step,
+    so `discard()` must fire exactly once.
+    """
+    from vllm.v1.core.sched.request_queue import SchedulingPolicy
+
+    from vllm_rbln.v1.core.utils import DecodeBatchBudget
+
+    discard_calls = []
+    orig_discard = DecodeBatchBudget.discard
+
+    def spy(self, n=1):
+        discard_calls.append(n)
+        return orig_discard(self, n)
+
+    monkeypatch.setattr(DecodeBatchBudget, "discard", spy)
+
+    block_size = 16
+    # num_blocks=4 -> 3 usable (block 0 is the null block): one block per
+    # prefill (2) leaves exactly one free for a decode boundary block, so only
+    # one of the two decodes can grow this step.
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_num_seqs=4,
+        block_size=block_size,
+        num_blocks=4,
+        enable_prefix_caching=False,
+    )
+    scheduler.policy = SchedulingPolicy.PRIORITY
+
+    victim, trigger = create_requests(
+        num_requests=2,
+        num_tokens=block_size,
+        block_size=block_size,
+        req_ids=["victim", "trigger"],
+    )
+    # Higher priority VALUE == lower scheduling importance == preempted first.
+    victim.priority = 1
+    trigger.priority = 0
+    for r in (victim, trigger):
+        advance_to_decode(scheduler, r)
+
+    out = scheduler.schedule()
+
+    assert victim.status == RequestStatus.PREEMPTED
+    assert trigger.request_id in out.num_scheduled_tokens
+    assert discard_calls == [1], (
+        "discard() must fire exactly once for the preempted already-scheduled "
+        f"decode, got {discard_calls}"
+    )
+
+
+def test_pp_balance_decode_spreads_microbatch(monkeypatch):
+    """With VLLM_RBLN_PP_BALANCE_DECODE_BATCH=1 under PP, one step's
+    decode batch is sized to ~ceil(active / pp_size), spreading the active
+    decodes across the PP microbatches instead of packing them into one
+    (which would idle the other stage). The static default packs more.
+    """
+    import math
+
+    from vllm_rbln.v1.core.rbln_scheduler import is_prefill
+
+    n = 6
+
+    def run(balance: bool):
+        if balance:
+            monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "1")
+        else:
+            # Force the static cap explicitly: the default is now on under PP,
+            # so unsetting would still give the balanced (dynamic) behavior.
+            monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "0")
+        # max_num_seqs=16, pp=2 -> static cap 8; n=6 active -> ceil(6/2)=3.
+        scheduler = create_scheduler(
+            max_num_seqs=16, pipeline_parallel_size=2, block_size=16
+        )
+        reqs = create_requests(
+            num_requests=n,
+            num_tokens=32,
+            block_size=16,
+            req_ids=[f"d{i}" for i in range(n)],
+        )
+        for r in reqs:
+            advance_to_decode(scheduler, r)
+        running_decodes = sum(1 for r in scheduler.running if not is_prefill(r))
+        out = scheduler.schedule()
+        return running_decodes, len(out.num_scheduled_tokens)
+
+    run_on, sched_on = run(True)
+    run_off, sched_off = run(False)
+
+    # Balanced: at most ceil(active / pp) admitted this step.
+    assert sched_on <= math.ceil(run_on / 2)
+    assert sched_on >= 1
+    # Static packs more decodes into the single microbatch than balanced does.
+    assert sched_off > sched_on

--- a/tests/torch_compile/unit/v1/core/test_spec_pp_helpers.py
+++ b/tests/torch_compile/unit/v1/core/test_spec_pp_helpers.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the speculative-decode + pipeline-parallelism scheduler/runner
+helpers in ``vllm_rbln.v1.core.utils``:
+
+  * ``should_defer_spec_step`` -- the running-loop anchor-reconciled deferral
+    predicate (a verify is scheduled only once its base/anchor token is
+    reconciled under sync-scheduling PP).
+  * ``num_base_tokens`` / ``resolve_propagated_token_write`` -- the non-last-PP-
+    rank multi-accept token propagation bookkeeping (bring the recorded-token
+    cursor up to committed_tip by writing the scheduler-propagated payload at
+    absolute position).
+
+These are pure functions, so they are exercised directly (no scheduler or
+runner instance).
+"""
+
+from vllm_rbln.v1.core.utils import (
+    num_base_tokens,
+    resolve_propagated_token_write,
+    should_defer_spec_step,
+)
+
+
+class TestSpecDecodePropagationHelpers:
+    """Pure helpers extracted from the scheduler + runner non-last-rank token
+    propagation: num_base_tokens and resolve_propagated_token_write."""
+
+    def test_num_base_tokens(self):
+        num_sched = {"A": 4, "B": 1}
+        drafts = {"A": [1, 2, 3]}  # B carries no drafts this step
+        assert num_base_tokens(num_sched, drafts, "A") == 1  # 4 - 3 drafts
+        assert num_base_tokens(num_sched, drafts, "B") == 1  # 1 - 0
+        assert num_base_tokens(num_sched, drafts, "missing") == 0
+
+    def test_write_normal_decode_writes_newest_token(self):
+        # base=1, cursor caught up (== num_computed). Payload is extended
+        # backward by num_spec (positions 97..100); write only the newest.
+        payload = [10, 11, 12, 13]
+        assert resolve_propagated_token_write(
+            cursor=100, num_computed_tokens=100, base=1, new_token_ids=payload
+        ) == (101, [13])
+
+    def test_write_multi_accept_lag_fills_gap(self):
+        # After a verify accepted 3 drafts the cursor lags num_computed by 3;
+        # the extended payload lets PP0 fill positions 97..100 by absolute pos.
+        payload = [10, 11, 12, 13]
+        assert resolve_propagated_token_write(
+            cursor=97, num_computed_tokens=100, base=1, new_token_ids=payload
+        ) == (101, [10, 11, 12, 13])
+
+    def test_write_nothing_when_cursor_at_tip(self):
+        assert (
+            resolve_propagated_token_write(
+                cursor=101, num_computed_tokens=100, base=1, new_token_ids=[10, 11]
+            )
+            is None
+        )
+
+    def test_write_empty_payload_advances_cursor_only(self):
+        # Async GPU-broadcast path: no payload, cursor still advances.
+        assert resolve_propagated_token_write(
+            cursor=100, num_computed_tokens=100, base=1, new_token_ids=[]
+        ) == (101, [])
+
+    def test_write_out_of_window_falls_back_to_tail(self):
+        # Defensive: a payload too short to cover [cursor, committed_tip) falls
+        # back to its tail so the cursor still advances in-bounds.
+        assert resolve_propagated_token_write(
+            cursor=97, num_computed_tokens=100, base=1, new_token_ids=[13]
+        ) == (101, [13])
+
+
+class TestShouldDeferSpecStep:
+    """Pure predicate for the spec+PP running-loop deferral."""
+
+    def test_disabled_when_spec_off(self):
+        # num_spec_tokens == 0: never defers, even for a negative num_new.
+        assert should_defer_spec_step(0, [], -3) is False
+        assert should_defer_spec_step(0, [], 0) is False
+
+    def test_drafts_held_defers_on_base_le_zero(self):
+        # base = num_new - len(drafts). drafts=[1,2,3].
+        assert should_defer_spec_step(3, [1, 2, 3], 3) is True  # base 0
+        assert should_defer_spec_step(3, [1, 2, 3], 0) is True  # base -3
+        assert should_defer_spec_step(3, [1, 2, 3], 4) is False  # base 1
+
+    def test_no_drafts_defers_only_on_negative(self):
+        # base == num_new. Only the post-verify overshoot (negative) defers;
+        # the mundane == 0 and any positive are left to the caller.
+        assert should_defer_spec_step(3, [], -3) is True
+        assert should_defer_spec_step(3, [], 0) is False
+        assert should_defer_spec_step(3, [], 1) is False

--- a/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
+++ b/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
@@ -123,6 +123,10 @@ def make_fake_runner(
         kv_cache_view_infos=[],
         compile_context=object(),
         is_prefill=is_prefill,
+        # eagle.propose reads the scheduler-stamped phase via the method
+        # is_prefill_phase() (feat(pp) replaced the per-rank is_prefill property),
+        # so the fake must expose it as a callable, not just the bool attribute.
+        is_prefill_phase=lambda: is_prefill,
         is_intermediate_chunked_prefill=is_intermediate_chunked_prefill,
         # _build_dummy_attn_metadata only consumes the cumsum (arange ignored).
         _get_cumsum_and_arange=lambda num_tokens, cumsum_dtype=None: (

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -3149,7 +3149,7 @@ def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypat
     rbln_model_runner._is_prefill_step = True
     assert rbln_model_runner.is_prefill_phase() is True
 
-    num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+    num_reqs_padded, num_tokens_padded, num_tokens_across_dp, _ = (
         rbln_model_runner._determine_batch_padding(
             num_reqs_unpadded=3,
             num_tokens_unpadded=8,
@@ -3165,7 +3165,7 @@ def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypat
     rbln_model_runner._is_prefill_step = False
     assert rbln_model_runner.is_prefill_phase() is False
 
-    num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+    num_reqs_padded, num_tokens_padded, num_tokens_across_dp, _ = (
         rbln_model_runner._determine_batch_padding(
             num_reqs_unpadded=3,
             num_tokens_unpadded=3,
@@ -3206,6 +3206,7 @@ def test_determine_batch_padding_data_parallel_prefill_uses_max_num_tokens(
         dp_size,
         dp_rank,
         is_prefill,
+        is_idle=False,
     ):
         calls.append(
             {
@@ -3216,7 +3217,11 @@ def test_determine_batch_padding_data_parallel_prefill_uses_max_num_tokens(
                 "is_prefill": is_prefill,
             }
         )
-        return torch.tensor([64, 96], dtype=torch.int32), None
+        return (
+            torch.tensor([64, 96], dtype=torch.int32),
+            None,
+            torch.tensor([0, 0], dtype=torch.int32),  # no dummy ranks
+        )
 
     monkeypatch.setattr(
         rbln_model_runner_module.RBLNDPMetadata,
@@ -3230,7 +3235,7 @@ def test_determine_batch_padding_data_parallel_prefill_uses_max_num_tokens(
         FakeBucketingManager(fail_message="decode bucket must not be used for prefill"),
     )
 
-    num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+    num_reqs_padded, num_tokens_padded, num_tokens_across_dp, _ = (
         rbln_model_runner._determine_batch_padding(
             num_reqs_unpadded=3,
             num_tokens_unpadded=64,
@@ -3293,6 +3298,7 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
         dp_size,
         dp_rank,
         is_prefill,
+        is_idle=False,
     ):
         calls.append(
             {
@@ -3305,8 +3311,10 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
         )
         # Simulate this rank having 3 requests with 4 query tokens each, while
         # another rank requires bucket selection for max request count == 5.
-        return torch.tensor([12, 20], dtype=torch.int32), torch.tensor(
-            [3, 5], dtype=torch.int32
+        return (
+            torch.tensor([12, 20], dtype=torch.int32),
+            torch.tensor([3, 5], dtype=torch.int32),
+            torch.tensor([0, 0], dtype=torch.int32),  # no dummy ranks
         )
 
     monkeypatch.setattr(
@@ -3322,7 +3330,7 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
         fake_bucketing_manager,
     )
 
-    num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+    num_reqs_padded, num_tokens_padded, num_tokens_across_dp, _ = (
         rbln_model_runner._determine_batch_padding(
             num_reqs_unpadded=3,
             num_tokens_unpadded=12,
@@ -3394,6 +3402,7 @@ def test_determine_batch_padding_specialized_moe_qlen_asymmetric_top_bucket(
         dp_size,
         dp_rank,
         is_prefill,
+        is_idle=False,
     ):
         calls.append(
             {
@@ -3406,8 +3415,10 @@ def test_determine_batch_padding_specialized_moe_qlen_asymmetric_top_bucket(
         )
         # This rank: 3 requests x qlen 1 (== 3 tokens). A peer: 5 requests x
         # qlen 4 (spec, == 20 tokens). tokens_per_req = [1, 4] -> qlen-asymmetric.
-        return torch.tensor([3, 20], dtype=torch.int32), torch.tensor(
-            [3, 5], dtype=torch.int32
+        return (
+            torch.tensor([3, 20], dtype=torch.int32),
+            torch.tensor([3, 5], dtype=torch.int32),
+            torch.tensor([0, 0], dtype=torch.int32),  # no dummy ranks
         )
 
     monkeypatch.setattr(
@@ -3425,12 +3436,17 @@ def test_determine_batch_padding_specialized_moe_qlen_asymmetric_top_bucket(
         fake_bucketing_manager,
     )
 
-    num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+    num_reqs_padded, num_tokens_padded, num_tokens_across_dp, eff_qlen = (
         rbln_model_runner._determine_batch_padding(
             num_reqs_unpadded=3,
             num_tokens_unpadded=3,
         )
     )
+
+    # Here the token count is a padding target, not request-count x length, so an
+    # idle rank adopts query length 1 (the smallest prepared graph) rather than
+    # the longer speculative length.
+    assert eff_qlen == 1
 
     assert calls == [
         {
@@ -3457,6 +3473,159 @@ def test_determine_batch_padding_specialized_moe_qlen_asymmetric_top_bucket(
     assert num_tokens_across_dp.dtype == torch.int32
     assert num_tokens_across_dp.device.type == "cpu"
     assert num_tokens_across_dp.tolist() == [3, 20]
+
+
+def test_determine_batch_padding_dummy_excluded_from_decision(
+    rbln_model_runner, monkeypatch
+):
+    """A DP-idle dummy rank is EXCLUDED from the cross-DP shape decision: a busy
+    peer running symmetric spec (qlen 4) still routes to its per-bucket decode
+    graph, not the top-bucket fall-back, even though this (dummy) rank presents
+    qlen 1. Without the exclusion the qlen-asymmetry (1 vs 4) would wrongly force
+    the top bucket."""
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
+
+    monkeypatch.setattr(rbln_model_runner.parallel_config, "data_parallel_size", 2)
+    monkeypatch.setattr(rbln_model_runner.parallel_config, "data_parallel_rank", 0)
+    monkeypatch.setattr(
+        rbln_model_runner, "specialized_moe_decode", True, raising=False
+    )
+
+    def fake_across_dp(
+        num_tokens, num_reqs, dp_size, dp_rank, is_prefill, is_idle=False
+    ):
+        # rank0 = this dummy rank (qlen 1), rank1 = busy spec peer (qlen 4).
+        return (
+            torch.tensor([1, 4], dtype=torch.int32),
+            torch.tensor([1, 1], dtype=torch.int32),
+            torch.tensor([1, 0], dtype=torch.int32),
+        )
+
+    monkeypatch.setattr(
+        rbln_model_runner_module.RBLNDPMetadata,
+        "num_tokens_and_reqs_across_dp",
+        staticmethod(fake_across_dp),
+    )
+    monkeypatch.setattr(
+        rbln_model_runner,
+        "bucketing_manager",
+        FakeBucketingManager(buckets={1: 4}, decode_batch_buckets=[4, 8]),
+    )
+
+    num_reqs_padded, num_tokens_padded, _, eff_qlen = (
+        rbln_model_runner._determine_batch_padding(
+            num_reqs_unpadded=1, num_tokens_unpadded=1, is_idle=True
+        )
+    )
+
+    # Decided from the non-dummy peer only (symmetric qlen 4) -> per-bucket
+    # find_decode_batch_bucket(1) == 4, NOT the top bucket (8).
+    assert num_reqs_padded == 4
+    assert num_tokens_padded == 16  # 4 (bucket) * 4 (peer qlen)
+    # The peers agree on query length, so the idle rank just follows them: no
+    # explicit query length is pinned (it is derived from the token count).
+    assert eff_qlen is None
+
+
+def test_determine_batch_padding_all_dummy_uses_minimal_bucket(
+    rbln_model_runner, monkeypatch
+):
+    """When every DP rank is a dummy (lockstep wind-down / re-sync) there is no
+    real work to size to -> fall back to the smallest compiled decode graph
+    (decode_batch_buckets[0], qlen 1)."""
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
+
+    monkeypatch.setattr(rbln_model_runner.parallel_config, "data_parallel_size", 2)
+    monkeypatch.setattr(rbln_model_runner.parallel_config, "data_parallel_rank", 0)
+    monkeypatch.setattr(
+        rbln_model_runner, "specialized_moe_decode", True, raising=False
+    )
+
+    def fake_across_dp(
+        num_tokens, num_reqs, dp_size, dp_rank, is_prefill, is_idle=False
+    ):
+        return (
+            torch.tensor([1, 1], dtype=torch.int32),
+            torch.tensor([1, 1], dtype=torch.int32),
+            torch.tensor([1, 1], dtype=torch.int32),  # all dummy
+        )
+
+    monkeypatch.setattr(
+        rbln_model_runner_module.RBLNDPMetadata,
+        "num_tokens_and_reqs_across_dp",
+        staticmethod(fake_across_dp),
+    )
+    monkeypatch.setattr(
+        rbln_model_runner,
+        "bucketing_manager",
+        FakeBucketingManager(buckets={1: 4}, decode_batch_buckets=[4, 8]),
+    )
+
+    num_reqs_padded, num_tokens_padded, _, eff_qlen = (
+        rbln_model_runner._determine_batch_padding(
+            num_reqs_unpadded=1, num_tokens_unpadded=1, is_idle=True
+        )
+    )
+
+    # decode_batch_buckets[0] == 4 (smallest), qlen 1.
+    assert num_reqs_padded == 4
+    assert num_tokens_padded == 4
+    # No busy rank to follow, so the query length is derived from the token count
+    # (== 1) -> the smallest decode graph.
+    assert eff_qlen is None
+
+
+def test_determine_batch_padding_dummy_any_prefill_uses_qlen_1(
+    rbln_model_runner, monkeypatch
+):
+    """When a peer is reading a prompt, an idle rank cannot see any peer query
+    length, so it adopts query length 1 (eff_qlen == 1): it runs the smallest
+    prepared graph at the largest request count and lets the padding target ride
+    along on its own, instead of an oversized length from dividing the padding
+    target by the request count."""
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
+
+    monkeypatch.setattr(rbln_model_runner.parallel_config, "data_parallel_size", 2)
+    monkeypatch.setattr(rbln_model_runner.parallel_config, "data_parallel_rank", 0)
+    monkeypatch.setattr(
+        rbln_model_runner, "specialized_moe_decode", True, raising=False
+    )
+
+    def fake_across_dp(
+        num_tokens, num_reqs, dp_size, dp_rank, is_prefill, is_idle=False
+    ):
+        # rank0 = this idle rank; rank1 = a busy peer reading a prompt, which
+        # makes the shared request count come back as None.
+        return (
+            torch.tensor([1, 64], dtype=torch.int32),
+            None,
+            torch.tensor([1, 0], dtype=torch.int32),
+        )
+
+    monkeypatch.setattr(
+        rbln_model_runner_module.RBLNDPMetadata,
+        "num_tokens_and_reqs_across_dp",
+        staticmethod(fake_across_dp),
+    )
+    monkeypatch.setattr(
+        rbln_model_runner,
+        "bucketing_manager",
+        FakeBucketingManager(buckets={1: 4}, decode_batch_buckets=[4, 8]),
+    )
+
+    num_reqs_padded, num_tokens_padded, _, eff_qlen = (
+        rbln_model_runner._determine_batch_padding(
+            num_reqs_unpadded=1, num_tokens_unpadded=1, is_idle=True
+        )
+    )
+
+    # Largest request count, padded to the max token budget, query length 1.
+    assert num_reqs_padded == 8
+    assert num_tokens_padded == rbln_model_runner.max_num_tokens
+    assert eff_qlen == 1
 
 
 def test_may_reinitialize_input_batch_rebuilds_on_kernel_block_size_change(

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -438,11 +438,26 @@ class FakeSpecConfig:
 
 
 class FakeBucketingManager:
-    def __init__(self, *, buckets=None, default=None, fail_message: str | None = None):
+    def __init__(
+        self,
+        *,
+        buckets=None,
+        default=None,
+        fail_message: str | None = None,
+        decode_batch_buckets=None,
+    ):
         self.buckets = buckets or {}
         self.default = default
         self.fail_message = fail_message
         self.calls: list[Any] = []
+        # Mirror the real RBLNBucketingManager attribute (the sorted decode
+        # batch bucket sizes). Defaults to the distinct find_decode_batch_bucket
+        # targets when not given explicitly.
+        self.decode_batch_buckets = (
+            decode_batch_buckets
+            if decode_batch_buckets is not None
+            else sorted(set(self.buckets.values()))
+        )
 
     def find_decode_batch_bucket(self, batch_size):
         if self.fail_message is not None:
@@ -3244,8 +3259,11 @@ def test_determine_batch_padding_data_parallel_prefill_uses_max_num_tokens(
 def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
     rbln_model_runner, monkeypatch
 ):
-    """Specialized MoE decode should bucket by request count and pad by the
-    request bucket times the per-request query length."""
+    """Specialized MoE decode on a qlen-SYMMETRIC step (all DP ranks share the
+    same query length -- here every rank runs qlen 4) buckets by the cross-DP
+    max request count and pads by that bucket times the per-request query
+    length. It does NOT fall back to the top bucket -- that is reserved for
+    qlen-asymmetric steps (see the qlen_asymmetric test below)."""
     # Force decode via the scheduler-stamped phase.
     rbln_model_runner._is_prefill_step = False
     assert rbln_model_runner.is_prefill_phase() is False
@@ -3322,9 +3340,13 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
     ]
 
     # First call: initial decode padding for this rank's unpadded request count.
-    # Second call: specialized MoE decode repads using cross-DP max request count.
+    # Second call: qlen-symmetric specialized MoE decode repads using the
+    # cross-DP max request count (per-bucket, find_decode_batch_bucket(5) == 8),
+    # NOT the top bucket.
     assert fake_bucketing_manager.calls == [3, 5]
 
+    # num_reqs_padded == decode_batch_buckets[-1]; padded tokens == that bucket
+    # times the per-request query length (max_tokens_per_req == 4).
     assert num_reqs_padded == 8
     assert num_tokens_padded == 32
 
@@ -3332,6 +3354,109 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
     assert num_tokens_across_dp.dtype == torch.int32
     assert num_tokens_across_dp.device.type == "cpu"
     assert num_tokens_across_dp.tolist() == [12, 20]
+
+
+def test_determine_batch_padding_specialized_moe_qlen_asymmetric_top_bucket(
+    rbln_model_runner, monkeypatch
+):
+    """Specialized MoE decode on a qlen-ASYMMETRIC step -- a peer runs a
+    multi-token (spec) query while this rank is qlen=1, so the per-rank query
+    lengths disagree (min != max) -- falls back to the TOP decode bucket and
+    pads by that bucket times the max per-request query length. Warm-up only
+    compiles the spec-asymmetric padding for the top bucket, so there is no
+    per-bucket re-bucketing here (no second find_decode_batch_bucket call)."""
+    # Force decode via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
+
+    monkeypatch.setattr(
+        rbln_model_runner.parallel_config,
+        "data_parallel_size",
+        2,
+    )
+    monkeypatch.setattr(
+        rbln_model_runner.parallel_config,
+        "data_parallel_rank",
+        0,
+    )
+    monkeypatch.setattr(
+        rbln_model_runner,
+        "specialized_moe_decode",
+        True,
+        raising=False,
+    )
+
+    calls = []
+
+    def fake_num_tokens_and_reqs_across_dp(
+        num_tokens,
+        num_reqs,
+        dp_size,
+        dp_rank,
+        is_prefill,
+    ):
+        calls.append(
+            {
+                "num_tokens": num_tokens,
+                "num_reqs": num_reqs,
+                "dp_size": dp_size,
+                "dp_rank": dp_rank,
+                "is_prefill": is_prefill,
+            }
+        )
+        # This rank: 3 requests x qlen 1 (== 3 tokens). A peer: 5 requests x
+        # qlen 4 (spec, == 20 tokens). tokens_per_req = [1, 4] -> qlen-asymmetric.
+        return torch.tensor([3, 20], dtype=torch.int32), torch.tensor(
+            [3, 5], dtype=torch.int32
+        )
+
+    monkeypatch.setattr(
+        rbln_model_runner_module.RBLNDPMetadata,
+        "num_tokens_and_reqs_across_dp",
+        staticmethod(fake_num_tokens_and_reqs_across_dp),
+    )
+
+    fake_bucketing_manager = FakeBucketingManager(
+        buckets={3: 4}, decode_batch_buckets=[4, 8]
+    )
+    monkeypatch.setattr(
+        rbln_model_runner,
+        "bucketing_manager",
+        fake_bucketing_manager,
+    )
+
+    num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+        rbln_model_runner._determine_batch_padding(
+            num_reqs_unpadded=3,
+            num_tokens_unpadded=3,
+        )
+    )
+
+    assert calls == [
+        {
+            "num_tokens": 3,
+            "num_reqs": 3,
+            "dp_size": 2,
+            "dp_rank": 0,
+            "is_prefill": False,
+        }
+    ]
+
+    # Only the initial decode padding calls find_decode_batch_bucket (this rank's
+    # unpadded request count). The qlen-asymmetric spec step then routes to the
+    # top decode bucket (decode_batch_buckets[-1] == 8) instead of re-bucketing
+    # by request count, so there is no second find_decode_batch_bucket call.
+    assert fake_bucketing_manager.calls == [3]
+
+    # num_reqs_padded == decode_batch_buckets[-1]; padded tokens == that bucket
+    # times the max per-request query length (max_tokens_per_req == 4).
+    assert num_reqs_padded == 8
+    assert num_tokens_padded == 32
+
+    assert isinstance(num_tokens_across_dp, torch.Tensor)
+    assert num_tokens_across_dp.dtype == torch.int32
+    assert num_tokens_across_dp.device.type == "cpu"
+    assert num_tokens_across_dp.tolist() == [3, 20]
 
 
 def test_may_reinitialize_input_batch_rebuilds_on_kernel_block_size_change(

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -88,6 +88,7 @@ def get_vllm_config(
     max_num_batched_tokens: int = 128,
     max_model_len: int = 4096,
     block_size: int = BLOCK_SIZE,
+    pipeline_parallel_size: int = 1,
 ) -> VllmConfig:
     model_config = ModelConfig(
         model="meta-llama/Llama-3.2-1B-Instruct",
@@ -106,7 +107,9 @@ def get_vllm_config(
         cache_dtype="auto",
         enable_prefix_caching=True,
     )
-    parallel_config = ParallelConfig()
+    parallel_config = ParallelConfig(
+        pipeline_parallel_size=pipeline_parallel_size,
+    )
 
     return VllmConfig(
         model_config=model_config,
@@ -149,6 +152,59 @@ def rbln_model_runner():
         runner = RBLNModelRunner(vllm_config, DEVICE_TYPE)
         initialize_kv_cache(runner)
         yield runner
+
+
+def _build_runner_for_bucketing(*, max_num_seqs, pipeline_parallel_size):
+    """Construct a runner far enough to expose ``bucketing_manager``.
+
+    With no ``speculative_config`` the runner's ``__init__`` touches no
+    distributed group (the only such access is guarded by
+    ``speculative_config``), so a ``pp > 1`` runner can be built in-process
+    without a real multi-rank setup. ``initialize_kv_cache`` is intentionally
+    skipped -- the decode bucketing is fixed in ``__init__``.
+    """
+    vllm_config = get_vllm_config(
+        max_num_seqs=max_num_seqs,
+        pipeline_parallel_size=pipeline_parallel_size,
+    )
+    with set_current_vllm_config(vllm_config):
+        model_config = vllm_config.model_config
+        num_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
+        head_size = model_config.get_head_size()
+        vllm_config.compilation_config.static_forward_context["layer.0"] = Attention(
+            num_heads,
+            head_size,
+            scale=0.1,
+            prefix="layer.0",
+        )
+        return RBLNModelRunner(vllm_config, DEVICE_TYPE)
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "pp_size"),
+    [
+        (4, 1),  # non-PP: compiled decode batch == max_num_seqs
+        (4, 2),  # PP=2: compiled decode batch == max_num_seqs // pp_size == 2
+        (2, 2),  # regression: max_num_seqs=2, pp=2 -> per-stage 1 (was 2)
+    ],
+)
+def test_decode_bucketing_uses_per_pp_stage_batch(max_num_seqs, pp_size):
+    """The compiled decode bucket must be the per-PP-stage batch
+    (``max_num_seqs // pp_size``) -- the single source of truth shared with the
+    scheduler's decode admission cap -- not the raw ``max_num_seqs``.
+
+    Regression: the refactor wired the runner's bucketing to the raw
+    ``max_num_seqs``, so PP compiled an oversized decode graph (e.g. [2] instead
+    of [1] at ``max_num_seqs=2, pp=2``) while the scheduler still capped decode
+    admission at 1.
+    """
+    runner = _build_runner_for_bucketing(
+        max_num_seqs=max_num_seqs, pipeline_parallel_size=pp_size
+    )
+    # Largest compiled bucket is the per-PP-stage decode batch.
+    assert max(runner.bucketing_manager.decode_batch_buckets) == (
+        max_num_seqs // pp_size
+    )
 
 
 @pytest.fixture
@@ -247,6 +303,9 @@ def _schedule_new_request(
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+        # New requests are always prefilled: stamp the step phase the runner's
+        # is_prefill_phase() reads (execute_model consumes this directly).
+        is_prefill_step=True,
     )
 
 
@@ -1331,10 +1390,11 @@ def test_prepare_inputs_num_spec_tokens_without_scheduled_drafts_uses_logical_le
     # tokens. This can happen for zero-draft ngram/suffix steps or boundary cases.
     monkeypatch.setattr(rbln_model_runner, "num_spec_tokens", 2)
 
-    # Force decode state. is_prefill must be False.
+    # Force decode state.
     ib.num_computed_tokens_cpu[0] = 3
     ib.num_tokens_no_spec[0] = 3
-    assert rbln_model_runner.is_prefill is False
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     scheduler_output = RBLNSchedulerOutput(
         scheduled_new_reqs=[],
@@ -1442,31 +1502,22 @@ def test_prepare_kv_sharing_fast_prefill_pads_with_last_index(rbln_model_runner)
     assert result.tolist() == [0, 2, 5]
 
 
-def test_is_prefill_boundary_properties(rbln_model_runner):
-    """is_prefill: num_computed < num_tokens_no_spec - 1 (boundary at ==);
-    is_intermediate_chunked_prefill = is_prefill AND discard_mask[0];
+def test_is_intermediate_chunked_prefill_and_logits_flags(rbln_model_runner):
+    """is_intermediate_chunked_prefill = is_prefill_phase() AND discard_mask[0];
     use_wrapped_compute_logits = not pooling."""
-    ib = rbln_model_runner.input_batch
 
-    def set_state(computed, nts, discard):
-        ib.num_computed_tokens_cpu[0] = computed
-        ib.num_tokens_no_spec[0] = nts
+    def set_state(is_prefill, discard):
+        # is_intermediate_chunked_prefill reads the scheduler-stamped phase
+        # (is_prefill_phase() == _is_prefill_step).
+        rbln_model_runner._is_prefill_step = is_prefill
         rbln_model_runner.discard_request_mask[0] = discard
 
-    # is_prefill: strictly less than nts - 1.
-    set_state(1, 5, False)
-    assert rbln_model_runner.is_prefill is True  # 1 < 4
-    set_state(4, 5, False)
-    assert rbln_model_runner.is_prefill is False  # 4 < 4 -> boundary == decode
-    set_state(5, 5, False)
-    assert rbln_model_runner.is_prefill is False  # past boundary
-
-    # is_intermediate_chunked_prefill = is_prefill AND discard_mask[0].
-    set_state(1, 5, True)  # prefill + discarded chunk
+    # is_intermediate_chunked_prefill = is_prefill_phase() AND discard_mask[0].
+    set_state(True, True)  # prefill + discarded chunk
     assert rbln_model_runner.is_intermediate_chunked_prefill is True
-    set_state(1, 5, False)  # prefill, last chunk kept
+    set_state(True, False)  # prefill, last chunk kept
     assert rbln_model_runner.is_intermediate_chunked_prefill is False
-    set_state(4, 5, True)  # NOT prefill -> False regardless
+    set_state(False, True)  # NOT prefill -> False regardless
     assert rbln_model_runner.is_intermediate_chunked_prefill is False
 
     # Generation model (fixture) is not a pooling model.
@@ -1488,6 +1539,8 @@ def test_sample_skips_sampler_for_intermediate_chunked_prefill(
     # Make is_prefill True:
     ib.num_computed_tokens_cpu[0] = 1
     ib.num_tokens_no_spec[0] = 5
+    # is_intermediate_chunked_prefill reads the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = True
 
     # Make is_intermediate_chunked_prefill True:
     rbln_model_runner.discard_request_mask[0] = True
@@ -2330,7 +2383,7 @@ def test_execute_model_prefill_passes_token_indices_and_stores_execute_state(
     assert output is None
 
     # Prefill runs the real input preparation path.
-    assert rbln_model_runner.is_prefill is True
+    assert rbln_model_runner.is_prefill_phase() is True
     assert attn_metadata_calls["num_tokens"] == 3
     assert attn_metadata_calls["num_reqs"] == 1
     assert attn_metadata_calls["max_query_len"] == 3
@@ -2362,8 +2415,8 @@ def test_execute_model_prefill_passes_token_indices_and_stores_execute_state(
 def test_execute_model_decode_slices_logits_by_logits_indices(
     rbln_model_runner, dist_init, monkeypatch
 ):
-    """Decode execution should store only logits selected by runner-owned
-    logits_indices before sampling."""
+    """Plain decode execution stores the full bucket-padded logits (no
+    pre-slicing); logits_indices pre-slicing applies only to spec decode."""
     req_ids = ("req_0", "req_1")
     rbln_model_runner._update_states(
         _schedule_new_request(
@@ -2387,7 +2440,7 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
     ib.num_tokens_no_spec[:2] = [4, 4]
     rbln_model_runner.requests["req_0"].output_token_ids = [101]
     rbln_model_runner.requests["req_1"].output_token_ids = [202]
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     scheduler_output = RBLNSchedulerOutput(
         scheduled_new_reqs=[],
@@ -2407,6 +2460,7 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+        is_prefill_step=False,
     )
 
     attn_metadata_calls: dict[str, Any] = {}
@@ -2446,7 +2500,7 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
     output = rbln_model_runner.execute_model(scheduler_output)
 
     assert output is None
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     # Decode path uses one query token per request and does not pass token_indices
     # to wrapped compute_logits.
@@ -2471,12 +2525,12 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
     assert state.sample_hidden_states is hidden_states
     assert state.aux_hidden_states is None
 
-    # Critical contract: padded logits are sliced by logits_indices before
-    # sample_tokens() sees them.
-    output_logits = state.logits[attn_metadata_calls["logits_indices"]]
-    expected_logits = logits[attn_metadata_calls["logits_indices"]]
-    assert torch.equal(output_logits, expected_logits)
-    assert output_logits.shape == (2, vocab_size)
+    # Since the bucket-pad-sampler change (c040dcee), plain decode keeps the
+    # full bucket-padded logits; execute_model pre-slices by logits_indices only
+    # for spec decode (spec_decode_metadata is not None). The bucket-padded
+    # sampler consumes the padded rows downstream.
+    assert state.logits is logits
+    assert state.logits.shape == (padded_reqs, vocab_size)
 
 
 def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_metadata(
@@ -2505,7 +2559,7 @@ def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_met
     ib.num_computed_tokens_cpu[0] = 3
     ib.num_tokens_no_spec[0] = 4
     rbln_model_runner.requests[req_id].output_token_ids = [101]
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     monkeypatch.setattr(rbln_model_runner, "num_spec_tokens", 2)
 
@@ -2527,6 +2581,7 @@ def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_met
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+        is_prefill_step=False,
     )
 
     common_attn_metadata = SimpleNamespace(max_seq_len=6)
@@ -2566,7 +2621,7 @@ def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_met
     output = rbln_model_runner.execute_model(scheduler_output)
 
     assert output is None
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     assert attn_metadata_calls["num_tokens"] == 3
     assert attn_metadata_calls["num_reqs"] == 1
@@ -3065,8 +3120,6 @@ def test_take_draft_token_ids_returns_current_req_ids_and_draft_ids(
 def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypatch):
     """Prefill keeps the unpadded request count; decode uses the bucketing
     manager. With data_parallel_size == 1, token padding metadata stays None."""
-    ib = rbln_model_runner.input_batch
-
     fake_bucketing_manager = FakeBucketingManager(default=4)
     monkeypatch.setattr(
         rbln_model_runner,
@@ -3076,11 +3129,10 @@ def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypat
 
     assert rbln_model_runner.parallel_config.data_parallel_size == 1
 
-    # Prefill path:
-    # is_prefill == num_computed_tokens < num_tokens_no_spec - 1
-    ib.num_computed_tokens_cpu[0] = 0
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is True
+    # Prefill path: _determine_batch_padding selects the graph via the
+    # scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = True
+    assert rbln_model_runner.is_prefill_phase() is True
 
     num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
         rbln_model_runner._determine_batch_padding(
@@ -3094,11 +3146,9 @@ def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypat
     assert num_tokens_across_dp is None
     assert fake_bucketing_manager.calls == []
 
-    # Decode path:
-    # boundary condition for decode: computed == num_tokens_no_spec - 1
-    ib.num_computed_tokens_cpu[0] = 7
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is False
+    # Decode path: select the decode graph via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
         rbln_model_runner._determine_batch_padding(
@@ -3118,12 +3168,9 @@ def test_determine_batch_padding_data_parallel_prefill_uses_max_num_tokens(
 ):
     """Data-parallel prefill should use max_num_tokens padding and return
     cross-rank token counts."""
-    ib = rbln_model_runner.input_batch
-
-    # Force prefill.
-    ib.num_computed_tokens_cpu[0] = 0
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is True
+    # Force prefill via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = True
+    assert rbln_model_runner.is_prefill_phase() is True
 
     monkeypatch.setattr(
         rbln_model_runner.parallel_config,
@@ -3199,12 +3246,9 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
 ):
     """Specialized MoE decode should bucket by request count and pad by the
     request bucket times the per-request query length."""
-    ib = rbln_model_runner.input_batch
-
-    # Force decode.
-    ib.num_computed_tokens_cpu[0] = 7
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is False
+    # Force decode via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     monkeypatch.setattr(
         rbln_model_runner.parallel_config,

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -801,7 +801,11 @@ class TestDetermineAvailableMemory:
         assert kernel_est.call_args_list[0].kwargs["n_model_bytes"] == 300
         assert kernel_est.call_args_list[1].kwargs["n_model_bytes"] == 80
         assert est.call_args.kwargs["kernel_size"] == 520
-        assert est.call_args.kwargs["num_runtimes"] == 4
+        # Spec on (worker.speculative_config set) -> num_decode_query_lens == 2.
+        # target = 1 prefill + bucket_count(1) * 2 query lens = 3; draft = 1
+        # prefill + bucket_count(1) = 2 (draft compiles only at num_spec+1, no
+        # x2). Total 5.
+        assert est.call_args.kwargs["num_runtimes"] == 5
         assert "n_model_bytes" not in est.call_args.kwargs
 
     @pytest.mark.parametrize("quantization", ["fp8", "mxfp4", "compressed-tensors"])

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker_handshake.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker_handshake.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for RBLNWorker.get_kv_connector_handshake_metadata.
+
+Verifies the handshake dict is keyed by a flat intra-engine global rank
+(pp_rank * tp_size + tp_rank) so pipeline-parallel stages don't collide when
+EngineCore merges the per-worker dicts, while non-PP behavior (key == tp_rank)
+is unchanged.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import vllm_rbln.v1.worker.rbln_worker as rw
+from vllm_rbln.v1.worker.rbln_worker import RBLNWorker
+
+
+def _handshake(
+    *,
+    pp_rank,
+    tp_rank,
+    tp_size,
+    has_group=True,
+    metadata="META",
+):
+    """Call get_kv_connector_handshake_metadata with the parallel-state and
+    KV-transfer module functions mocked."""
+    worker = object.__new__(RBLNWorker)
+    tp_group = MagicMock()
+    tp_group.rank_in_group = tp_rank
+    tp_group.world_size = tp_size
+    pp_group = MagicMock()
+    pp_group.rank_in_group = pp_rank
+    connector = MagicMock()
+    connector.get_handshake_metadata.return_value = metadata
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(rw, "has_kv_transfer_group", return_value=has_group)
+        )
+        stack.enter_context(
+            patch.object(rw, "get_kv_transfer_group", return_value=connector)
+        )
+        stack.enter_context(patch.object(rw, "get_tp_group", return_value=tp_group))
+        stack.enter_context(patch.object(rw, "get_pp_group", return_value=pp_group))
+        return worker.get_kv_connector_handshake_metadata()
+
+
+class TestHandshakeMetadataKeying:
+    def test_non_pp_key_is_tp_rank(self):
+        """pp_rank == 0 → global_rank == tp_rank (no regression)."""
+        assert _handshake(pp_rank=0, tp_rank=0, tp_size=1) == {0: "META"}
+        assert _handshake(pp_rank=0, tp_rank=2, tp_size=4) == {2: "META"}
+
+    def test_pp_stage_offset(self):
+        """global_rank = pp_rank * tp_size + tp_rank."""
+        # TP=1: each PP stage gets its pp_rank as the key.
+        assert _handshake(pp_rank=0, tp_rank=0, tp_size=1) == {0: "META"}
+        assert _handshake(pp_rank=1, tp_rank=0, tp_size=1) == {1: "META"}
+        # TP=2, PP=2: (pp,tp) -> pp*2+tp.
+        assert _handshake(pp_rank=0, tp_rank=1, tp_size=2) == {1: "META"}
+        assert _handshake(pp_rank=1, tp_rank=0, tp_size=2) == {2: "META"}
+        assert _handshake(pp_rank=1, tp_rank=1, tp_size=2) == {3: "META"}
+
+    def test_pp_stages_do_not_collide_on_merge(self):
+        """Merging per-stage dicts (EngineCore content.update) preserves every
+        stage — the collision that {tp_rank: ...} caused under PP is gone."""
+        merged = {}
+        for pp_rank in range(2):  # pp_size=2, tp_size=1 -> keys 0 and 1
+            merged.update(
+                _handshake(
+                    pp_rank=pp_rank,
+                    tp_rank=0,
+                    tp_size=1,
+                    metadata=f"stage{pp_rank}",
+                )
+            )
+        assert merged == {0: "stage0", 1: "stage1"}
+
+    def test_returns_none_without_kv_transfer_group(self):
+        assert _handshake(pp_rank=0, tp_rank=0, tp_size=1, has_group=False) is None
+
+    def test_returns_none_when_connector_has_no_metadata(self):
+        assert _handshake(pp_rank=1, tp_rank=0, tp_size=1, metadata=None) is None

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RBLN-specific NIXL metadata: pipeline-parallel (PP) extensions.
+
+Isolated from upstream ``NixlAgentMetadata`` so the base struct and its
+compatibility hash stay untouched. Both P and D are RBLN, so there is no
+cross-vendor interop concern -- a private RBLN version tag folded into the NIXL
+compatibility hash (``rbln_pp_compat_hash``) is enough to gate PP-aware peers
+against mismatched ones.
+
+Under pipeline parallelism the producer advertises, per (pp_rank, tp_rank)
+shard, the registered KV-cache layer names it owns. After the side-channel
+handshake the consumer matches each producer stage's shard to its own local KV
+regions by name (the owned layer range is derived locally on each side, not sent
+over the wire).
+"""
+
+from dataclasses import dataclass, field
+
+from vllm.config.utils import hash_factors
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+
+# Bump on any incompatible change to the RBLN PP metadata schema/semantics.
+# Folded into the NIXL compatibility hash so a PP-aware producer and a
+# mismatched consumer fail the handshake cleanly (both ends are RBLN).
+RBLN_NIXL_PP_VERSION: int = 1
+
+
+@dataclass
+class RblnNixlAgentMetadata(NixlAgentMetadata):
+    """``NixlAgentMetadata`` + this producer stage's PP identity and the layer
+    names it owns.
+
+    New fields default to the ``pp_size == 1`` (no-PP) values so a blob decoded
+    by the base/older consumer (which uses ``NixlAgentMetadata`` and ignores the
+    extra fields) degrades to single-stage behavior. A PP-aware consumer decodes
+    with this type to read them and matches ``registered_layer_names`` against
+    its own local layers to place each shard's regions.
+    """
+
+    pp_rank: int = 0
+    pp_size: int = 1
+    # Registered KV-cache layer names, ordered as kv_caches_base_addr / block_lens.
+    registered_layer_names: list[str] = field(default_factory=list)
+
+
+def rbln_pp_compat_hash(base_hash: str) -> str:
+    """Fold the RBLN PP schema version into the upstream NIXL compat hash.
+
+    Keeps PP-aware RBLN peers from handshaking with PP-unaware / mismatched
+    ones without touching upstream ``compute_nixl_compatibility_hash``.
+    """
+    return hash_factors(
+        {"base": base_hash, "rbln_nixl_pp_version": RBLN_NIXL_PP_VERSION}
+    )

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import msgspec
 import numpy as np
 import rebel
 import torch
+import zmq
 from rebel.kv_cache import aligned_tensor
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
@@ -33,12 +35,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    GET_META_MSG,
     NixlHandshakePayload,
     compute_nixl_compatibility_hash,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     compute_tp_mapping,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import zmq_ctx
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import make_zmq_path
 from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
@@ -46,9 +53,14 @@ from vllm.v1.kv_cache_interface import (
 )
 
 import vllm_rbln.envs as envs
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
 from vllm_rbln.logger import init_logger
 
 if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import ReqMeta
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
@@ -67,6 +79,9 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
     layer (kernel granularity), whose `cache.shape[0]` mismatches
     `num_blocks`. Non-disagg serving is unaffected.
     """
+
+    compat_hash: str | None
+    xfer_handshake_metadata: NixlHandshakePayload | None
 
     def __init__(
         self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
@@ -108,6 +123,27 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
         self.use_host_buffer = self.kv_buffer_device == "cpu"
 
         self._pending_kv_caches: dict[str, torch.Tensor] | None = None
+
+        # --- Pipeline-parallel (PP) P/D state (empty / inert for pp_size == 1) ---
+        # Per remote producer shard, the ordered KV-cache layer names it owns,
+        # keyed by engine_id -> global_rank (= pp_rank * tp_size + tp_rank,
+        # == pp_rank when tensor parallelism is off).
+        self._remote_shard_layer_names: defaultdict[str, dict[int, tuple[str, ...]]] = (
+            defaultdict(dict)
+        )
+        # engine_id -> producer pp_size (discovered at handshake).
+        self._remote_pp_size: dict[str, int] = {}
+        # engine_id -> the producer stages (flat global ranks) whose layers this
+        # rank owns; drives _read_blocks_for_req.
+        self._overlapping_ranks: defaultdict[str, list[int]] = defaultdict(list)
+        # Per producer shard, a local xfer dlist scoped to that shard's local
+        # region subset, keyed by (engine_id, global_rank, block_size); and the
+        # shard's per-region KV-group ids, keyed by (engine_id, global_rank).
+        self.src_xfer_handles_by_remote: dict[tuple[str, int, int], int] = {}
+        self._shard_region_group_ids: dict[tuple[str, int], tuple[int, ...]] = {}
+        # Ordered local KV-cache layer names (one per layer), captured at
+        # register_kv_caches.
+        self.local_seen_layer_names: list[str] = []
 
         # Pin to logical values. Upstream would otherwise multiply by the
         # attention backend's kernel ratio, which doesn't reflect per-spec
@@ -168,6 +204,10 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
         fall straight through to upstream's UCX-backed registration —
         the host xfer buffers are plain DRAM in either case.
         """
+        # Capture the ordered local layer names before any deferral so the PP
+        # metadata publish (and the consumer-side name->region matching) can
+        # use them; the D2D path re-uses these at finalize time.
+        self.local_seen_layer_names = list(kv_caches.keys())
         if self.kv_buffer_device == "rbln":
             self._pending_kv_caches = kv_caches
             logger.info(
@@ -181,6 +221,13 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
 
             nixl_rbln.ensure_rbln_backend(self.nixl_wrapper, device_id=0)
         super().register_kv_caches(kv_caches)
+        # Re-wrap the base-published handshake metadata with this stage's PP
+        # identity + owned layer names (no-op degrade for pp_size == 1).
+        if self.xfer_handshake_metadata is not None:
+            base_agent_metadata = msgspec.msgpack.Decoder(NixlAgentMetadata).decode(
+                self.xfer_handshake_metadata.agent_metadata_bytes
+            )
+            self._publish_pp_handshake_metadata(base_agent_metadata, kv_caches.keys())
 
     def finalize_kv_cache_registration(self) -> None:
         """Run the deferred D2D registration. No-op on host-bounce and
@@ -402,11 +449,10 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
                 self._physical_blocks_per_logical_kv_block
             ),
         )
-        assert self.compat_hash is not None
-        encoder = msgspec.msgpack.Encoder()
-        self.xfer_handshake_metadata = NixlHandshakePayload(
-            compatibility_hash=self.compat_hash,
-            agent_metadata_bytes=encoder.encode(agent_metadata),
+        # Publish the handshake metadata wrapped with this stage's PP identity
+        # and owned layer names (degrades to no-PP for pp_size == 1).
+        self._publish_pp_handshake_metadata(
+            agent_metadata, self.device_kv_caches.keys()
         )
 
     # ------------------------------------------------------------------
@@ -446,10 +492,20 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
     def register_local_xfer_handler(
         self,
         block_size: int,
+        *,
+        registered_layer_names: tuple[str, ...] | list[str] | None = None,
     ) -> tuple[int, list[tuple[int, int, int]]]:
         if self._sw_ratio is None:
-            # No SWA view opt: upstream's Full-only desc layout applies.
-            return super().register_local_xfer_handler(block_size)
+            if registered_layer_names is None:
+                # No SWA view opt, no PP shard: upstream's Full-only layout.
+                return super().register_local_xfer_handler(block_size)
+            # PP shard — register only this producer stage's local regions.
+            return self._register_shard_local_xfer_handler(
+                block_size, registered_layer_names
+            )
+        assert registered_layer_names is None, (
+            "RBLN NIXL: SWA view-opt is not supported with pipeline parallelism"
+        )
         assert self.transfer_topo is not None
         assert not self.transfer_topo.is_kv_layout_blocks_first, (
             "RBLN NIXL connector only supports FA layout (K and V in "
@@ -663,3 +719,414 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
             group_arr = np.asarray(group)[None, :]
             all_descs.append((region_ids * num_blocks + group_arr + offset).flatten())
         return np.concatenate(all_descs) if all_descs else np.empty(0, dtype=int)
+
+    # ------------------------------------------------------------------
+    # Pipeline-parallel (PP) P/D over NIXL
+    # ------------------------------------------------------------------
+    #
+    # Under sync-scheduling PP the producer runs pipeline_parallel_size
+    # stages, each owning a contiguous band of layers. Every stage
+    # advertises its (pp_rank, tp_rank) shard and the KV-cache layer names
+    # it registered; the consumer matches each shard to its own local KV
+    # regions BY NAME (the owned layer range is derived locally on each
+    # side, never sent over the wire) and reads each overlapping shard with
+    # a shard-scoped local/remote descriptor pair. All of this collapses to
+    # the upstream single-stage path for pp_size == 1.
+
+    def _check_pp_constraints(self) -> None:
+        if self.vllm_config.parallel_config.pipeline_parallel_size <= 1:
+            return
+        assert self.transfer_topo is not None
+        if self.transfer_topo.cross_layers_blocks:
+            raise RuntimeError(
+                "RBLN NIXL: cross-layer-blocks mode is not supported with "
+                "pipeline_parallel_size > 1."
+            )
+        if self._has_mamba:
+            raise RuntimeError(
+                "RBLN NIXL: hybrid (Mamba/SSM) models are not supported with "
+                "pipeline_parallel_size > 1 over NIXL P/D."
+            )
+        if self._sw_ratio is not None:
+            raise RuntimeError(
+                "RBLN NIXL: sliding-window view-opt (VLLM_RBLN_NIXL_SWA_VIEW_OPT) "
+                "is not supported with pipeline_parallel_size > 1."
+            )
+
+    def _publish_pp_handshake_metadata(
+        self, base_meta: NixlAgentMetadata, registered_layer_names
+    ) -> None:
+        self._check_pp_constraints()
+        pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+        pp_rank = get_pp_group().rank_in_group if pp_size > 1 else 0
+        pp_meta = RblnNixlAgentMetadata(
+            engine_id=base_meta.engine_id,
+            agent_metadata=base_meta.agent_metadata,
+            device_id=base_meta.device_id,
+            kv_caches_base_addr=base_meta.kv_caches_base_addr,
+            num_blocks=base_meta.num_blocks,
+            block_lens=base_meta.block_lens,
+            kv_cache_layout=base_meta.kv_cache_layout,
+            block_size=base_meta.block_size,
+            ssm_sizes=base_meta.ssm_sizes,
+            attn_backend_name=base_meta.attn_backend_name,
+            physical_blocks_per_logical_kv_block=(
+                base_meta.physical_blocks_per_logical_kv_block
+            ),
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+            registered_layer_names=list(registered_layer_names),
+        )
+        base_hash = self.compat_hash
+        assert base_hash is not None
+        self.compat_hash = rbln_pp_compat_hash(base_hash)
+        self.xfer_handshake_metadata = NixlHandshakePayload(
+            compatibility_hash=self.compat_hash,
+            agent_metadata_bytes=msgspec.msgpack.Encoder().encode(pp_meta),
+        )
+
+    def _query_agent_meta(
+        self, sock: "zmq.Socket", remote_rank: int, expected_engine_id: str
+    ) -> RblnNixlAgentMetadata:
+        sock.send(msgspec.msgpack.encode((GET_META_MSG, remote_rank)))
+        handshake_payload = msgspec.msgpack.Decoder(NixlHandshakePayload).decode(
+            sock.recv()
+        )
+        assert self.compat_hash is not None
+        if (
+            self.enforce_compat_hash
+            and handshake_payload.compatibility_hash != self.compat_hash
+        ):
+            raise RuntimeError(
+                "NIXL compatibility hash mismatch "
+                f"(local={self.compat_hash}, "
+                f"remote={handshake_payload.compatibility_hash}). Prefill and "
+                "decode instances have incompatible configurations."
+            )
+        metadata = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            handshake_payload.agent_metadata_bytes
+        )
+        if metadata.engine_id != expected_engine_id:
+            raise RuntimeError(
+                "Remote NIXL agent engine ID mismatch. "
+                f"Expected {expected_engine_id}, received {metadata.engine_id}."
+            )
+        return metadata
+
+    def _nixl_handshake(
+        self,
+        host: str,
+        port: int,
+        remote_tp_size: int,
+        expected_engine_id: str,
+    ) -> dict[int, str]:
+        # Background thread needs a device context (see base _nixl_handshake).
+        if not self.use_host_buffer:
+            current_platform.set_device(self.device_id)
+
+        assert self.transfer_topo is not None
+        p_remote_tp_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
+        path = make_zmq_path("tcp", host, port)
+        remote_rank_to_agent_name: dict[int, str] = {}
+
+        with zmq_ctx(zmq.REQ, path) as sock:
+            sock.setsockopt(zmq.RCVTIMEO, 5000)  # ms; avoid hang on dead server
+
+            # Bootstrap: the first shard (pp_rank 0) advertises pp_size.
+            first_rank = p_remote_tp_ranks[0]
+            metas = {
+                first_rank: self._query_agent_meta(sock, first_rank, expected_engine_id)
+            }
+            pp_size = metas[first_rank].pp_size
+
+            if pp_size > 1:
+                if self._sw_ratio is not None:
+                    raise RuntimeError(
+                        "RBLN NIXL: sliding-window attention combined with "
+                        "pipeline-parallel P/D is not supported."
+                    )
+                if remote_tp_size > 1:
+                    raise RuntimeError(
+                        "RBLN NIXL: tensor parallelism (remote_tp_size>1) "
+                        "combined with pipeline-parallel P/D is not supported."
+                    )
+
+            for pp_rank in range(pp_size):
+                for remote_tp_rank in p_remote_tp_ranks:
+                    global_rank = pp_rank * remote_tp_size + remote_tp_rank
+                    if global_rank in metas:
+                        metadata = metas[global_rank]
+                    else:
+                        metadata = self._query_agent_meta(
+                            sock, global_rank, expected_engine_id
+                        )
+                    names = tuple(metadata.registered_layer_names)
+                    self._remote_shard_layer_names[expected_engine_id][global_rank] = (
+                        names
+                    )
+                    if pp_size == 1:
+                        # No pipeline parallelism: single-stage registration,
+                        # exactly as the non-PP path (read path also delegates to
+                        # base for pp_size == 1).
+                        remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                            metadata, global_rank, remote_tp_size
+                        )
+                        continue
+
+                    # PP: only build/register producer stages whose layers this
+                    # rank actually owns. base.add_remote_agent -> _build_fa_remote
+                    # indexes the *local* block_len_per_layer by the *remote*
+                    # region position, so it is only safe when n_remote <= n_local.
+                    # Overlapping stages satisfy that (symmetric same-stage: equal;
+                    # asymmetric fan-in: remote is a sub-band of this larger band);
+                    # a non-overlapping peer stage may be larger under an uneven
+                    # split (e.g. 62 layers / 4 = 16/16/15/15) and would index out
+                    # of range -- and this rank never reads it -- so skip it.
+                    indices = self._local_region_indices_for_layer_names(names)
+                    if 0 < len(indices) < len(names):
+                        raise RuntimeError(
+                            f"RBLN NIXL PP: producer stage {global_rank} "
+                            f"({len(names)} layers) partially overlaps this "
+                            f"decode rank's band ({len(indices)} owned). "
+                            "The prefill pipeline-parallel size must be >= "
+                            "the decode pipeline-parallel size and an integer "
+                            "multiple of it."
+                        )
+                    if not indices:
+                        continue
+                    remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                        metadata, global_rank, remote_tp_size
+                    )
+                    self._register_shard_read_state(
+                        expected_engine_id,
+                        global_rank,
+                        metadata.block_size,
+                        names,
+                    )
+                    self._overlapping_ranks[expected_engine_id].append(global_rank)
+        self._remote_pp_size[expected_engine_id] = pp_size
+        return remote_rank_to_agent_name
+
+    def _register_shard_read_state(
+        self,
+        engine_id: str,
+        global_rank: int,
+        block_size: int,
+        registered_layer_names: tuple[str, ...],
+    ) -> None:
+        handle, _ = self.register_local_xfer_handler(
+            block_size, registered_layer_names=registered_layer_names
+        )
+        self.src_xfer_handles_by_remote[(engine_id, global_rank, block_size)] = handle
+        assert len(self.kv_cache_config.kv_cache_groups) == 1, (
+            "RBLN NIXL PP currently supports a single KV-cache group"
+        )
+        region_ids = self._shard_local_region_ids(registered_layer_names)
+        self._shard_region_group_ids[(engine_id, global_rank)] = tuple(
+            0 for _ in region_ids
+        )
+
+    def _local_region_indices_for_layer_names(
+        self, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> list[int]:
+        positions_by_name: dict[str, list[int]] = defaultdict(list)
+        for local_idx, layer_name in enumerate(self.local_seen_layer_names):
+            positions_by_name[layer_name].append(local_idx)
+
+        occurrences_by_name: dict[str, int] = defaultdict(int)
+        local_indices: list[int] = []
+        for layer_name in registered_layer_names:
+            occurrence = occurrences_by_name[layer_name]
+            occurrences_by_name[layer_name] += 1
+            matches = positions_by_name.get(layer_name, [])
+            if occurrence >= len(matches):
+                continue
+            local_indices.append(matches[occurrence])
+        return local_indices
+
+    def _regions_per_layer(self) -> int:
+        num_layers = len(self.local_seen_layer_names)
+        assert num_layers > 0 and self.num_regions % num_layers == 0, (
+            f"num_regions={self.num_regions} not divisible by num_layers={num_layers}"
+        )
+        return self.num_regions // num_layers
+
+    def _shard_local_region_ids(
+        self, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> list[int]:
+        rpl = self._regions_per_layer()
+        layer_indices = self._local_region_indices_for_layer_names(
+            registered_layer_names
+        )
+        return [layer_idx * rpl + k for layer_idx in layer_indices for k in range(rpl)]
+
+    def _register_shard_local_xfer_handler(
+        self, block_size: int, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> tuple[int, list[tuple[int, int, int]]]:
+        assert self.transfer_topo is not None
+        assert not self.transfer_topo.is_kv_layout_blocks_first, (
+            "RBLN NIXL connector only supports FA layout (K and V in separate "
+            "regions), not FlashInfer."
+        )
+        assert not self._has_mamba, "RBLN NIXL connector does not support Mamba."
+
+        block_size_ratio = self.block_size // block_size
+        num_blocks = self.num_blocks * block_size_ratio
+        all_base_addrs = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        region_ids = self._shard_local_region_ids(registered_layer_names)
+
+        blocks_data: list[tuple[int, int, int]] = []
+        for region_id in region_ids:
+            base_addr = all_base_addrs[region_id]
+            kv_block_len = (
+                self.get_backend_aware_kv_block_len(
+                    layer_idx=region_id, first_split=True, mamba_view=False
+                )
+                // block_size_ratio
+            )
+            stride = self.block_len_per_layer[region_id] // block_size_ratio
+            for block_id in range(num_blocks):
+                blocks_data.append(
+                    (base_addr + block_id * stride, kv_block_len, self.device_id)
+                )
+
+        descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
+        return (
+            self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs),
+            blocks_data,
+        )
+
+    def _get_block_descs_ids_for_shard(
+        self,
+        engine_id: str,
+        global_rank: int,
+        num_blocks: int,
+        block_ids: BlockIds,
+    ) -> np.ndarray:
+        region_group_ids = self._shard_region_group_ids[(engine_id, global_rank)]
+        desc_ids: list[np.ndarray] = []
+        for region_id, group_id in enumerate(region_group_ids):
+            group_arr = np.asarray(block_ids[group_id], dtype=np.int64)
+            if group_arr.size == 0:
+                continue
+            desc_ids.append(region_id * num_blocks + group_arr)
+        if not desc_ids:
+            return np.empty(0, dtype=np.int64)
+        return np.concatenate(desc_ids)
+
+    def _validate_remote_agent_handshake(
+        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+    ) -> None:
+        if getattr(nixl_agent_meta, "pp_size", 1) <= 1:
+            super()._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+            return
+
+        assert self.transfer_topo is not None
+        remote_engine_id = nixl_agent_meta.engine_id
+        remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
+        assert remote_info.remote_tp_size == remote_tp_size == 1, (
+            "PP over NIXL P/D requires TP=1 on both sides."
+        )
+        assert self.transfer_topo.block_size_ratio(nixl_agent_meta.block_size) == 1, (
+            "PP over NIXL P/D requires equal P/D block sizes."
+        )
+        assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
+        rpl = self._regions_per_layer()
+        n_remote = len(nixl_agent_meta.kv_caches_base_addr)
+        assert (
+            n_remote > 0
+            and n_remote % rpl == 0
+            and n_remote <= len(self.block_len_per_layer)
+        ), (
+            f"PP shard advertised {n_remote} KV regions, not a valid "
+            f"sub-multiple of this consumer's {len(self.block_len_per_layer)} "
+            f"regions (regions/layer={rpl})."
+        )
+
+    def _read_blocks_for_req(self, req_id: str, meta: "ReqMeta") -> None:
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        pp_size = self._remote_pp_size.get(engine_id, 1)
+        if pp_size == 1:
+            return super()._read_blocks_for_req(req_id, meta)
+
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        assert self.transfer_topo.tp_ratio(remote_info.remote_tp_size) == 1, (
+            "RBLN NIXL PP read path supports TP=1 only"
+        )
+        assert (
+            self.transfer_topo.block_size_ratio(remote_info.remote_block_size) == 1
+        ), "RBLN NIXL PP read path requires equal P/D block sizes"
+        remote_block_size = remote_info.remote_block_size
+
+        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
+            meta.remote.block_ids, remote_info.remote_physical_blocks_per_logical
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+        prefix_hit = len(local_block_ids) == 0
+        n_prompt_blocks = sum(len(g) for g in remote_block_ids)
+
+        if not prefix_hit:
+            local_block_ids, remote_block_ids = self._apply_prefix_caching(
+                local_block_ids,
+                remote_block_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+
+        n_read_blocks = sum(len(g) for g in local_block_ids)
+        logger.info(
+            "PP read req %s: pp_size=%d prompt_blocks=%d read_blocks=%d "
+            "prefix_skipped=%d%s",
+            req_id,
+            pp_size,
+            n_prompt_blocks,
+            n_read_blocks,
+            n_prompt_blocks - n_read_blocks,
+            " (full prefix hit, notif only)" if prefix_hit else "",
+        )
+
+        for global_rank in self._overlapping_ranks[engine_id]:
+            if prefix_hit:
+                agent_name = self._remote_agents[engine_id][global_rank]
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+                continue
+
+            remote_descs = self._get_block_descs_ids_for_shard(
+                engine_id,
+                global_rank,
+                self.dst_num_blocks[engine_id],
+                remote_block_ids,
+            )
+            local_descs = self._get_block_descs_ids_for_shard(
+                engine_id, global_rank, self.num_blocks, local_block_ids
+            )
+            assert len(local_descs) == len(remote_descs)
+            local_handle = self.src_xfer_handles_by_remote[
+                (engine_id, global_rank, remote_block_size)
+            ]
+            remote_handle = self.dst_xfer_side_handles[engine_id][global_rank]
+
+            handle = None
+            try:
+                handle = self.nixl_wrapper.make_prepped_xfer(
+                    "READ",
+                    local_handle,
+                    local_descs,
+                    remote_handle,
+                    remote_descs,
+                    notif_msg=notif_id,
+                )
+                self.nixl_wrapper.transfer(handle)
+                self._recving_transfers[req_id].append(handle)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="transfer_setup_failed",
+                    req_id=req_id,
+                    msg="Marking blocks as invalid",
+                    error=e,
+                    dst_engine_id=engine_id,
+                    remote_pp_rank=global_rank,
+                )
+                self._handle_failed_transfer(req_id, handle)

--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     # --- MOE ---
     VLLM_RBLN_SPECIALIZE_MOE_DECODE: bool = True
     VLLM_RBLN_USE_MOE_TOKENS_MASK: bool = True
+    VLLM_RBLN_PP_BALANCE_DECODE_BATCH: bool = True
     VLLM_RBLN_DISPATCH_ALL2ALL: bool = False
     VLLM_RBLN_COMBINE_ALL2ALL: bool = False
     # --- DECODE BATCH BUCKET ---
@@ -215,6 +216,15 @@ environment_variables = {
     "VLLM_RBLN_ENABLE_WARM_UP": (
         lambda: (
             os.environ.get("VLLM_RBLN_ENABLE_WARM_UP", "True").lower() in ("true", "1")
+        )
+    ),
+    # Under pipeline parallelism, distribute the per-step decode batch across
+    # PP stages (dynamic soft cap ~ceil(demand/pp_size)) so microbatches do not
+    # collapse to depth-1. No-op when pipeline_parallel_size == 1.
+    "VLLM_RBLN_PP_BALANCE_DECODE_BATCH": (
+        lambda: (
+            os.environ.get("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "True").lower()
+            in ("true", "1")
         )
     ),
     "VLLM_RBLN_METRICS": (

--- a/vllm_rbln/forward_context.py
+++ b/vllm_rbln/forward_context.py
@@ -60,27 +60,40 @@ class RBLNDPMetadata(DPMetadata):
 
     @staticmethod
     def num_tokens_and_reqs_across_dp(
-        num_tokens: int, num_reqs: int, dp_size: int, dp_rank: int, is_prefill: bool
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """All-reduce per-rank (num_tokens, num_reqs, is_prefill) across DP via
-        a single bit-packed int32 and split the result back out.
+        num_tokens: int,
+        num_reqs: int,
+        dp_size: int,
+        dp_rank: int,
+        is_prefill: bool,
+        is_idle: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        """All-reduce per-rank (num_tokens, num_reqs, is_prefill, is_idle)
+        across DP via a single bit-packed int32 and split the result back out.
 
-        Bit layout (int32, low to high):
-            bits  0..15  num_tokens (max 65535)
-            bits 16..29  num_reqs   (max 16383)
-            bit  30      is_prefill flag
+        Bit layout (int32, low to high; bit 31 is left unused to keep the packed
+        value non-negative for the sum-based all-gather):
+            bits  0..15  num_tokens  (max 65535)
+            bits 16..28  num_reqs    (max 8191; >> any real max_num_seqs)
+            bit  29      is_prefill flag
+            bit  30      is_idle flag (DP-idle dummy step -- excluded from the
+                         shape decision by the caller)
 
         Returns:
             num_tokens_across_dp_cpu: per-rank num_tokens (size dp_size).
             num_reqs_across_dp_cpu: per-rank num_reqs (size dp_size), or None
                 if any rank is in prefill phase.
+            idle_across_dp_cpu: per-rank is_idle flag as 0/1 (size dp_size), so
+                the caller can decide the padding shape from the busy (non-idle)
+                ranks only (a DP-idle dummy must not drag the collective into a
+                fall-back route).
         """
         token_bits = 16
-        req_bits = 14
+        req_bits = 13
         token_mask = (1 << token_bits) - 1
         req_mask_raw = (1 << req_bits) - 1
         req_mask_shifted = req_mask_raw << token_bits
         prefill_flag = 1 << (token_bits + req_bits)
+        idle_flag = 1 << (token_bits + req_bits + 1)
 
         assert num_tokens <= token_mask, (
             f"num_tokens={num_tokens} exceeds bit-packed limit {token_mask}"
@@ -92,6 +105,8 @@ class RBLNDPMetadata(DPMetadata):
         encoded = num_tokens | (num_reqs << token_bits)
         if is_prefill:
             encoded |= prefill_flag
+        if is_idle:
+            encoded |= idle_flag
 
         encoded_across_dp = RBLNDPMetadata.num_tokens_across_dp(
             encoded, dp_size, dp_rank
@@ -107,6 +122,13 @@ class RBLNDPMetadata(DPMetadata):
         )
         num_tokens_across_dp_cpu = encoded_across_dp & token_mask_t
 
+        idle_mask_t = torch.tensor(
+            [idle_flag] * dp_size, device="cpu", dtype=torch.int32
+        )
+        idle_across_dp_cpu = (encoded_across_dp & idle_mask_t) >> (
+            token_bits + req_bits + 1
+        )
+
         if any_prefill:
             num_reqs_across_dp_cpu = None
         else:
@@ -115,7 +137,11 @@ class RBLNDPMetadata(DPMetadata):
             )
             num_reqs_across_dp_cpu = (encoded_across_dp & req_mask_t) >> token_bits
 
-        return num_tokens_across_dp_cpu, num_reqs_across_dp_cpu
+        return (
+            num_tokens_across_dp_cpu,
+            num_reqs_across_dp_cpu,
+            idle_across_dp_cpu,
+        )
 
     @staticmethod
     def make(

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -297,6 +297,48 @@ class RblnPlatform(Platform):
                 "vllm_rbln.v1.core.rbln_scheduler.RBLNScheduler"
             )
 
+            # NOTE(RBLN): max_num_seqs is the max number of concurrently running
+            # sequences (the scheduler's running-queue cap), consistent with
+            # upstream and the non-PP case. Under PP the engine keeps
+            # pipeline_parallel_size microbatches in flight, so to keep total
+            # in-flight sequences <= max_num_seqs the *compiled* decode batch per
+            # PP stage is the derived max_num_seqs // pp_size (unlike GPU, which
+            # uses dynamic batch shapes and never divides). Validate here so an
+            # impossible config (e.g. max_num_seqs=1 with pp_size=2 -> 0) fails
+            # with a clear message instead of a cryptic assert deep in
+            # bucketing/scheduling.
+            pp_size = parallel_config.pipeline_parallel_size
+            if pp_size > 1:
+                max_num_seqs = scheduler_config.max_num_seqs
+                if max_num_seqs < pp_size:
+                    raise ValueError(
+                        f"pipeline_parallel_size={pp_size} requires "
+                        f"max_num_seqs >= {pp_size}: each PP stage is compiled "
+                        f"for max_num_seqs // pipeline_parallel_size decode "
+                        f"slots, but max_num_seqs={max_num_seqs} yields "
+                        f"{max_num_seqs // pp_size}."
+                    )
+                per_stage = max_num_seqs // pp_size
+                if max_num_seqs % pp_size != 0:
+                    logger.warning(
+                        "max_num_seqs=%d is not a multiple of "
+                        "pipeline_parallel_size=%d; the per-PP-stage decode "
+                        "batch floors to %d, so %d sequence slot(s) of the "
+                        "budget are unused. Set max_num_seqs to a multiple of "
+                        "pipeline_parallel_size to use the full budget.",
+                        max_num_seqs,
+                        pp_size,
+                        per_stage,
+                        max_num_seqs - per_stage * pp_size,
+                    )
+                logger.info(
+                    "PP=%d: max_num_seqs=%d (max concurrent sequences) -> "
+                    "per-PP-stage decode batch = %d (compiled).",
+                    pp_size,
+                    max_num_seqs,
+                    per_stage,
+                )
+
             # FIXME(jiwoo.park) This is a temporary workaround.
             if model_config.enforce_eager:
                 if not USE_DEVICE_TENSOR:

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -23,7 +23,11 @@ from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import init_none_hash
 from vllm.v1.core.sched.interface import PauseState
-from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
@@ -38,6 +42,11 @@ from vllm_rbln.v1.core.rbln_kv_cache_manager import (
     RBLNKVCacheManager,
     SubBlockMatch,
 )
+from vllm_rbln.v1.core.utils import (
+    DecodeAdmissionController,
+    num_base_tokens,
+    should_defer_spec_step,
+)
 
 logger = init_logger(__name__)
 
@@ -45,9 +54,19 @@ logger = init_logger(__name__)
 @dataclass
 class RBLNSchedulerOutput(SchedulerOutput):
     """SchedulerOutput extended with KV cache copy operations for sub-block
-    prefix caching."""
+    prefix caching, and a step-level prefill/decode phase anchor."""
 
     kv_cache_copy_ops: list[KVCacheCopyOp] = field(default_factory=list)
+    # NOTE(RBLN): Whether this step runs the prefill graph (True) or the decode
+    # graph (False). RBLN has no mixed batching, so a step is uniformly one or
+    # the other. Stamped by the scheduler (a single authority) from the
+    # authoritative pre-advance Request state, so every PP rank reads an
+    # identical value. The runner MUST use this (via is_prefill_phase()) rather
+    # than re-deriving the phase from its own per-rank input_batch, whose
+    # num_tokens_no_spec is maintained on different paths on the last PP rank
+    # (sampling) vs other ranks (scheduler output) -- a runner-side
+    # classification would diverge across ranks under spec-decode + PP.
+    is_prefill_step: bool = False
 
 
 def is_prefill(request: Request) -> bool:
@@ -113,6 +132,35 @@ class RBLNScheduler(Scheduler):
         # lifecycle hooks clear its pending delta before it can resume with
         # a full block table.
         self._pending_runner_block_deltas: dict[str, KVCacheBlocks] = {}
+
+        # NOTE(RBLN): Per-step decode-batch admission. Under PP the engine keeps
+        # pipeline_parallel_size microbatches in flight, so each step's decode
+        # batch must stay <= max_num_seqs // pp_size (== the runner's compiled
+        # bucket ceiling). The controller produces a per-step budget shared by
+        # the running loop and the waiting-loop remote-KV promotion, and owns
+        # the static-vs-dynamic (PP-balanced) cap choice. See v1/core/utils.py.
+        self._decode_admission = DecodeAdmissionController(
+            max_num_seqs=self.max_num_running_reqs,
+            pipeline_parallel_size=(
+                self.vllm_config.parallel_config.pipeline_parallel_size
+            ),
+            pp_balance_decode=envs.VLLM_RBLN_PP_BALANCE_DECODE_BATCH,
+        )
+
+    def _decode_demand(self) -> int:
+        """Total decode demand for this step's PP-balanced admission cap.
+
+        = running decodes + remote-KV requests ready to be admitted (transfer
+        complete, awaiting promotion). Including the ready remote-KV gives the
+        dynamic cap headroom to ramp the decode batch on the P/D-disaggregated
+        decode side; running-only would stall the ramp. Demand is invariant
+        under admission (promoting a ready remote-KV moves it from ready ->
+        running), so this snapshot is exact even as the running/ready split
+        shifts during the waiting loop. Evaluated only when PP balancing is on.
+        """
+        num_running_decodes = sum(1 for r in self.running if not is_prefill(r))
+        num_ready_remote_kv = len(self.finished_recving_kv_req_ids)
+        return num_running_decodes + num_ready_remote_kv
 
     def _add_pending_runner_block_delta(
         self,
@@ -191,6 +239,16 @@ class RBLNScheduler(Scheduler):
 
         self.kv_cache_manager.new_step_starts()
 
+        # NOTE(RBLN): Per-step decode-batch admission budget shared by the
+        # running loop and the waiting-loop remote-KV promotion. can_admit()
+        # enforces the hard cap (max_num_seqs // pp == compiled bucket ceiling)
+        # plus, under PP with balancing on, a dynamic ceil(demand/pp) soft cap.
+        # In the non-PP / balance-off case this is exactly the old
+        # `len(scheduled_running_reqs) >= max_num_seqs // pp` gate.
+        decode_budget = self._decode_admission.make_budget(
+            demand_fn=self._decode_demand
+        )
+
         # First, schedule the RUNNING requests.
         # NOTE(RBLN): Prioritize prefill requests. Given our constraint that the prefill
         # batch size fixed to 1 if any prefill request is running there must be exactly
@@ -224,6 +282,17 @@ class RBLNScheduler(Scheduler):
                 + request.num_output_placeholders
                 - request.num_computed_tokens
             )
+            # NOTE(RBLN): Under sync-scheduling PP + spec decode, defer a step
+            # with no reconciled base (anchor) token yet -- num_computed_tokens
+            # is optimistically advanced by the drafts, so the RAW num_new_tokens
+            # can still be draft-inflated (drafts held) or negative (post-verify
+            # overshoot). See should_defer_spec_step. Non-spec decode is untouched
+            # (its no-new-tokens case is the plain `<= 0` continue below).
+            if should_defer_spec_step(
+                self.num_spec_tokens, request.spec_token_ids, num_new_tokens
+            ):
+                req_index += 1
+                continue
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
@@ -321,6 +390,10 @@ class RBLNScheduler(Scheduler):
                         if preempted_req in scheduled_running_reqs:
                             preempted_req_id = preempted_req.request_id
                             scheduled_running_reqs.remove(preempted_req)
+                            # NOTE(RBLN): the victim was admitted just below its
+                            # append; un-admit it so the stale (over)count does
+                            # not make can_admit() stop admitting early.
+                            decode_budget.discard()
                             token_budget += num_scheduled_tokens.pop(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
@@ -351,6 +424,11 @@ class RBLNScheduler(Scheduler):
 
             # Schedule the request.
             scheduled_running_reqs.append(request)
+            # NOTE(RBLN): every scheduled running req joins this step's decode
+            # batch; admit() keeps the shared budget's count == batch size so
+            # the can_admit() gate at the loop's end (and the waiting loop)
+            # stops at the cap.
+            decode_budget.admit()
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -392,11 +470,9 @@ class RBLNScheduler(Scheduler):
 
             # NOTE(RBLN): We restrict the decode batch size to
             # (max_num_seqs // pipeline_parallel_size) to prevent pipeline
-            # bubbles.
-            if len(scheduled_running_reqs) >= (
-                self.max_num_running_reqs
-                // self.vllm_config.parallel_config.pipeline_parallel_size
-            ):
+            # bubbles. Enforced via the shared decode budget (hard cap ==
+            # max_num_seqs // pp; optional PP-balanced soft cap on top).
+            if not decode_budget.can_admit():
                 break
 
         # Record the LoRAs in scheduled_running_reqs
@@ -433,6 +509,19 @@ class RBLNScheduler(Scheduler):
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
+
+                # NOTE(RBLN): Gate by the shared decode budget so the combined
+                # decode batch (running loop + waiting-loop remote-KV promotion)
+                # never exceeds max_num_seqs // pp (the runner's compiled bucket)
+                # -- the disagg over-admission fix. The soft (PP-balance) cap
+                # applies only to remote-KV promotions, which are in the demand
+                # snapshot; other joins (local prefix-cache / resumed) face only
+                # the hard cap. Checked before promoting a blocked-waiting
+                # request so a gated remote-KV req stays in WAITING_FOR_REMOTE_KVS
+                # (re-evaluated next step) instead of flipping its status.
+                apply_soft_cap = request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+                if not decode_budget.can_admit(apply_soft_cap=apply_soft_cap):
+                    break
 
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
@@ -780,6 +869,12 @@ class RBLNScheduler(Scheduler):
                         required_backfill = self.num_spec_tokens  # (num_spec+1)-1
                         if required_backfill > tokens_used_in_block:
                             unsafe_backfill_req_ids.add(request.request_id)
+                    # NOTE(RBLN): this decode-ready request has just joined the
+                    # decode batch (any route -- full remote-KV match or full
+                    # local prefix-cache match), so count it against the shared
+                    # per-step cap. A PARTIAL remote-KV match stays is_prefill
+                    # (not here) and is counted via the running loop next step.
+                    decode_budget.admit()
                     # The scheduled new request is added as a decoding-phase req, so
                     # we can continue to schedule the next request.
                     continue
@@ -803,6 +898,10 @@ class RBLNScheduler(Scheduler):
                     self._add_pending_runner_block_delta(req.request_id, evicted_delta)
 
                 scheduled_running_reqs.clear()
+                # NOTE(RBLN): the decode batch was just evicted for a prefill
+                # (no-mixed-batching); clear the admission count so this step
+                # budgets only the lone prefill.
+                decode_budget.reset()
                 token_budget = prefill_token_budget
 
                 # NOTE(RBLN): we restrict the prefill batch size to 1 for now.
@@ -919,6 +1018,16 @@ class RBLNScheduler(Scheduler):
             else None
         )
 
+        # NOTE(RBLN): Stamp the step-level prefill/decode phase from the
+        # pre-advance Request state (num_computed < num_tokens - 1). No mixed
+        # batching makes the step uniform (all decodes, or a lone prefill), so
+        # one representative request decides it -- the first scheduled id
+        # (running reqs are inserted first; otherwise the waiting-loop prefill).
+        # Empty step (no tokens) -> False (decode); the runner early-returns.
+        is_prefill_step = bool(num_scheduled_tokens) and is_prefill(
+            self.requests[next(iter(num_scheduled_tokens))]
+        )
+
         scheduler_output = RBLNSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -935,6 +1044,7 @@ class RBLNScheduler(Scheduler):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            is_prefill_step=is_prefill_step,
         )
 
         # Drain pending copy ops from the KV cache manager.
@@ -974,6 +1084,48 @@ class RBLNScheduler(Scheduler):
         # from the previous running state are stale.
         self._pending_runner_block_deltas.pop(request.request_id, None)
         return super()._preempt_request(request, timestamp)
+
+    def _make_cached_request_data(
+        self,
+        running_reqs: list[Request],
+        resumed_reqs: list[Request],
+        num_scheduled_tokens: dict[str, int],
+        spec_decode_tokens: dict[str, list[int]],
+        req_to_new_blocks: dict[str, KVCacheBlocks],
+    ) -> CachedRequestData:
+        data = super()._make_cached_request_data(
+            running_reqs,
+            resumed_reqs,
+            num_scheduled_tokens,
+            spec_decode_tokens,
+            req_to_new_blocks,
+        )
+        # NOTE(RBLN): multi-accept token propagation to the non-last PP rank
+        # under sync scheduling. The base builds new_token_ids =
+        # all_token_ids[num_computed : num_computed + base] (base =
+        # num_scheduled - drafts). When a prior verify accepted k drafts, the
+        # non-last rank's write cursor (num_tokens_no_spec) lags num_computed by
+        # up to num_spec, so a base-length payload cannot fill
+        # [cursor : num_computed + base] -> stale/garbage tokens on PP0. Extend
+        # the payload backward by num_spec so it always covers the max lag; the
+        # runner writes it by absolute position, idempotently overwriting any
+        # mis-speculated draft slots. Only the sync-PP spec path (where the base
+        # sends a new_token_ids payload) is touched.
+        if (
+            self.use_pp
+            and not self.scheduler_config.async_scheduling
+            and self.num_spec_tokens > 0
+            and data.new_token_ids
+        ):
+            for idx, req in enumerate(itertools.chain(running_reqs, resumed_reqs)):
+                if idx >= len(data.new_token_ids):
+                    break
+                req_id = req.request_id
+                base = num_base_tokens(num_scheduled_tokens, spec_decode_tokens, req_id)
+                lo = max(0, req.num_computed_tokens - self.num_spec_tokens)
+                hi = req.num_computed_tokens + base
+                data.new_token_ids[idx] = req.all_token_ids[lo:hi]
+        return data
 
     def _free_request(
         self, request: Request, delay_free_blocks: bool = False

--- a/vllm_rbln/v1/core/utils.py
+++ b/vllm_rbln/v1/core/utils.py
@@ -1,0 +1,345 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility helpers for the RBLN scheduler (``rbln_scheduler.py``).
+
+A home for small, self-contained, independently-testable pieces of RBLN
+scheduling/engine logic factored out of ``RBLNScheduler`` so that
+``schedule()`` (a large copy of upstream's method with RBLN-specific tweaks)
+stays readable. Unlike ``vllm_rbln.utils`` (general torch-tensor primitives),
+these encode engine/scheduler semantics; some are shared with the runner
+(``RBLNModelRunner``) -- e.g. ``decode_batch_size`` and the spec-decode
+``num_base_tokens`` / ``resolve_propagated_token_write`` token bookkeeping.
+Add further scheduler utilities here.
+
+The speculative-decode + PP helpers -- ``should_defer_spec_step`` (running-loop
+anchor-reconciled deferral), ``num_base_tokens`` and
+``resolve_propagated_token_write`` (non-last-rank token propagation) -- live
+next to their docstrings above/below.
+
+The per-step decode-batch admission budget (``DecodeBatchBudget`` +
+``DecodeCapPolicy``):
+
+Under pipeline parallelism the engine keeps ``pipeline_parallel_size``
+microbatches in flight (one per PP stage). To bound the total in-flight
+decode requests to ``max_num_seqs`` and to never exceed the runner's
+compiled decode-batch bucket, each single step's decode batch must be
+capped at ``max_num_seqs // pipeline_parallel_size`` (==
+``RBLNModelRunner.bucketing_manager.max_batch_size``). ``schedule()`` admits
+decode requests from two places — the running loop and the waiting-loop
+remote-KV promotion
+(P/D-disaggregated decode) — so the cap is centralized into one budget both
+loops share, rather than enforced per-loop.
+"""
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+
+def decode_batch_size(max_num_seqs: int, pipeline_parallel_size: int) -> int:
+    """Per-PP-stage (compiled) decode batch size — the single source of truth.
+
+    ``max_num_seqs`` is the max number of concurrently running sequences (the
+    scheduler's running-queue cap), consistent with upstream vLLM and with the
+    non-PP case; the KV cache is provisioned to hold that many concurrent
+    sequences. Under pipeline parallelism the engine keeps
+    ``pipeline_parallel_size`` microbatches in flight, so to keep total
+    in-flight sequences <= ``max_num_seqs`` the batch RBLN must *compile* for
+    one PP stage is that cap split across stages:
+
+        decode_batch_size = max_num_seqs // pipeline_parallel_size
+
+    Unlike GPU (dynamic batch shapes, no division), RBLN compiles a fixed
+    decode-batch shape, so this derived value — not ``max_num_seqs`` itself —
+    is what the runner buckets to and the scheduler caps at. ``pp_size == 1``
+    returns ``max_num_seqs`` unchanged (non-PP). Callers must ensure
+    ``max_num_seqs >= pipeline_parallel_size`` (validated at config time in
+    ``RBLNPlatform.check_and_update_config``); otherwise this floors to 0.
+    """
+    return max_num_seqs // pipeline_parallel_size
+
+
+def should_defer_spec_step(
+    num_spec_tokens: int,
+    spec_token_ids: list[int],
+    num_new_tokens: int,
+) -> bool:
+    """Whether ``schedule()``'s running loop must defer a speculative-decode
+    step under sync-scheduling PP because it has no reconciled BASE (anchor)
+    token to schedule yet.
+
+    Called with the RAW ``num_new_tokens`` (before the scheduler's caps). The
+    base count is ``num_new_tokens - len(spec_token_ids)``. The branch is on
+    whether the proposer currently holds drafts (``spec_token_ids``), which only
+    selects how the base is tested:
+
+    - Drafts held: ``num_new_tokens`` is draft-inflated, so gate on the base
+      itself. ``base <= 0`` means there is no fresh anchor token for the drafts
+      to verify against yet (the token-producing step has not reconciled);
+      scheduling anyway hands the non-last PP rank an empty token payload.
+    - No drafts held (just consumed, or no proposer match): ``base ==
+      num_new_tokens``, which goes negative only in the post-verify overshoot
+      (num_computed_tokens still optimistically advanced). The mundane ``== 0``
+      (no work this step) and the no-match case are left to the caller's plain
+      upstream defer.
+
+    Returns ``False`` when spec is disabled (``num_spec_tokens <= 0``), so
+    non-spec decode is untouched; also inert for pp=1, where synchronous
+    scheduling keeps the base reconciled.
+    """
+    if num_spec_tokens <= 0:
+        return False
+    if spec_token_ids:
+        return num_new_tokens - len(spec_token_ids) <= 0
+    return num_new_tokens < 0
+
+
+def num_base_tokens(
+    num_scheduled_tokens: dict[str, int],
+    scheduled_spec_decode_tokens: dict[str, list[int]],
+    req_id: str,
+) -> int:
+    """Number of non-draft (anchor / decode) tokens scheduled for ``req_id`` in
+    a step: the total scheduled tokens minus the speculative draft tokens.
+
+    This is the count that advances the request's committed sequence (the base
+    decode token plus any catch-up), as opposed to the unverified drafts. It is
+    the shared notion of "base" used by the scheduler's non-last-rank token
+    propagation and by the runner's token-write / output bookkeeping.
+    """
+    return num_scheduled_tokens.get(req_id, 0) - len(
+        scheduled_spec_decode_tokens.get(req_id, ())
+    )
+
+
+def resolve_propagated_token_write(
+    cursor: int,
+    num_computed_tokens: int,
+    base: int,
+    new_token_ids: list[int],
+) -> tuple[int, list[int]] | None:
+    """Plan the non-last PP rank's write of scheduler-propagated tokens.
+
+    Under sync-scheduling pipeline parallelism the scheduler ships
+    ``new_token_ids`` covering the request's committed-token tail (extended
+    backward by ``num_spec_tokens`` so it always spans a prior verify's
+    multi-accept lag). This rank brings its recorded-token cursor
+    (``num_tokens_no_spec``) up to
+    ``committed_tip = num_computed_tokens + base`` by writing the payload slice
+    that lands at ``[cursor, committed_tip)`` by ABSOLUTE position, idempotently
+    overwriting any mis-speculated slots.
+
+    Returns ``(committed_tip, tokens)`` where ``tokens`` is the slice to write
+    at ``token_ids_cpu[cursor:committed_tip]`` -- empty when the payload is
+    empty (e.g. the async-scheduling GPU-broadcast path), in which case only the
+    cursor advances -- or ``None`` if the cursor has already reached
+    ``committed_tip`` (nothing to write).
+    """
+    committed_tip = num_computed_tokens + base
+    if committed_tip <= cursor:
+        return None
+    span = committed_tip - cursor
+    if not new_token_ids:
+        return committed_tip, []
+    # The payload covers all_token_ids[committed_tip - len : committed_tip], so
+    # the token for absolute position `cursor` sits at offset `lo`.
+    lo = cursor - (committed_tip - len(new_token_ids))
+    if lo >= 0 and lo + span <= len(new_token_ids):
+        return committed_tip, new_token_ids[lo : lo + span]
+    # Defensive: the payload should always cover [cursor, committed_tip); if it
+    # somehow does not, fall back to its tail so the cursor still advances
+    # without an out-of-bounds slice.
+    return committed_tip, new_token_ids[-span:]
+
+
+@runtime_checkable
+class DecodeCapPolicy(Protocol):
+    """Supplies the per-step decode-batch cap (max decode requests admitted
+    to one PP microbatch).
+
+    Injected into ``DecodeBatchBudget`` so the admission logic stays fixed
+    while the *sizing* rule can evolve — e.g. a future dynamic policy that
+    splits available decodes across PP stages to avoid microbatch collapse."""
+
+    def cap(self) -> int: ...
+
+
+class StaticDecodeCapPolicy:
+    """Fixed cap = ``max_num_seqs // pipeline_parallel_size``.
+
+    Must equal ``RBLNModelRunner.bucketing_manager.max_batch_size`` so the
+    scheduled decode batch always maps onto a compiled decode-batch bucket.
+    ``pp_size == 1``
+    degenerates to ``max_num_seqs`` (the cap is then a no-op, since the
+    running queue is already bounded by ``max_num_seqs``).
+    """
+
+    def __init__(self, cap: int) -> None:
+        assert cap >= 1, f"decode-batch cap must be >= 1, got {cap}"
+        self._cap = cap
+
+    def cap(self) -> int:
+        return self._cap
+
+
+class DynamicDecodeCapPolicy:
+    """Cap that spreads the decode *demand* across the PP pipeline.
+
+    Avoids PP-depth collapse: after a pipeline drain (e.g. a
+    prefill stall) every decode becomes reschedulable at once, and the static
+    ``max_num_seqs // pp_size`` cap lets them pack into a single microbatch ->
+    the other ``pp_size - 1`` stages idle (depth-1, ~2x decode latency). Sizing
+    each step's batch to ``ceil(demand / pp_size)`` instead spreads the decode
+    demand across ``pp_size`` microbatches so the pipeline stays full.
+
+    ``num_demand_decodes`` is the total decode demand, NOT just the currently
+    running decodes: it must also include remote-KV requests that are ready to
+    join the decode batch (P/D-disaggregated decode). Using running-only would
+    leave no headroom to admit those, stalling the ramp (the cap is fully
+    consumed by the requests already cycling). Crucially, demand is *invariant*
+    under admission -- promoting a ready remote-KV moves it from "ready" to
+    "running" without changing the total -- so a single step-start snapshot is
+    exact even though the running/ready split shifts during the waiting loop.
+
+    The cap is **clamped to** ``static_max_cap`` (== the runner's compiled
+    decode-batch ceiling) so it can only go *lower*, never overflow the bucket;
+    and floored at 1. ``pp_size == 1`` yields ``min(static_max_cap, demand)``,
+    a no-op (only ``demand`` decodes are admittable anyway).
+
+    Constructed per ``schedule()`` call with that step's decode demand.
+    """
+
+    def __init__(
+        self,
+        static_max_cap: int,
+        pipeline_parallel_size: int,
+        num_demand_decodes: int,
+    ) -> None:
+        assert static_max_cap >= 1, f"static_max_cap must be >= 1, got {static_max_cap}"
+        # ceil(num_demand_decodes / pipeline_parallel_size)
+        spread = -(-num_demand_decodes // pipeline_parallel_size)
+        self._cap = max(1, min(static_max_cap, spread))
+
+    def cap(self) -> int:
+        return self._cap
+
+
+class DecodeBatchBudget:
+    """Tracks how many decode requests have been admitted to the current
+    step's batch, shared across ``schedule()``'s running and waiting loops.
+
+    Lifecycle: one instance per ``schedule()`` call. ``admit()`` on every
+    decode added to the step; ``can_admit()`` gates further admissions in
+    both loops; ``reset()`` clears the count when a prefill evicts the
+    decode batch (the "disable mixed batching" path).
+    """
+
+    def __init__(self, cap_policy: DecodeCapPolicy, hard_cap: int) -> None:
+        self._cap_policy = cap_policy
+        # Compiled decode-bucket ceiling (max_num_seqs // pp). The batch may
+        # never exceed it or the runner has no bucket -> crash. The policy's
+        # cap() is the (<=) soft/spreading cap (== hard_cap in static mode).
+        self._hard_cap = hard_cap
+        self._count = 0
+
+    def can_admit(self, *, apply_soft_cap: bool = True) -> bool:
+        """True iff one more decode request may be admitted this step.
+
+        Two limits:
+          * hard cap (always): the compiled bucket ceiling; exceeding it
+            crashes the runner. Applies to every candidate decode join.
+          * soft cap (``apply_soft_cap``): the balance/spreading target
+            ``ceil(demand/pp)`` for the *budgeted* decode demand (running
+            decodes + ready remote-KV). Skip it (``apply_soft_cap=False``) for
+            joins not in the demand snapshot (full local prefix-cache match,
+            resumed-after-eviction) — they only face the hard limit. In static
+            mode the two caps are equal, so the flag has no effect.
+        """
+        if self._count >= self._hard_cap:
+            return False
+        # Soft (spreading) cap for the budgeted demand; skipped for
+        # demand-unbudgeted joins, which then face only the hard cap above.
+        return not (apply_soft_cap and self._count >= self._cap_policy.cap())
+
+    def admit(self, n: int = 1) -> None:
+        """Record ``n`` decode requests as admitted to this step's batch."""
+        self._count += n
+
+    def discard(self, n: int = 1) -> None:
+        """Un-admit ``n`` decode requests dropped from this step's batch.
+
+        Unlike ``reset()`` (whole batch dropped by a prefill eviction), this
+        removes only the requests that left the batch while others remain
+        admitted -- currently the PRIORITY-policy preemption in the running
+        loop, which evicts an already-scheduled decode to free KV blocks.
+        Keeping the count in step with the batch keeps the subsequent
+        ``can_admit()`` gate from stopping early on a stale (over)count.
+        """
+        self._count -= n
+
+    def reset(self) -> None:
+        """Clear the admitted count (decode batch dropped, e.g. by eviction)."""
+        self._count = 0
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    @property
+    def cap(self) -> int:
+        return self._cap_policy.cap()
+
+
+class DecodeAdmissionController:
+    """Per-scheduler factory for per-step decode-batch admission budgets.
+
+    Built once from scheduler config; produces a fresh ``DecodeBatchBudget``
+    for each ``schedule()`` call. It owns the PP decode-cap machinery — the
+    compiled per-stage batch size, the static cap policy, and the choice
+    between the static cap and the PP-balanced dynamic cap — so ``schedule()``
+    only has to supply the demand and use the returned budget.
+
+    Dynamic (demand-spread) capping applies only when ``pp_balance_decode`` is
+    enabled *and* ``pipeline_parallel_size > 1``; otherwise the fixed
+    ``max_num_seqs // pp_size`` cap is used.
+    """
+
+    def __init__(
+        self,
+        max_num_seqs: int,
+        pipeline_parallel_size: int,
+        pp_balance_decode: bool,
+    ) -> None:
+        self._pp_size = pipeline_parallel_size
+        self._max_decode_batch_size = decode_batch_size(
+            max_num_seqs, pipeline_parallel_size
+        )
+        self._static_policy = StaticDecodeCapPolicy(self._max_decode_batch_size)
+        # Demand-spread capping is only meaningful under PP.
+        self._balance = pp_balance_decode and pipeline_parallel_size > 1
+
+    def make_budget(self, demand_fn: Callable[[], int]) -> DecodeBatchBudget:
+        """Return a fresh budget for this step.
+
+        ``demand_fn`` is a zero-arg callable returning the total decode demand
+        (running decodes + ready remote-KV). It is invoked **only** when PP
+        balancing is active, so the static path pays nothing to compute it.
+        """
+        if self._balance:
+            policy: DecodeCapPolicy = DynamicDecodeCapPolicy(
+                self._max_decode_batch_size, self._pp_size, demand_fn()
+            )
+        else:
+            policy = self._static_policy
+        return DecodeBatchBudget(policy, hard_cap=self._max_decode_batch_size)

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -620,7 +620,11 @@ class RBLNEagleProposer(EagleProposer):
         if dp_size == 1:
             return num_reqs_padded, None, None
 
-        num_tokens_across_dp, num_reqs_across_dp = (
+        # NOTE(RBLN): the DP-idle-dummy exclusion implemented in the main runner's
+        # _determine_batch_padding is not yet mirrored on the draft-model side, so
+        # the 3rd return (per-rank idle mask) is ignored here. Follow-up for
+        # full DP-idle-dummy correctness under EAGLE speculative decode.
+        num_tokens_across_dp, num_reqs_across_dp, _ = (
             RBLNDPMetadata.num_tokens_and_reqs_across_dp(
                 num_tokens, num_reqs, dp_size, self.dp_rank, is_prefill
             )

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -92,7 +92,10 @@ class RBLNEagleProposer(EagleProposer):
         )
 
         assert self.runner is not None
-        is_prefill = self.runner.is_prefill
+        # Use the scheduler-stamped step phase (rank-consistent) rather than the
+        # runner's per-rank is_prefill property, which can diverge across PP
+        # ranks under spec-decode. Drives draft batch padding + draft attn build.
+        is_prefill = self.runner.is_prefill_phase()
 
         # Build attention metadata
         num_reqs = self.runner.input_batch.num_reqs

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -121,6 +121,11 @@ from vllm_rbln.v1.attention.kv_cache_bindings import (
 )
 from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
+from vllm_rbln.v1.core.utils import (
+    decode_batch_size,
+    num_base_tokens,
+    resolve_propagated_token_write,
+)
 from vllm_rbln.v1.sample.rbln_rejection_sampler import RBLNRejectionSampler
 from vllm_rbln.v1.spec_decode.eagle import RBLNEagleProposer
 from vllm_rbln.v1.spec_decode.medusa import RBLNMedusaProposer
@@ -211,6 +216,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.parallel_config = vllm_config.parallel_config
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
+
+        # Step-level prefill/decode phase, stamped from RBLNSchedulerOutput at
+        # the top of execute_model (see is_prefill_phase()). Scheduler-authored
+        # so it is identical across PP ranks.
+        self._is_prefill_step: bool = False
         # self.observability_config = vllm_config.observability_config
 
         model_config = self.model_config
@@ -402,10 +412,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # (and across the PP / pooling / empty-batch paths).
         self.kv_connector_output: KVConnectorOutput | None = None
 
-        # NOTE(RBLN): Initialize bucketing manager
+        # NOTE(RBLN): Initialize bucketing manager. RBLN compiles a fixed
+        # decode-batch shape, so it buckets to the per-PP-stage decode batch
+        # (max_num_seqs // pp_size) -- the single source of truth shared with
+        # the scheduler's decode admission cap -- not the raw max_num_seqs.
         self.bucketing_manager = get_bucketing_manager(
             envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY,
-            max_batch_size=self.max_num_reqs,
+            max_batch_size=decode_batch_size(
+                self.max_num_reqs, self.parallel_config.pipeline_parallel_size
+            ),
             min_batch_size=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_MIN,
             step=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STEP,
             limit=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT,
@@ -625,8 +640,20 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 new_token_ids = req_data.new_token_ids[i]
                 # Add the sampled token(s) from the previous step (if any).
                 # This doesn't include "unverified" tokens like spec tokens.
+                # NOTE(RBLN): new_token_ids is extended backward by num_spec
+                # (multi-accept propagation) and ends at committed_tip =
+                # num_computed + base. The number of NEW output tokens is the
+                # committed delta, computed from base (not len(new_token_ids),
+                # which now includes the backward-extended catch-up window).
+                # new_token_ids[-num_new:] still takes the newest tokens because
+                # the payload ends at committed_tip.
+                base_out = num_base_tokens(
+                    scheduler_output.num_scheduled_tokens,
+                    scheduled_spec_tokens,
+                    req_id,
+                )
                 num_new_tokens = (
-                    num_computed_tokens + len(new_token_ids) - req_state.num_tokens
+                    num_computed_tokens + base_out - req_state.num_tokens
                 )
                 if num_new_tokens == 1:
                     # Avoid slicing list in most common case.
@@ -672,13 +699,32 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # For the last rank, we don't need to update the token_ids_cpu
             # because the sampled tokens are already cached.
             if not is_last_rank:
-                # Add new_token_ids to token_ids_cpu.
-                start_token_index = num_computed_tokens
-                end_token_index = num_computed_tokens + len(new_token_ids)
-                self.input_batch.token_ids_cpu[
-                    req_index, start_token_index:end_token_index
-                ] = new_token_ids
-                self.input_batch.num_tokens_no_spec[req_index] = end_token_index
+                # NOTE(RBLN): bring this rank's recorded-token cursor
+                # (num_tokens_no_spec) up to committed_tip = num_computed + base
+                # by writing the scheduler-propagated tokens at their ABSOLUTE
+                # position. The payload is extended backward by num_spec so it
+                # spans a prior verify's multi-accept lag; the write idempotently
+                # overwrites any mis-speculated draft slots. See
+                # resolve_propagated_token_write.
+                base = num_base_tokens(
+                    scheduler_output.num_scheduled_tokens,
+                    scheduled_spec_tokens,
+                    req_id,
+                )
+                start_token_index = self.input_batch.num_tokens_no_spec[req_index]
+                write = resolve_propagated_token_write(
+                    start_token_index, num_computed_tokens, base, new_token_ids
+                )
+                if write is not None:
+                    committed_tip, tokens = write
+                    if tokens:
+                        self.input_batch.token_ids_cpu[
+                            req_index, start_token_index:committed_tip
+                        ] = tokens
+                    self.input_batch.is_token_ids[
+                        req_index, start_token_index:committed_tip
+                    ] = True
+                    self.input_batch.num_tokens_no_spec[req_index] = committed_tip
 
             # Add spec_token_ids to token_ids_cpu.
             self.input_batch.update_req_spec_token_ids(req_state, scheduled_spec_tokens)
@@ -758,7 +804,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # ngram/suffix steps clear scheduled_spec_decode_tokens and run with
         # the logical query length, usually qlen=1.
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
-        if use_spec_decode and self.num_spec_tokens > 0 and not self.is_prefill:
+        if use_spec_decode and self.num_spec_tokens > 0 and not self.is_prefill_phase():
             target_query_len = self.num_spec_tokens + 1
             query_lengths = np.full(num_reqs, target_query_len, dtype=np.int32)
             backfill = query_lengths - logical_num_tokens
@@ -928,8 +974,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, RBLNEagleProposer):
-                    if self.drafter.kv_cache_gid == kv_cache_gid:
+                # NOTE(RBLN): the drafter lives only on the last PP rank, so
+                # use getattr (like the warmup/load-model paths) -- this runs on
+                # every rank under spec-decode + PP. Non-last ranks (drafter
+                # absent -> None) take the else branch; the resulting
+                # spec_decode_common_attn_metadata is unused there (only the
+                # last rank drafts).
+                drafter = getattr(self, "drafter", None)
+                if isinstance(drafter, RBLNEagleProposer):
+                    if drafter.kv_cache_gid == kv_cache_gid:
                         spec_decode_common_attn_metadata = cm
                 else:
                     spec_decode_common_attn_metadata = cm
@@ -942,7 +995,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 attn_metadata_i = builder.build(
                     common_attn_metadata=cm,
                     positions=self.positions,
-                    is_prefill=self.is_prefill,
+                    is_prefill=self.is_prefill_phase(),
                     batch_pad=num_reqs_padded,
                 )
 
@@ -1161,12 +1214,13 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         else:
             assert intermediate_tensors is not None
 
+        is_prefill_phase = self.is_prefill_phase()
         layout = InputLayout(
             num_reqs=num_reqs,
-            num_reqs_padded=num_reqs if self.is_prefill else num_reqs_padded,
+            num_reqs_padded=num_reqs if is_prefill_phase else num_reqs_padded,
             query_len=input_ids.shape[1],
             query_len_padded=self.max_num_tokens
-            if self.is_prefill
+            if is_prefill_phase
             else input_ids.shape[1],
         )
         staged_model_inputs = self.input_stager.stage(
@@ -1175,7 +1229,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             intermediate_tensors=intermediate_tensors,
             inputs_embeds=inputs_embeds,
             token_indices=logits_indices
-            if self.is_prefill and self.use_wrapped_compute_logits
+            if is_prefill_phase and self.use_wrapped_compute_logits
             else None,
             layout=layout,
         )
@@ -1348,6 +1402,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             assert kv_connector_metadata is not None
             get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
 
+        # Stamp this step's prefill/decode phase from the scheduler before any
+        # is_prefill_phase() read or early return, so all PP ranks agree on the
+        # graph they select this step.
+        self._set_step_phase(scheduler_output)
+
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
 
         with record_function_or_nullcontext("rbln_model_runner: preprocess"):
@@ -1421,7 +1480,14 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # When spec decode is enabled, defer connector finalization
         # (wait_for_save + clear metadata) until after the draft model runs
         # in sample_tokens(), so the draft model can also save its KV cache.
-        defer_kv_connector_finalize = self.speculative_config is not None
+        # NOTE(RBLN): gate on the last PP rank -- the deferred finalize runs in
+        # the sample path, which only the last rank reaches, so deferring on
+        # non-last ranks would drop their KV save entirely (every PP rank must
+        # finalize its own layers' KV). Only the last rank drafts, so only it
+        # needs to defer; non-last ranks finalize in-context like non-spec.
+        defer_kv_connector_finalize = (
+            self.speculative_config is not None and get_pp_group().is_last_rank
+        )
         with (
             set_forward_context(
                 attn_metadata,
@@ -1436,7 +1502,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 scheduler_output,
                 defer_finalize=defer_kv_connector_finalize,
             ) as kv_connector_output,
-            self.performance_ctx.profile_model(self.is_prefill),
+            self.performance_ctx.profile_model(self.is_prefill_phase()),
         ):
             model_output = self.model_executable(
                 **staged_model_inputs.as_kwargs(),
@@ -1465,7 +1531,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
             sample_hidden_states = hidden_states
             assert self.use_wrapped_compute_logits
-            if not self.is_prefill and spec_decode_metadata is not None:
+            if not self.is_prefill_phase() and spec_decode_metadata is not None:
                 logits = logits[logits_indices]
 
         self.execute_model_state = ExecuteModelState(
@@ -2019,13 +2085,22 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         seq_lens_np[:num_reqs] = num_scheduled_tokens
         seq_lens_np[num_reqs:] = 0
 
-        # NOTE(RBLN): self.is_prefill is derived from num_tokens_no_spec.
-        # For decode warmup, keep it at 1 so multi-token speculative decode
-        # query lengths are not misclassified as prefill.
+        # NOTE(RBLN): num_tokens_no_spec is the per-request no-spec logical
+        # length consumed downstream (query backfill, spec metadata). For decode
+        # warmup keep it at 1 so a multi-token speculative decode query is sized
+        # as decode. The step phase itself is stamped below via _is_prefill_step.
         if is_prefill:
             self.input_batch.num_tokens_no_spec[:num_reqs] = num_scheduled_tokens
         else:
             self.input_batch.num_tokens_no_spec[:num_reqs] = 1
+
+        # Stamp the phase from this dummy's own classification so the graph/phase
+        # selection helpers below (_determine_batch_padding,
+        # _build_attention_metadata) read is_prefill_phase() consistently. This
+        # bypasses execute_model's scheduler stamp and also guards the DP-idle
+        # path (rbln_worker.execute_dummy_batch): a stale value from a prior real
+        # step cannot leak into any is_prefill_phase() read while the dummy runs.
+        self._is_prefill_step = is_prefill
 
         num_reqs_padded, _num_tokens_padded, num_tokens_across_dp = (
             self._determine_batch_padding(num_reqs, num_tokens_unpadded)
@@ -2066,9 +2141,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 dtype=self.model_config.dtype,
                 device=self.device,
             )
+            # The empty tensor holds num_tokens_unpadded (= num_reqs *
+            # num_tokens_per_req) rows, so the view must reshape by num_reqs to
+            # keep the trailing hidden dimension intact. Using the DP-padded
+            # count here would over-count the leading dims and split the hidden
+            # size (num_reqs_padded > num_reqs whenever a peer forces padding),
+            # matching input_ids / InputLayout which also stage by num_reqs.
             intermediate_tensors = IntermediateTensors(
                 {
-                    k: v.view(num_reqs_padded, num_tokens_per_req, -1)
+                    k: v.view(num_reqs, num_tokens_per_req, -1)
                     for k, v in intermediate_tensors.items()
                 }
             )
@@ -2752,15 +2833,28 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
     # Only RBLN-Specific Methods
     ####################################################################################################
 
-    @property
-    def is_prefill(self) -> bool:
-        num_computed_tokens = self.input_batch.num_computed_tokens_cpu[0]
-        num_tokens_no_spec = self.input_batch.num_tokens_no_spec[0]
-        return bool(num_computed_tokens < (num_tokens_no_spec - 1))
+    def _set_step_phase(self, scheduler_output: "RBLNSchedulerOutput") -> None:
+        """Record this step's prefill/decode phase from the scheduler stamp."""
+        self._is_prefill_step = scheduler_output.is_prefill_step
+
+    def is_prefill_phase(self) -> bool:
+        """The step's prefill/decode classification, stamped by the scheduler
+        (RBLNSchedulerOutput.is_prefill_step) and stashed at the top of
+        execute_model.
+
+        The single source of truth for all graph/phase selection in the runner.
+        A runner-side re-derivation from num_tokens_no_spec would diverge across
+        PP ranks under spec-decode -- it is updated on the sampling path on the
+        last PP rank but on the scheduler-output path on the others -- so the
+        rank-consistent scheduler value is used instead. On the dummy path
+        (_dummy_run, incl. the DP-idle execute_dummy_batch), _is_prefill_step is
+        stamped from the dummy's own phase instead of a scheduler output.
+        """
+        return self._is_prefill_step
 
     @property
     def is_intermediate_chunked_prefill(self) -> bool:
-        return self.is_prefill and bool(self.discard_request_mask[0])
+        return self.is_prefill_phase() and bool(self.discard_request_mask[0])
 
     @property
     def use_wrapped_compute_logits(self) -> bool:
@@ -2784,9 +2878,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         num_reqs_unpadded: int,
         num_tokens_unpadded: int,
     ) -> tuple[int, int | None, torch.Tensor | None]:
+        is_prefill_phase = self.is_prefill_phase()
         num_reqs_padded = (
             self.bucketing_manager.find_decode_batch_bucket(num_reqs_unpadded)
-            if not self.is_prefill
+            if not is_prefill_phase
             else num_reqs_unpadded
         )
         if self.parallel_config.data_parallel_size == 1:
@@ -2798,7 +2893,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 num_reqs_unpadded,
                 self.parallel_config.data_parallel_size,
                 self.parallel_config.data_parallel_rank,
-                self.is_prefill,
+                is_prefill_phase,
             )
         )
         num_tokens_padded = self.max_num_tokens

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1445,7 +1445,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 num_scheduled_tokens_np,
             )
 
-            num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
+            num_reqs_padded, num_tokens_padded, num_tokens_across_dp, _ = (
                 self._determine_batch_padding(num_reqs, num_query_tokens)
             )
 
@@ -2058,6 +2058,27 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         except IndexError:
             return {}
 
+    def _stage_dummy_seq_lens(
+        self, num_reqs: int, num_tokens_per_req: int, is_prefill: bool
+    ) -> tuple[np.ndarray, int]:
+        """Set seq_lens / num_tokens_no_spec for a dummy batch of this shape and
+        return (num_scheduled_tokens, num_tokens_unpadded). Shared by the initial
+        prep and the DP-idle adopt path so both size the dummy identically.
+
+        num_tokens_no_spec is the per-request no-spec logical length consumed
+        downstream (query backfill, spec metadata); for decode it stays 1 so a
+        multi-token speculative-decode query is still sized as decode.
+        """
+        num_scheduled_tokens = np.array([num_tokens_per_req] * num_reqs, dtype=np.int32)
+        seq_lens_np = self.seq_lens.numpy()
+        seq_lens_np[:num_reqs] = num_scheduled_tokens
+        seq_lens_np[num_reqs:] = 0
+        if is_prefill:
+            self.input_batch.num_tokens_no_spec[:num_reqs] = num_scheduled_tokens
+        else:
+            self.input_batch.num_tokens_no_spec[:num_reqs] = 1
+        return num_scheduled_tokens, int(num_scheduled_tokens.sum())
+
     @torch.inference_mode()
     def _dummy_run(
         self,
@@ -2066,31 +2087,30 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         is_prefill: bool,
         *,
         num_tokens_padded: int | None = None,
+        warmup: bool = True,
     ) -> None:
         """
         Run a dummy forward pass to warm up for the model.
+
+        ``warmup=True`` (default) is the compile-time path. ``warmup=False``
+        marks the serving-time DP-idle dummy step (``execute_dummy_batch``):
+        this rank has no real work and must not drive the cross-DP shape
+        decision. It contributes a minimal (num_reqs=1) entry to the collective
+        all-reduce (excluded from the decision in ``_determine_batch_padding``
+        via ``is_idle``) and then ADOPTS the busy-decided shape below, running
+        the same compiled decode graph the busy ranks run.
         """
+        # The serving-time DP-idle dummy is the only non-warmup use of this
+        # method; downstream shape logic keys on this idle flag.
+        is_idle = not warmup
         num_tokens = num_tokens_per_req * num_reqs
         assert num_tokens <= self.max_num_tokens
         assert num_reqs <= self.max_num_reqs
         draft_num_tokens_padded = num_tokens_padded
 
-        num_scheduled_tokens_list = [num_tokens_per_req] * num_reqs
-        num_scheduled_tokens = np.array(num_scheduled_tokens_list, dtype=np.int32)
-        num_tokens_unpadded = int(num_scheduled_tokens.sum())
-
-        seq_lens_np = self.seq_lens.numpy()
-        seq_lens_np[:num_reqs] = num_scheduled_tokens
-        seq_lens_np[num_reqs:] = 0
-
-        # NOTE(RBLN): num_tokens_no_spec is the per-request no-spec logical
-        # length consumed downstream (query backfill, spec metadata). For decode
-        # warmup keep it at 1 so a multi-token speculative decode query is sized
-        # as decode. The step phase itself is stamped below via _is_prefill_step.
-        if is_prefill:
-            self.input_batch.num_tokens_no_spec[:num_reqs] = num_scheduled_tokens
-        else:
-            self.input_batch.num_tokens_no_spec[:num_reqs] = 1
+        num_scheduled_tokens, num_tokens_unpadded = self._stage_dummy_seq_lens(
+            num_reqs, num_tokens_per_req, is_prefill
+        )
 
         # Stamp the phase from this dummy's own classification so the graph/phase
         # selection helpers below (_determine_batch_padding,
@@ -2100,10 +2120,32 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # step cannot leak into any is_prefill_phase() read while the dummy runs.
         self._is_prefill_step = is_prefill
 
-        num_reqs_padded, _num_tokens_padded, num_tokens_across_dp = (
-            self._determine_batch_padding(num_reqs, num_tokens_unpadded)
+        num_reqs_padded, _num_tokens_padded, num_tokens_across_dp, eff_qlen = (
+            self._determine_batch_padding(num_reqs, num_tokens_unpadded, is_idle)
         )
         num_tokens_padded = num_tokens_padded or _num_tokens_padded
+
+        if is_idle and num_tokens_padded is not None:
+            # Adopt the shape the busy ranks settled on and stage the whole dummy
+            # batch at it (num_reqs == num_reqs_padded, no split), so this rank
+            # runs the same graph they run.
+            #
+            # num_tokens_per_req is this rank's query length. Usually it is
+            # num_tokens_padded / num_reqs_padded; but when num_tokens_padded is a
+            # padding target rather than that product, _determine_batch_padding
+            # returns eff_qlen=1 so the idle rank runs the smallest prepared graph
+            # and lets num_tokens_padded carry the padding on its own.
+            num_reqs = num_reqs_padded
+            num_tokens_per_req = (
+                eff_qlen
+                if eff_qlen is not None
+                else num_tokens_padded // num_reqs_padded
+            )
+            draft_num_tokens_padded = num_tokens_padded
+            num_scheduled_tokens, num_tokens_unpadded = self._stage_dummy_seq_lens(
+                num_reqs, num_tokens_per_req, is_prefill
+            )
+            num_tokens = num_tokens_unpadded
 
         cum_num_tokens, _ = self._get_cumsum_and_arange(num_scheduled_tokens)
         query_start_loc_np = self.query_start_loc.np
@@ -2875,7 +2917,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self,
         num_reqs_unpadded: int,
         num_tokens_unpadded: int,
-    ) -> tuple[int, int | None, torch.Tensor | None]:
+        is_idle: bool = False,
+    ) -> tuple[int, int | None, torch.Tensor | None, int | None]:
         is_prefill_phase = self.is_prefill_phase()
         num_reqs_padded = (
             self.bucketing_manager.find_decode_batch_bucket(num_reqs_unpadded)
@@ -2883,53 +2926,95 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             else num_reqs_unpadded
         )
         if self.parallel_config.data_parallel_size == 1:
-            return num_reqs_padded, None, None
+            return num_reqs_padded, None, None, None
 
-        num_tokens_across_dp, num_reqs_across_dp = (
+        num_tokens_across_dp, num_reqs_across_dp, idle_across_dp = (
             RBLNDPMetadata.num_tokens_and_reqs_across_dp(
                 num_tokens_unpadded,
                 num_reqs_unpadded,
                 self.parallel_config.data_parallel_size,
                 self.parallel_config.data_parallel_rank,
                 is_prefill_phase,
+                is_idle,
             )
         )
         num_tokens_padded = self.max_num_tokens
+        # Per-request query length the idle dummy should adopt (used only there).
+        # None means "derive it from num_tokens_padded / num_reqs_padded", which
+        # holds whenever num_tokens_padded really is that product. The two
+        # fall-back routes below set num_tokens_padded to a padding target
+        # instead, so they pin this to 1.
+        eff_qlen: int | None = None
         if self.specialized_moe_decode:
             if num_reqs_across_dp is None:
                 # any_prefill (PD disaggregation): route padded-decode to the max
                 # bucket so only ONE padded-decode graph is ever needed.
                 num_reqs_padded = self.bucketing_manager.decode_batch_buckets[-1]
+                # An idle rank here cannot see any peer's query length (a peer is
+                # reading a prompt), so it runs the smallest prepared graph;
+                # num_tokens_padded stays the padding target.
+                eff_qlen = 1
             else:
-                assert torch.all(num_tokens_across_dp % num_reqs_across_dp == 0)
-                tokens_per_req_across_dp = num_tokens_across_dp // num_reqs_across_dp
-                max_tokens_per_req = int(torch.max(tokens_per_req_across_dp).item())
-                min_tokens_per_req = int(torch.min(tokens_per_req_across_dp).item())
-                if min_tokens_per_req != max_tokens_per_req:
-                    # DP qlen-ASYMMETRIC step: the ranks disagree on query length
-                    # -- a peer runs multi-token (spec) decode (query_len =
-                    # num_speculative_tokens + 1) while this rank is qlen=1. This
-                    # is the fall-back case: warm-up compiles the spec-asymmetric
-                    # padding ONLY for the top bucket (top_bucket, *, top_bucket *
-                    # spec_qlen) to keep the decode-graph count minimal, so route
-                    # up to it here (same policy as the any_prefill branch above).
-                    #
-                    # A qlen-SYMMETRIC step -- all ranks the same query length,
-                    # whether 1 or the spec length -- instead falls through to the
-                    # per-bucket branch below and runs on its own optimally-sized
-                    # decode graph (compiled per bucket by the warm-up loop). Only
-                    # gating on max_tokens_per_req > 1 here would wrongly route
-                    # symmetric spec to the top bucket, running it oversized and
-                    # orphaning the per-bucket spec graphs.
-                    num_reqs_padded = self.bucketing_manager.decode_batch_buckets[-1]
+                # A DP-idle dummy step (execute_dummy_batch) has no real work, so
+                # it must NOT drive the shape decision -- its fixed (bucket, qlen)
+                # could otherwise drag an optimal collective into a fall-back route
+                # (e.g. an idle rank claiming a spec qlen forces qlen-asymmetry when
+                # the busy ranks are plain qlen=1). Decide the shape from the busy
+                # (non-idle) ranks only; the idle rank then adopts it.
+                busy = idle_across_dp == 0
+                if not bool(busy.any().item()):
+                    # All ranks idle (DP lockstep wind-down / re-sync): no real
+                    # work anywhere -> cheapest compiled decode graph (smallest
+                    # bucket, qlen=1). Deterministic + identical on every rank;
+                    # output discarded.
+                    num_reqs_padded = self.bucketing_manager.decode_batch_buckets[0]
+                    num_tokens_padded = num_reqs_padded
                 else:
-                    num_reqs_padded = self.bucketing_manager.find_decode_batch_bucket(
-                        int(torch.max(num_reqs_across_dp).item())
+                    assert torch.all(
+                        (num_tokens_across_dp % num_reqs_across_dp)[busy] == 0
                     )
-                assert num_reqs_padded is not None
-                num_tokens_padded = num_reqs_padded * max_tokens_per_req
+                    tokens_per_req_across_dp = (
+                        num_tokens_across_dp // num_reqs_across_dp
+                    )
+                    busy_tokens_per_req = tokens_per_req_across_dp[busy]
+                    max_tokens_per_req = int(torch.max(busy_tokens_per_req).item())
+                    min_tokens_per_req = int(torch.min(busy_tokens_per_req).item())
+                    if min_tokens_per_req != max_tokens_per_req:
+                        # DP qlen-ASYMMETRIC step (among the busy ranks): the ranks
+                        # disagree on query length -- a peer runs multi-token (spec)
+                        # decode (query_len = num_speculative_tokens + 1) while
+                        # another is qlen=1. Fall-back: warm-up compiles the
+                        # spec-asymmetric padding ONLY for the top bucket
+                        # (top_bucket, *, top_bucket * spec_qlen) to keep the
+                        # decode-graph count minimal, so route up to it here (same
+                        # policy as the any_prefill branch above).
+                        #
+                        # A qlen-SYMMETRIC step -- all busy ranks the same query
+                        # length, whether 1 or the spec length -- instead falls
+                        # through to the per-bucket branch below and runs on its
+                        # own optimally-sized decode graph. Only gating on
+                        # max_tokens_per_req > 1 would wrongly route symmetric spec
+                        # to the top bucket, running it oversized and orphaning the
+                        # per-bucket spec graphs.
+                        num_reqs_padded = self.bucketing_manager.decode_batch_buckets[
+                            -1
+                        ]
+                        # The busy ranks disagree on query length; an idle rank
+                        # follows the single-token ones (the cheapest prepared
+                        # graph), not the longer speculative ones. The padding
+                        # target rides along on num_tokens_padded below.
+                        eff_qlen = 1
+                    else:
+                        busy_num_reqs = num_reqs_across_dp[busy]
+                        num_reqs_padded = (
+                            self.bucketing_manager.find_decode_batch_bucket(
+                                int(torch.max(busy_num_reqs).item())
+                            )
+                        )
+                    assert num_reqs_padded is not None
+                    num_tokens_padded = num_reqs_padded * max_tokens_per_req
 
-        return num_reqs_padded, num_tokens_padded, num_tokens_across_dp
+        return num_reqs_padded, num_tokens_padded, num_tokens_across_dp, eff_qlen
 
     def _update_kv_cache_base_bindings(
         self,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -652,9 +652,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                     scheduled_spec_tokens,
                     req_id,
                 )
-                num_new_tokens = (
-                    num_computed_tokens + base_out - req_state.num_tokens
-                )
+                num_new_tokens = num_computed_tokens + base_out - req_state.num_tokens
                 if num_new_tokens == 1:
                     # Avoid slicing list in most common case.
                     req_state.output_token_ids.append(new_token_ids[-1])
@@ -2903,13 +2901,32 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 # bucket so only ONE padded-decode graph is ever needed.
                 num_reqs_padded = self.bucketing_manager.decode_batch_buckets[-1]
             else:
-                num_reqs_padded = self.bucketing_manager.find_decode_batch_bucket(
-                    int(torch.max(num_reqs_across_dp).item())
-                )
-                assert num_reqs_padded is not None
                 assert torch.all(num_tokens_across_dp % num_reqs_across_dp == 0)
                 tokens_per_req_across_dp = num_tokens_across_dp // num_reqs_across_dp
                 max_tokens_per_req = int(torch.max(tokens_per_req_across_dp).item())
+                min_tokens_per_req = int(torch.min(tokens_per_req_across_dp).item())
+                if min_tokens_per_req != max_tokens_per_req:
+                    # DP qlen-ASYMMETRIC step: the ranks disagree on query length
+                    # -- a peer runs multi-token (spec) decode (query_len =
+                    # num_speculative_tokens + 1) while this rank is qlen=1. This
+                    # is the fall-back case: warm-up compiles the spec-asymmetric
+                    # padding ONLY for the top bucket (top_bucket, *, top_bucket *
+                    # spec_qlen) to keep the decode-graph count minimal, so route
+                    # up to it here (same policy as the any_prefill branch above).
+                    #
+                    # A qlen-SYMMETRIC step -- all ranks the same query length,
+                    # whether 1 or the spec length -- instead falls through to the
+                    # per-bucket branch below and runs on its own optimally-sized
+                    # decode graph (compiled per bucket by the warm-up loop). Only
+                    # gating on max_tokens_per_req > 1 here would wrongly route
+                    # symmetric spec to the top bucket, running it oversized and
+                    # orphaning the per-bucket spec graphs.
+                    num_reqs_padded = self.bucketing_manager.decode_batch_buckets[-1]
+                else:
+                    num_reqs_padded = self.bucketing_manager.find_decode_batch_bucket(
+                        int(torch.max(num_reqs_across_dp).item())
+                    )
+                assert num_reqs_padded is not None
                 num_tokens_padded = num_reqs_padded * max_tokens_per_req
 
         return num_reqs_padded, num_tokens_padded, num_tokens_across_dp

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -198,7 +198,23 @@ class RBLNWorker(WorkerBase):
             self.model_runner.bucketing_manager.decode_batch_buckets_count
         )
 
-        num_runtimes = 1 + decode_batch_buckets_count + specialized_moe_decode
+        # NOTE(RBLN): warm-up compiles one decode graph -- hence one runtime,
+        # each reserving a fixed command-stream buffer in
+        # estimate_available_memory -- per (decode bucket, query length). Without
+        # spec there is a single decode query length (1); spec decode compiles a
+        # second (num_spec + 1) for every bucket, and the specialized-MoE-decode
+        # fallback repeats those query lengths (plus one extra DP-asymmetric spec
+        # dummy). Count all of them so the KV-block estimate does not over-reserve
+        # DRAM and OOM at runtime. num_decode_query_lens mirrors warmup_model's
+        # query_lens exactly. Non-spec (== 1) is unchanged from the old
+        # 1 + buckets + specialized formula.
+        spec_enabled = getattr(self, "speculative_config", None) is not None
+        num_decode_query_lens = 2 if spec_enabled else 1
+        num_runtimes = 1 + decode_batch_buckets_count * num_decode_query_lens
+        if specialized_moe_decode:
+            num_runtimes += num_decode_query_lens
+            if spec_enabled:
+                num_runtimes += 1
 
         ratio: float = 1.0
         if self.model_config.quantization is not None:

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """A RBLN worker class."""
 
-import copy
 import os
 import time
 from types import NoneType
@@ -52,7 +51,6 @@ from vllm.tracing import instrument
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
-    EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
     DraftTokenIds,
     ModelRunnerOutput,
@@ -376,8 +374,18 @@ class RBLNWorker(WorkerBase):
         if (metadata := connector.get_handshake_metadata()) is None:
             return None
 
-        tp_rank = get_tp_group().rank_in_group
-        return {tp_rank: metadata}
+        # Key by the flat global rank (pp_rank * tp_size + tp_rank), NOT tp_rank
+        # alone: under pipeline parallelism every PP stage has tp_rank 0, so a
+        # tp_rank key would collide across stages and the scheduler-side
+        # handshake listener would serve only one shard's metadata (the others
+        # KeyError). This mirrors the consumer's global_rank keying in
+        # RblnNixlConnectorWorker._nixl_handshake. Reduces to tp_rank for
+        # pp_size == 1 (pp_rank 0).
+        tp_group = get_tp_group()
+        global_rank = (
+            get_pp_group().rank_in_group * tp_group.world_size + tp_group.rank_in_group
+        )
+        return {global_rank: metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()
@@ -501,21 +509,12 @@ class RBLNWorker(WorkerBase):
         # NOTE(RBLN): DO NOT all_gather_group for RBLN pp
         get_pp_group().send_tensor_dict(output.tensors)
 
-        # For PP with a KV connector, surface the connector output the
-        # model runner attached to the intermediate tensors so finished
-        # send/recv notifications still propagate from non-last ranks.
-        kv_connector_output = output.kv_connector_output
-        if not kv_connector_output:
-            return None
-        if (
-            not kv_connector_output.finished_sending
-            and not kv_connector_output.finished_recving
-        ):
-            return EMPTY_MODEL_RUNNER_OUTPUT
-
-        empty_output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
-        empty_output.kv_connector_output = kv_connector_output
-        return empty_output
+        # Non-last PP rank: the model runner already surfaces this rank's
+        # KV-connector output through the two-phase sample_tokens() path
+        # (mirroring the upstream model runner). The engine consumes this
+        # execute_model result only for error propagation, so return None
+        # rather than emitting the same finished send/recv notifications here.
+        return None
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -588,9 +588,13 @@ class RBLNWorker(WorkerBase):
             self.profiler.stop()
 
     def execute_dummy_batch(self) -> None:
-        bucket_size = self.model_runner.bucketing_manager.find_decode_batch_bucket(1)
-        query_len = 1 + self.model_runner.num_spec_tokens
-        self.model_runner._dummy_run(bucket_size, query_len, is_prefill=False)
+        # Serving-time DP-idle step: this rank has no real work. Run a non-warmup
+        # dummy (warmup=False) so it contributes a minimal (num_reqs=1, qlen=1)
+        # entry to the cross-DP collective, is EXCLUDED from the shape decision,
+        # then adopts the busy-decided shape and runs the same compiled decode
+        # graph the busy ranks run -- so an idle rank never drags the collective
+        # into a fall-back route nor lands on an uncompiled shape.
+        self.model_runner._dummy_run(1, 1, is_prefill=False, warmup=False)
 
     # def add_lora(self, lora_request: LoRARequest) -> bool:
     #     return self.model_runner.add_lora(lora_request)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

#### Summary

Pipeline parallelism (`pipeline_parallel_size > 1`) on the RBLN path worked for plain decode but broke down the moment decode batching, speculative decoding, disaggregated serving, or NIXL KV-cache transfer entered the picture: a step's decode batch could overflow the compiled per-stage bucket, spec-decode misclassified the prefill/decode phase inconsistently across ranks, the KV connector saved only part of the model's layers, and a NIXL reader would connect to producer stages it does not read from and index per-stage descriptors out of range. This PR reorganizes the scheduler/runner so PP is a first-class, correct, and efficient mode, and extends prefill→decode KV transfer over NIXL to work when either side runs with pipeline parallelism.

The work is one story told in three movements: (1) give the scheduler a single PP-aware decode-admission budget, make speculative decoding rank-consistent on top of it, consolidate prefill/decode phase authority onto the scheduler, and turn batch balancing on by default for PP; (2) make the NIXL handshake advertise per-stage layer bands so a reader pulls from — and builds descriptors for — only the producer stages it owns; (3) correct speculative-decode memory sizing and data-parallel batch padding for the extra query positions a spec step carries.

#### What changed

##### A. PP-aware scheduler & runner

**1. PP-aware decode-batch admission (scheduler).** Under PP the engine keeps one decode microbatch in flight per stage, so a single step's decode batch must fit the compiled per-stage bucket (`max_num_seqs // pp_size`). Admission from both the running queue and (in disaggregated serving) KV-transfer-completed requests is centralized into **one per-step budget** (`DecodeAdmissionController` / `DecodeBatchBudget` in `v1/core/utils.py`):
- Hard cap = the compiled bucket size on every decode that joins the batch.
- Optional **demand spreading** across stages (`ceil(demand / pp_size)`) so no stage idles after a pipeline drain.
- Requests that become decode-ready outside the demand snapshot (full local prefix-cache hit, resume-after-eviction) are gated by the hard cap only.
- The admitted count stays consistent when the batch shrinks (cleared on whole-batch eviction, decremented on preemption of an admitted decode).
- `pp_size == 1` degenerates to `max_num_seqs` — unchanged.

**2. Speculative decoding under PP (scheduler + runner).** Enables spec decode (ngram, EAGLE, MTP, …) together with `pp_size > 1`. With `pp_size` microbatches in flight under synchronous scheduling, a verify step — whose query spans `num_spec_tokens + 1` positions and whose accepted tokens are produced only on the last PP rank — stays bit-consistent on every non-last rank one step later via:
- **Uniform per-query-length bookkeeping** — the prefill/decode phase is stamped once on `RBLNSchedulerOutput` and read by every rank (never re-derived per-rank), PP inter-stage tensors are sized per `(bucket, query_len)`, and non-last ranks write propagated tokens from `num_tokens_no_spec`.
- **Anchor-reconciled scheduling** — `should_defer_spec_step` admits a verify only when its base token is reconciled, deciding on the base count. Gated on spec being enabled → non-spec decode untouched.
- **Multi-accept token propagation** — the scheduler extends a lagging rank's `new_token_ids` payload back by `num_spec_tokens`; the runner writes by absolute position (idempotent over mis-speculated slots).

**3. Scheduler as the single phase authority (runner cleanup).** With `RBLNSchedulerOutput` now the unified type every step carries, the legacy per-rank `is_prefills()` classifier (which diverged across PP ranks under spec decode) is removed along with its test and a dangling comment. Defensive `isinstance`/`getattr` fallbacks that hedged for a plain `SchedulerOutput` are dropped: RBLN-only helpers are narrowed to `RBLNSchedulerOutput`, and base-override methods sit behind a single boundary assert.

**4. PP decode-batch balancing on by default.** `VLLM_RBLN_PP_BALANCE_DECODE_BATCH` now defaults to **on**. The dynamic cap only ever caps *lower* than the static one (never overflows the bucket), is floored at 1, matches the static cap at saturation, and is a **no-op for `pp_size == 1`**. Set `=0` to force the static cap.

##### B. NIXL KV-cache transfer under PP

**5. Per-stage layer-band handshake.** Each pipeline stage advertises its own band of layers in the handshake metadata; a reader connects to and pulls from only the producer stages whose layers fall within the band it owns. This covers both the **symmetric layout** (prefill and decode share a pipeline size, stage matched to stage) and the **fan-in layout** (a reader without pipeline parallelism aggregates several producer stages).

**6. Overlap-aware remote descriptor build.** Per-stage remote descriptors are built assuming a producer exposes no more regions than the reader owns — which holds only for the stages the reader actually reads from. Stages outside the reader's band (which can expose more regions when the layer count does not divide evenly across stages) are **skipped before that build**, so it never indexes out of range.

**7. Non-last-rank KV output via the two-phase path.** The KV-connector output for a non-last PP rank is surfaced through the runner's two-phase `sample_tokens()` path; `RBLNWorker.execute_model` returns `None` on non-last ranks instead of re-emitting the same finished send/recv notifications from an empty output, so every rank saves its own layers' KV exactly once.

**8. Unsupported combinations rejected at handshake.** TP together with PP, sliding-window attention together with PP, and unequal prefill/decode block sizes are rejected during the handshake. Transfers without pipeline parallelism keep the existing single-stage path unchanged.

##### C. Speculative-decode corrections

**9. Memory sizing & DP batch padding.** Both stem from a spec step carrying `num_speculative_tokens + 1` query positions:
- Available-memory estimation counts the extra decode graph warm-up compiles per `(batch bucket, query length)` for spec decode, so the command-stream-buffer reservation matches warm-up and the KV-cache-block estimate does not over-reserve device memory.
- When DP ranks disagree on whether the current step is a speculative (multi-token) decode step, the batch is padded up to the largest decode bucket (mirroring the existing prefill-step policy), keeping every rank on an already-compiled graph. No-op for single-bucket configs.

#### Testing

- **Unit** — PP decode-admission budget and demand-spread contrast (`test_scheduler.py`), anchor-reconciled deferral predicate and multi-accept payload (`test_rbln_model_runner.py`), backfill/slide query-window math (`test_query_backfill.py`), PP disaggregation (`test_pd_disaggregation.py`), the NIXL per-stage layer-band handshake and overlap-skip (`test_rbln_nixl_handshake_pp.py`), handshake metadata PP fields (`test_rbln_nixl_metadata.py`), worker-side handshake (`test_rbln_worker_handshake.py`), and the non-last-rank `execute_model` return contract (`test_rbln_worker.py::TestExecuteModel`).
- `pre-commit run --hook-stage manual` clean (ruff, mypy 3.10–3.13, typos, license); full runner/scheduler/pd/connector unit suites green.

#### Risk / compatibility

- `pp_size == 1` and non-spec decode paths are untouched (predicate gated on spec; cap degenerates to `max_num_seqs`; balancing is a no-op).
- NIXL transfers with `pipeline_parallel_size == 1` on both sides take the unchanged single-stage path.
- The spec-decode changes are no-ops for single-bucket / non-spec configurations.
- The `VLLM_RBLN_PP_BALANCE_DECODE_BATCH` default flip is confined to PP; the escape hatch preserves the old behavior.

#### Affected modules

Platform, Scheduler, Runner, NIXL KV connector, Worker.


---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #
https://github.com/RBLN-SW/vllm-rbln/pull/777
---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [x] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
