### PR TITLE
other(metrics): drain warmup runtime report backlog before measuring

### DIFF
--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -170,15 +170,18 @@ class _NoopSpan:
 
 
 class _PerformanceContext:
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(self, name: str | None = None, runtimes: list | None = None) -> None:
         self.name = name
         self.rank_tag = _rank_tag()
         self._metrics: dict[bool, Metrics] = defaultdict(Metrics)
         self._pending: _Sample | None = None
         self._e2e_start: float | None = None
         self._e2e: dict[bool, Metrics] = defaultdict(Metrics)
+        self._runtimes = runtimes if runtimes is not None else []
+        self._backlog_drained = False
 
     def profile_model(self, is_prefill: bool) -> _TimingSpan:
+        self._drain_report_backlog()
         # A prior model step with no sampler (intermediate chunked prefill,
         # non-last PP rank) leaves a pending report; record it model-only here.
         self._flush_pending()
@@ -213,6 +216,16 @@ class _PerformanceContext:
             s.latency, s.host, s.device, s.ccl, s.prepare
         )
 
+    def _drain_report_backlog(self) -> None:
+        """Discard warmup reports left in the runtime FIFO before measuring."""
+        if self._backlog_drained:
+            return
+
+        self._backlog_drained = True
+        for runtime in self._runtimes:
+            if (flush := getattr(runtime, "flush_reports", None)) is not None:
+                flush()
+
     def print_stats(self) -> None:
         self._flush_pending()  # record the final step if it had no sampler
         sections: dict[str, Metrics] = {}
@@ -226,7 +239,7 @@ class _PerformanceContext:
 
 
 class _NoopPerformanceContext:
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
     def profile_model(self, *args, **kwargs) -> _NoopSpan:

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -422,7 +422,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             and envs.VLLM_RBLN_SPECIALIZE_MOE_DECODE
         )
 
-        self.performance_ctx = PerformanceContext("runner")
+        self.performance_ctx = PerformanceContext("runner", self.runtime_holder)
 
         self.offload_context = nullcontext
         if HAS_TORCH_RBLN and USE_DEVICE_TENSOR and not envs.VLLM_RBLN_DISABLE_OFFLOAD:


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Prefill `Mean prepare time` in the performance stats was reported far larger than the actual device time. This is a measurement artifact, not a real per-step cost.

With the performance measurement, each graph execution pushes reports into a single runtime FIFO, and `capture_reports()` only drains it. Warmup runs the graphs without an active capture window, so its reports are never consumed and stay at the head of the FIFO. Every measured step then reads a report shifted by the warmup submission count, misattributing the warmup prefill's one-time setup cost to the first real prefill.

This PR drains the leftover warmup reports once, lazily, on the first `profile_model()` call by calling `flush_reports()` on each runtime handle.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [x] ❓ Other (`other`): performance metrics

---

### 🧪 How to Test

Run the offline benchmark with metrics and the runtime timer enabled.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
