### PR TITLE
fix: add missing fields in optimum scheduler

### DIFF
--- a/vllm_rbln/v1/core/optimum_scheduler.py
+++ b/vllm_rbln/v1/core/optimum_scheduler.py
@@ -272,12 +272,7 @@ class RBLNOptimumScheduler(Scheduler):
             else EncoderCacheManager(cache_size=encoder_cache_size)
         )
 
-        # Speculative decoding is not supported on the optimum path, but
-        # inherited methods read these attributes: `_free_encoder_inputs`
-        # defers the encoder-cache free by `use_eagle` (hit by every
-        # encoder-decoder step, e.g. Whisper), `make_spec_decoding_stats`
-        # reads `num_spec_tokens`, and `_mamba_block_aligned_split` /
-        # `allocate_slots` callers read `num_lookahead_tokens`.
+        # Speculative decoding is not supported on the optimum path
         self.use_eagle = False
         self.num_spec_tokens = 0
         self.num_lookahead_tokens = 0

--- a/vllm_rbln/v1/core/optimum_scheduler.py
+++ b/vllm_rbln/v1/core/optimum_scheduler.py
@@ -272,6 +272,17 @@ class RBLNOptimumScheduler(Scheduler):
             else EncoderCacheManager(cache_size=encoder_cache_size)
         )
 
+        # Speculative decoding is not supported on the optimum path, but
+        # inherited methods read these attributes: `_free_encoder_inputs`
+        # defers the encoder-cache free by `use_eagle` (hit by every
+        # encoder-decoder step, e.g. Whisper), `make_spec_decoding_stats`
+        # reads `num_spec_tokens`, and `_mamba_block_aligned_split` /
+        # `allocate_slots` callers read `num_lookahead_tokens`.
+        self.use_eagle = False
+        self.num_spec_tokens = 0
+        self.num_lookahead_tokens = 0
+        self.dynamic_sd_lookup: list[int] | None = None
+
         self.use_pp = False
         self.use_v2_model_runner = False
         self._pause_state: PauseState = PauseState.UNPAUSED


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

These parameters aren't actually used in the Optimum path, but they are referenced by the inherited class, so I initialized them with default values.
For example, when running Whisper, the optimum scheduler throws an error in `_free_encoder_inputs` without them.
```
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233] Traceback (most recent call last):
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]   File "/usr/local/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1224, in run_engine_core
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]     engine_core.run_busy_loop()
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]   File "/usr/local/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1265, in run_busy_loop
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]     self._process_engine_step()
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]   File "/usr/local/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1304, in _process_engine_step
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]     outputs, model_executed = self.step_fn()
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]                               ^^^^^^^^^^^^^^
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]   File "/usr/local/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 504, in step
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]     engine_core_outputs = self.scheduler.update_from_output(
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]   File "/usr/local/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 1579, in update_from_output
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]     self._free_encoder_inputs(request)
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]   File "/usr/local/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 1878, in _free_encoder_inputs
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]     spec_lookahead = 1 if self.use_eagle else 0
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233]                           ^^^^^^^^^^^^^^
(EngineCore pid=1497) ERROR 07-27 06:40:00 [v1/engine/core.py:1233] AttributeError: 'RBLNOptimumScheduler' object has no attribute 'use_eagle'

```

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
