### PR TITLE
feature(pp): pipeline parallelism for the refactored RBLN scheduler/runner

### DIFF
--- a/tests/torch_compile/unit/v1/core/test_decode_batch_size.py
+++ b/tests/torch_compile/unit/v1/core/test_decode_batch_size.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``decode_batch_size`` -- the single source of truth for the
+per-PP-stage (compiled) decode batch, shared by the runner's bucketing and the
+scheduler's decode admission cap.
+"""
+
+import pytest
+
+from vllm_rbln.v1.core.utils import decode_batch_size
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "pp_size", "expected"),
+    [
+        (16, 1, 16),  # non-PP: unchanged
+        (16, 2, 8),
+        (16, 4, 4),
+        (2, 2, 1),  # small batch splits down to 1 per stage
+        (4, 2, 2),
+    ],
+)
+def test_decode_batch_size_divides_by_pp(max_num_seqs, pp_size, expected):
+    assert decode_batch_size(max_num_seqs, pp_size) == expected
+
+
+def test_decode_batch_size_pp1_is_identity():
+    """pp_size == 1 (non-PP) returns max_num_seqs unchanged."""
+    for n in (1, 2, 8, 37, 256):
+        assert decode_batch_size(n, 1) == n

--- a/tests/torch_compile/unit/v1/core/test_scheduler.py
+++ b/tests/torch_compile/unit/v1/core/test_scheduler.py
@@ -15,6 +15,7 @@
 from vllm.v1.request import RequestStatus
 
 from .utils import (
+    advance_to_decode,
     create_requests,
     create_runner_output,
     create_scheduler,
@@ -394,3 +395,185 @@ def _check_invariant(sched_out, req_id):
     assert n == 1 + len(spec), (
         f"req {req_id}: num_scheduled_tokens={n} but 1+spec={1 + len(spec)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Decode-cap machinery: DecodeBatchBudget / DynamicDecodeCapPolicy /
+# StaticDecodeCapPolicy / DecodeAdmissionController. Ported from
+# feat/nixl-pp-kv-transfer -- the refactor carried the classes over but dropped
+# their direct coverage (discard()/soft-vs-hard-cap are hard to verify by
+# reading alone, and PP decode-cap bugs kept surfacing on device, not in CI).
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_decode_cap_policy():
+    """DynamicDecodeCapPolicy spreads active decodes across PP stages:
+    cap = max(1, min(static_max, ceil(active / pp_size)))."""
+    import math
+
+    from vllm_rbln.v1.core.utils import DynamicDecodeCapPolicy
+
+    # static_max = 8 (e.g. max_num_seqs=16, pp=2)
+    # Few active -> spread below the static ceiling (avoids collapse).
+    assert DynamicDecodeCapPolicy(8, 2, 6).cap() == math.ceil(6 / 2) == 3
+    assert DynamicDecodeCapPolicy(8, 2, 1).cap() == 1
+    # No active -> floored at 1 (never 0, which would break the budget).
+    assert DynamicDecodeCapPolicy(8, 2, 0).cap() == 1
+    # ceil(15/2)=8 reaches the ceiling.
+    assert DynamicDecodeCapPolicy(8, 2, 15).cap() == 8
+    # Clamp: never exceed static_max (the compiled bucket ceiling).
+    assert DynamicDecodeCapPolicy(8, 2, 100).cap() == 8
+    # Non-divisible max_num_seqs: ceil(33/2)=17 clamps down to static_max 16.
+    assert DynamicDecodeCapPolicy(16, 2, 33).cap() == 16
+    # pp_size == 1: cap = min(static_max, active) -> no-op vs static.
+    assert DynamicDecodeCapPolicy(16, 1, 5).cap() == 5
+    assert DynamicDecodeCapPolicy(16, 1, 20).cap() == 16
+
+
+def test_decode_budget_hard_vs_soft_cap():
+    """DecodeBatchBudget.can_admit: the hard cap (compiled bucket ceiling)
+    always applies; the soft (spreading) cap applies only when apply_soft_cap.
+    Demand-unbudgeted joins (apply_soft_cap=False -- full local prefix match /
+    resumed-after-eviction) fill up to the hard cap, not the soft one."""
+    from vllm_rbln.v1.core.utils import (
+        DecodeBatchBudget,
+        DynamicDecodeCapPolicy,
+        StaticDecodeCapPolicy,
+    )
+
+    # Balance: hard=8, soft=ceil(4/2)=2.
+    b = DecodeBatchBudget(DynamicDecodeCapPolicy(8, 2, 4), hard_cap=8)
+    b.admit(2)  # count == soft
+    assert not b.can_admit()  # budgeted: gated at soft (2)
+    assert b.can_admit(apply_soft_cap=False)  # unbudgeted: hard (8) has room
+    b.admit(6)  # count == hard
+    assert not b.can_admit(apply_soft_cap=False)  # hard cap reached
+    assert not b.can_admit()
+
+    # Static: soft == hard, so apply_soft_cap makes no difference.
+    b2 = DecodeBatchBudget(StaticDecodeCapPolicy(8), hard_cap=8)
+    b2.admit(8)
+    assert not b2.can_admit()
+    assert not b2.can_admit(apply_soft_cap=False)
+
+
+def test_decode_budget_discard():
+    """discard() un-admits decodes dropped from the step (PRIORITY-policy
+    preemption of an already-scheduled decode) so the can_admit() gate is
+    not stopped early on a stale over-count. Unlike reset() it only removes
+    the dropped ones, leaving the still-admitted decodes counted."""
+    from vllm_rbln.v1.core.utils import DecodeBatchBudget, StaticDecodeCapPolicy
+
+    b = DecodeBatchBudget(StaticDecodeCapPolicy(2), hard_cap=2)
+    b.admit(2)  # batch full at the cap
+    assert not b.can_admit()  # gate closed
+    b.discard()  # a scheduled decode is preempted -> one slot freed
+    assert b.count == 1
+    assert b.can_admit()  # gate reopens for another admit
+    # reset() would instead zero the whole count (whole-batch eviction).
+    b.reset()
+    assert b.count == 0
+
+
+def test_priority_preemption_discards_admitted_decode(monkeypatch):
+    """When the PRIORITY policy preempts an ALREADY-SCHEDULED decode to free KV
+    blocks, the scheduler un-admits it from the per-step decode budget via
+    `discard()`, keeping the admitted count in step with the batch so the
+    `can_admit()` gate is not stopped early on a stale over-count.
+
+    Two decodes each need a fresh block this step but only one block is free,
+    so scheduling the trigger preempts the victim (higher priority value =
+    lower scheduling importance). The victim was already scheduled this step,
+    so `discard()` must fire exactly once.
+    """
+    from vllm.v1.core.sched.request_queue import SchedulingPolicy
+
+    from vllm_rbln.v1.core.utils import DecodeBatchBudget
+
+    discard_calls = []
+    orig_discard = DecodeBatchBudget.discard
+
+    def spy(self, n=1):
+        discard_calls.append(n)
+        return orig_discard(self, n)
+
+    monkeypatch.setattr(DecodeBatchBudget, "discard", spy)
+
+    block_size = 16
+    # num_blocks=4 -> 3 usable (block 0 is the null block): one block per
+    # prefill (2) leaves exactly one free for a decode boundary block, so only
+    # one of the two decodes can grow this step.
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_num_seqs=4,
+        block_size=block_size,
+        num_blocks=4,
+        enable_prefix_caching=False,
+    )
+    scheduler.policy = SchedulingPolicy.PRIORITY
+
+    victim, trigger = create_requests(
+        num_requests=2,
+        num_tokens=block_size,
+        block_size=block_size,
+        req_ids=["victim", "trigger"],
+    )
+    # Higher priority VALUE == lower scheduling importance == preempted first.
+    victim.priority = 1
+    trigger.priority = 0
+    for r in (victim, trigger):
+        advance_to_decode(scheduler, r)
+
+    out = scheduler.schedule()
+
+    assert victim.status == RequestStatus.PREEMPTED
+    assert trigger.request_id in out.num_scheduled_tokens
+    assert discard_calls == [1], (
+        "discard() must fire exactly once for the preempted already-scheduled "
+        f"decode, got {discard_calls}"
+    )
+
+
+def test_pp_balance_decode_spreads_microbatch(monkeypatch):
+    """With VLLM_RBLN_PP_BALANCE_DECODE_BATCH=1 under PP, one step's
+    decode batch is sized to ~ceil(active / pp_size), spreading the active
+    decodes across the PP microbatches instead of packing them into one
+    (which would idle the other stage). The static default packs more.
+    """
+    import math
+
+    from vllm_rbln.v1.core.rbln_scheduler import is_prefill
+
+    n = 6
+
+    def run(balance: bool):
+        if balance:
+            monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "1")
+        else:
+            # Force the static cap explicitly: the default is now on under PP,
+            # so unsetting would still give the balanced (dynamic) behavior.
+            monkeypatch.setenv("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "0")
+        # max_num_seqs=16, pp=2 -> static cap 8; n=6 active -> ceil(6/2)=3.
+        scheduler = create_scheduler(
+            max_num_seqs=16, pipeline_parallel_size=2, block_size=16
+        )
+        reqs = create_requests(
+            num_requests=n,
+            num_tokens=32,
+            block_size=16,
+            req_ids=[f"d{i}" for i in range(n)],
+        )
+        for r in reqs:
+            advance_to_decode(scheduler, r)
+        running_decodes = sum(1 for r in scheduler.running if not is_prefill(r))
+        out = scheduler.schedule()
+        return running_decodes, len(out.num_scheduled_tokens)
+
+    run_on, sched_on = run(True)
+    run_off, sched_off = run(False)
+
+    # Balanced: at most ceil(active / pp) admitted this step.
+    assert sched_on <= math.ceil(run_on / 2)
+    assert sched_on >= 1
+    # Static packs more decodes into the single microbatch than balanced does.
+    assert sched_off > sched_on

--- a/tests/torch_compile/unit/v1/core/test_spec_pp_helpers.py
+++ b/tests/torch_compile/unit/v1/core/test_spec_pp_helpers.py
@@ -1,0 +1,106 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the speculative-decode + pipeline-parallelism scheduler/runner
+helpers in ``vllm_rbln.v1.core.utils``:
+
+  * ``should_defer_spec_step`` -- the running-loop anchor-reconciled deferral
+    predicate (a verify is scheduled only once its base/anchor token is
+    reconciled under sync-scheduling PP).
+  * ``num_base_tokens`` / ``resolve_propagated_token_write`` -- the non-last-PP-
+    rank multi-accept token propagation bookkeeping (bring the recorded-token
+    cursor up to committed_tip by writing the scheduler-propagated payload at
+    absolute position).
+
+These are pure functions, so they are exercised directly (no scheduler or
+runner instance).
+"""
+
+import pytest
+
+from vllm_rbln.v1.core.utils import (
+    num_base_tokens,
+    resolve_propagated_token_write,
+    should_defer_spec_step,
+)
+
+
+class TestSpecDecodePropagationHelpers:
+    """Pure helpers extracted from the scheduler + runner non-last-rank token
+    propagation: num_base_tokens and resolve_propagated_token_write."""
+
+    def test_num_base_tokens(self):
+        num_sched = {"A": 4, "B": 1}
+        drafts = {"A": [1, 2, 3]}  # B carries no drafts this step
+        assert num_base_tokens(num_sched, drafts, "A") == 1  # 4 - 3 drafts
+        assert num_base_tokens(num_sched, drafts, "B") == 1  # 1 - 0
+        assert num_base_tokens(num_sched, drafts, "missing") == 0
+
+    def test_write_normal_decode_writes_newest_token(self):
+        # base=1, cursor caught up (== num_computed). Payload is extended
+        # backward by num_spec (positions 97..100); write only the newest.
+        payload = [10, 11, 12, 13]
+        assert resolve_propagated_token_write(
+            cursor=100, num_computed_tokens=100, base=1, new_token_ids=payload
+        ) == (101, [13])
+
+    def test_write_multi_accept_lag_fills_gap(self):
+        # After a verify accepted 3 drafts the cursor lags num_computed by 3;
+        # the extended payload lets PP0 fill positions 97..100 by absolute pos.
+        payload = [10, 11, 12, 13]
+        assert resolve_propagated_token_write(
+            cursor=97, num_computed_tokens=100, base=1, new_token_ids=payload
+        ) == (101, [10, 11, 12, 13])
+
+    def test_write_nothing_when_cursor_at_tip(self):
+        assert (
+            resolve_propagated_token_write(
+                cursor=101, num_computed_tokens=100, base=1, new_token_ids=[10, 11]
+            )
+            is None
+        )
+
+    def test_write_out_of_window_asserts_broken_invariant(self):
+        # A payload too short to cover [cursor, committed_tip) means the
+        # token-propagation invariant is broken (the non-last rank's cursor lags
+        # num_computed by more than num_spec_tokens). Fail loudly with a clear
+        # signal rather than returning a short slice that would then mismatch the
+        # width of token_ids_cpu[cursor:committed_tip] at the write site.
+        # committed_tip=101, span=4, payload len=1 -> lo=-3 -> assert.
+        with pytest.raises(AssertionError, match="invariant is broken"):
+            resolve_propagated_token_write(
+                cursor=97, num_computed_tokens=100, base=1, new_token_ids=[13]
+            )
+
+
+class TestShouldDeferSpecStep:
+    """Pure predicate for the spec+PP running-loop deferral."""
+
+    def test_disabled_when_spec_off(self):
+        # num_spec_tokens == 0: never defers, even for a negative num_new.
+        assert should_defer_spec_step(0, [], -3) is False
+        assert should_defer_spec_step(0, [], 0) is False
+
+    def test_drafts_held_defers_on_base_le_zero(self):
+        # base = num_new - len(drafts). drafts=[1,2,3].
+        assert should_defer_spec_step(3, [1, 2, 3], 3) is True  # base 0
+        assert should_defer_spec_step(3, [1, 2, 3], 0) is True  # base -3
+        assert should_defer_spec_step(3, [1, 2, 3], 4) is False  # base 1
+
+    def test_no_drafts_defers_only_on_negative(self):
+        # base == num_new. Only the post-verify overshoot (negative) defers;
+        # the mundane == 0 and any positive are left to the caller.
+        assert should_defer_spec_step(3, [], -3) is True
+        assert should_defer_spec_step(3, [], 0) is False
+        assert should_defer_spec_step(3, [], 1) is False

--- a/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
+++ b/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
@@ -123,6 +123,10 @@ def make_fake_runner(
         kv_cache_view_infos=[],
         compile_context=object(),
         is_prefill=is_prefill,
+        # eagle.propose reads the scheduler-stamped phase via the method
+        # is_prefill_phase() (feat(pp) replaced the per-rank is_prefill property),
+        # so the fake must expose it as a callable, not just the bool attribute.
+        is_prefill_phase=lambda: is_prefill,
         is_intermediate_chunked_prefill=is_intermediate_chunked_prefill,
         # _build_dummy_attn_metadata only consumes the cumsum (arange ignored).
         _get_cumsum_and_arange=lambda num_tokens, cumsum_dtype=None: (

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -88,6 +88,7 @@ def get_vllm_config(
     max_num_batched_tokens: int = 128,
     max_model_len: int = 4096,
     block_size: int = BLOCK_SIZE,
+    pipeline_parallel_size: int = 1,
 ) -> VllmConfig:
     model_config = ModelConfig(
         model="meta-llama/Llama-3.2-1B-Instruct",
@@ -106,7 +107,9 @@ def get_vllm_config(
         cache_dtype="auto",
         enable_prefix_caching=True,
     )
-    parallel_config = ParallelConfig()
+    parallel_config = ParallelConfig(
+        pipeline_parallel_size=pipeline_parallel_size,
+    )
 
     return VllmConfig(
         model_config=model_config,
@@ -149,6 +152,59 @@ def rbln_model_runner():
         runner = RBLNModelRunner(vllm_config, DEVICE_TYPE)
         initialize_kv_cache(runner)
         yield runner
+
+
+def _build_runner_for_bucketing(*, max_num_seqs, pipeline_parallel_size):
+    """Construct a runner far enough to expose ``bucketing_manager``.
+
+    With no ``speculative_config`` the runner's ``__init__`` touches no
+    distributed group (the only such access is guarded by
+    ``speculative_config``), so a ``pp > 1`` runner can be built in-process
+    without a real multi-rank setup. ``initialize_kv_cache`` is intentionally
+    skipped -- the decode bucketing is fixed in ``__init__``.
+    """
+    vllm_config = get_vllm_config(
+        max_num_seqs=max_num_seqs,
+        pipeline_parallel_size=pipeline_parallel_size,
+    )
+    with set_current_vllm_config(vllm_config):
+        model_config = vllm_config.model_config
+        num_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
+        head_size = model_config.get_head_size()
+        vllm_config.compilation_config.static_forward_context["layer.0"] = Attention(
+            num_heads,
+            head_size,
+            scale=0.1,
+            prefix="layer.0",
+        )
+        return RBLNModelRunner(vllm_config, DEVICE_TYPE)
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "pp_size"),
+    [
+        (4, 1),  # non-PP: compiled decode batch == max_num_seqs
+        (4, 2),  # PP=2: compiled decode batch == max_num_seqs // pp_size == 2
+        (2, 2),  # regression: max_num_seqs=2, pp=2 -> per-stage 1 (was 2)
+    ],
+)
+def test_decode_bucketing_uses_per_pp_stage_batch(max_num_seqs, pp_size):
+    """The compiled decode bucket must be the per-PP-stage batch
+    (``max_num_seqs // pp_size``) -- the single source of truth shared with the
+    scheduler's decode admission cap -- not the raw ``max_num_seqs``.
+
+    Regression: the refactor wired the runner's bucketing to the raw
+    ``max_num_seqs``, so PP compiled an oversized decode graph (e.g. [2] instead
+    of [1] at ``max_num_seqs=2, pp=2``) while the scheduler still capped decode
+    admission at 1.
+    """
+    runner = _build_runner_for_bucketing(
+        max_num_seqs=max_num_seqs, pipeline_parallel_size=pp_size
+    )
+    # Largest compiled bucket is the per-PP-stage decode batch.
+    assert max(runner.bucketing_manager.decode_batch_buckets) == (
+        max_num_seqs // pp_size
+    )
 
 
 @pytest.fixture
@@ -247,6 +303,9 @@ def _schedule_new_request(
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+        # New requests are always prefilled: stamp the step phase the runner's
+        # is_prefill_phase() reads (execute_model consumes this directly).
+        is_prefill_step=True,
     )
 
 
@@ -1331,10 +1390,11 @@ def test_prepare_inputs_num_spec_tokens_without_scheduled_drafts_uses_logical_le
     # tokens. This can happen for zero-draft ngram/suffix steps or boundary cases.
     monkeypatch.setattr(rbln_model_runner, "num_spec_tokens", 2)
 
-    # Force decode state. is_prefill must be False.
+    # Force decode state.
     ib.num_computed_tokens_cpu[0] = 3
     ib.num_tokens_no_spec[0] = 3
-    assert rbln_model_runner.is_prefill is False
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     scheduler_output = RBLNSchedulerOutput(
         scheduled_new_reqs=[],
@@ -1442,31 +1502,22 @@ def test_prepare_kv_sharing_fast_prefill_pads_with_last_index(rbln_model_runner)
     assert result.tolist() == [0, 2, 5]
 
 
-def test_is_prefill_boundary_properties(rbln_model_runner):
-    """is_prefill: num_computed < num_tokens_no_spec - 1 (boundary at ==);
-    is_intermediate_chunked_prefill = is_prefill AND discard_mask[0];
+def test_is_intermediate_chunked_prefill_and_logits_flags(rbln_model_runner):
+    """is_intermediate_chunked_prefill = is_prefill_phase() AND discard_mask[0];
     use_wrapped_compute_logits = not pooling."""
-    ib = rbln_model_runner.input_batch
 
-    def set_state(computed, nts, discard):
-        ib.num_computed_tokens_cpu[0] = computed
-        ib.num_tokens_no_spec[0] = nts
+    def set_state(is_prefill, discard):
+        # is_intermediate_chunked_prefill reads the scheduler-stamped phase
+        # (is_prefill_phase() == _is_prefill_step).
+        rbln_model_runner._is_prefill_step = is_prefill
         rbln_model_runner.discard_request_mask[0] = discard
 
-    # is_prefill: strictly less than nts - 1.
-    set_state(1, 5, False)
-    assert rbln_model_runner.is_prefill is True  # 1 < 4
-    set_state(4, 5, False)
-    assert rbln_model_runner.is_prefill is False  # 4 < 4 -> boundary == decode
-    set_state(5, 5, False)
-    assert rbln_model_runner.is_prefill is False  # past boundary
-
-    # is_intermediate_chunked_prefill = is_prefill AND discard_mask[0].
-    set_state(1, 5, True)  # prefill + discarded chunk
+    # is_intermediate_chunked_prefill = is_prefill_phase() AND discard_mask[0].
+    set_state(True, True)  # prefill + discarded chunk
     assert rbln_model_runner.is_intermediate_chunked_prefill is True
-    set_state(1, 5, False)  # prefill, last chunk kept
+    set_state(True, False)  # prefill, last chunk kept
     assert rbln_model_runner.is_intermediate_chunked_prefill is False
-    set_state(4, 5, True)  # NOT prefill -> False regardless
+    set_state(False, True)  # NOT prefill -> False regardless
     assert rbln_model_runner.is_intermediate_chunked_prefill is False
 
     # Generation model (fixture) is not a pooling model.
@@ -1488,6 +1539,8 @@ def test_sample_skips_sampler_for_intermediate_chunked_prefill(
     # Make is_prefill True:
     ib.num_computed_tokens_cpu[0] = 1
     ib.num_tokens_no_spec[0] = 5
+    # is_intermediate_chunked_prefill reads the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = True
 
     # Make is_intermediate_chunked_prefill True:
     rbln_model_runner.discard_request_mask[0] = True
@@ -2330,7 +2383,7 @@ def test_execute_model_prefill_passes_token_indices_and_stores_execute_state(
     assert output is None
 
     # Prefill runs the real input preparation path.
-    assert rbln_model_runner.is_prefill is True
+    assert rbln_model_runner.is_prefill_phase() is True
     assert attn_metadata_calls["num_tokens"] == 3
     assert attn_metadata_calls["num_reqs"] == 1
     assert attn_metadata_calls["max_query_len"] == 3
@@ -2362,8 +2415,8 @@ def test_execute_model_prefill_passes_token_indices_and_stores_execute_state(
 def test_execute_model_decode_slices_logits_by_logits_indices(
     rbln_model_runner, dist_init, monkeypatch
 ):
-    """Decode execution should store only logits selected by runner-owned
-    logits_indices before sampling."""
+    """Plain decode execution stores the full bucket-padded logits (no
+    pre-slicing); logits_indices pre-slicing applies only to spec decode."""
     req_ids = ("req_0", "req_1")
     rbln_model_runner._update_states(
         _schedule_new_request(
@@ -2387,7 +2440,7 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
     ib.num_tokens_no_spec[:2] = [4, 4]
     rbln_model_runner.requests["req_0"].output_token_ids = [101]
     rbln_model_runner.requests["req_1"].output_token_ids = [202]
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     scheduler_output = RBLNSchedulerOutput(
         scheduled_new_reqs=[],
@@ -2407,6 +2460,7 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+        is_prefill_step=False,
     )
 
     attn_metadata_calls: dict[str, Any] = {}
@@ -2446,7 +2500,7 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
     output = rbln_model_runner.execute_model(scheduler_output)
 
     assert output is None
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     # Decode path uses one query token per request and does not pass token_indices
     # to wrapped compute_logits.
@@ -2471,12 +2525,12 @@ def test_execute_model_decode_slices_logits_by_logits_indices(
     assert state.sample_hidden_states is hidden_states
     assert state.aux_hidden_states is None
 
-    # Critical contract: padded logits are sliced by logits_indices before
-    # sample_tokens() sees them.
-    output_logits = state.logits[attn_metadata_calls["logits_indices"]]
-    expected_logits = logits[attn_metadata_calls["logits_indices"]]
-    assert torch.equal(output_logits, expected_logits)
-    assert output_logits.shape == (2, vocab_size)
+    # Since the bucket-pad-sampler change (c040dcee), plain decode keeps the
+    # full bucket-padded logits; execute_model pre-slices by logits_indices only
+    # for spec decode (spec_decode_metadata is not None). The bucket-padded
+    # sampler consumes the padded rows downstream.
+    assert state.logits is logits
+    assert state.logits.shape == (padded_reqs, vocab_size)
 
 
 def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_metadata(
@@ -2505,7 +2559,7 @@ def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_met
     ib.num_computed_tokens_cpu[0] = 3
     ib.num_tokens_no_spec[0] = 4
     rbln_model_runner.requests[req_id].output_token_ids = [101]
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     monkeypatch.setattr(rbln_model_runner, "num_spec_tokens", 2)
 
@@ -2527,6 +2581,7 @@ def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_met
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
+        is_prefill_step=False,
     )
 
     common_attn_metadata = SimpleNamespace(max_seq_len=6)
@@ -2566,7 +2621,7 @@ def test_execute_model_spec_decode_stores_spec_metadata_and_common_attention_met
     output = rbln_model_runner.execute_model(scheduler_output)
 
     assert output is None
-    assert rbln_model_runner.is_prefill is False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     assert attn_metadata_calls["num_tokens"] == 3
     assert attn_metadata_calls["num_reqs"] == 1
@@ -3065,8 +3120,6 @@ def test_take_draft_token_ids_returns_current_req_ids_and_draft_ids(
 def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypatch):
     """Prefill keeps the unpadded request count; decode uses the bucketing
     manager. With data_parallel_size == 1, token padding metadata stays None."""
-    ib = rbln_model_runner.input_batch
-
     fake_bucketing_manager = FakeBucketingManager(default=4)
     monkeypatch.setattr(
         rbln_model_runner,
@@ -3076,11 +3129,10 @@ def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypat
 
     assert rbln_model_runner.parallel_config.data_parallel_size == 1
 
-    # Prefill path:
-    # is_prefill == num_computed_tokens < num_tokens_no_spec - 1
-    ib.num_computed_tokens_cpu[0] = 0
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is True
+    # Prefill path: _determine_batch_padding selects the graph via the
+    # scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = True
+    assert rbln_model_runner.is_prefill_phase() is True
 
     num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
         rbln_model_runner._determine_batch_padding(
@@ -3094,11 +3146,9 @@ def test_determine_batch_padding_decode_uses_bucket(rbln_model_runner, monkeypat
     assert num_tokens_across_dp is None
     assert fake_bucketing_manager.calls == []
 
-    # Decode path:
-    # boundary condition for decode: computed == num_tokens_no_spec - 1
-    ib.num_computed_tokens_cpu[0] = 7
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is False
+    # Decode path: select the decode graph via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     num_reqs_padded, num_tokens_padded, num_tokens_across_dp = (
         rbln_model_runner._determine_batch_padding(
@@ -3118,12 +3168,9 @@ def test_determine_batch_padding_data_parallel_prefill_uses_max_num_tokens(
 ):
     """Data-parallel prefill should use max_num_tokens padding and return
     cross-rank token counts."""
-    ib = rbln_model_runner.input_batch
-
-    # Force prefill.
-    ib.num_computed_tokens_cpu[0] = 0
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is True
+    # Force prefill via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = True
+    assert rbln_model_runner.is_prefill_phase() is True
 
     monkeypatch.setattr(
         rbln_model_runner.parallel_config,
@@ -3199,12 +3246,9 @@ def test_determine_batch_padding_specialized_moe_decode_uses_decode_bucket(
 ):
     """Specialized MoE decode should bucket by request count and pad by the
     request bucket times the per-request query length."""
-    ib = rbln_model_runner.input_batch
-
-    # Force decode.
-    ib.num_computed_tokens_cpu[0] = 7
-    ib.num_tokens_no_spec[0] = 8
-    assert rbln_model_runner.is_prefill is False
+    # Force decode via the scheduler-stamped phase.
+    rbln_model_runner._is_prefill_step = False
+    assert rbln_model_runner.is_prefill_phase() is False
 
     monkeypatch.setattr(
         rbln_model_runner.parallel_config,

--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     # --- MOE ---
     VLLM_RBLN_SPECIALIZE_MOE_DECODE: bool = True
     VLLM_RBLN_USE_MOE_TOKENS_MASK: bool = True
+    VLLM_RBLN_PP_BALANCE_DECODE_BATCH: bool = True
     VLLM_RBLN_DISPATCH_ALL2ALL: bool = False
     VLLM_RBLN_COMBINE_ALL2ALL: bool = False
     # --- DECODE BATCH BUCKET ---
@@ -215,6 +216,15 @@ environment_variables = {
     "VLLM_RBLN_ENABLE_WARM_UP": (
         lambda: (
             os.environ.get("VLLM_RBLN_ENABLE_WARM_UP", "True").lower() in ("true", "1")
+        )
+    ),
+    # Under pipeline parallelism, distribute the per-step decode batch across
+    # PP stages (dynamic soft cap ~ceil(demand/pp_size)) so microbatches do not
+    # collapse to depth-1. No-op when pipeline_parallel_size == 1.
+    "VLLM_RBLN_PP_BALANCE_DECODE_BATCH": (
+        lambda: (
+            os.environ.get("VLLM_RBLN_PP_BALANCE_DECODE_BATCH", "True").lower()
+            in ("true", "1")
         )
     ),
     "VLLM_RBLN_METRICS": (

--- a/vllm_rbln/platform.py
+++ b/vllm_rbln/platform.py
@@ -297,6 +297,48 @@ class RblnPlatform(Platform):
                 "vllm_rbln.v1.core.rbln_scheduler.RBLNScheduler"
             )
 
+            # NOTE(RBLN): max_num_seqs is the max number of concurrently running
+            # sequences (the scheduler's running-queue cap), consistent with
+            # upstream and the non-PP case. Under PP the engine keeps
+            # pipeline_parallel_size microbatches in flight, so to keep total
+            # in-flight sequences <= max_num_seqs the *compiled* decode batch per
+            # PP stage is the derived max_num_seqs // pp_size (unlike GPU, which
+            # uses dynamic batch shapes and never divides). Validate here so an
+            # impossible config (e.g. max_num_seqs=1 with pp_size=2 -> 0) fails
+            # with a clear message instead of a cryptic assert deep in
+            # bucketing/scheduling.
+            pp_size = parallel_config.pipeline_parallel_size
+            if pp_size > 1:
+                max_num_seqs = scheduler_config.max_num_seqs
+                if max_num_seqs < pp_size:
+                    raise ValueError(
+                        f"pipeline_parallel_size={pp_size} requires "
+                        f"max_num_seqs >= {pp_size}: each PP stage is compiled "
+                        f"for max_num_seqs // pipeline_parallel_size decode "
+                        f"slots, but max_num_seqs={max_num_seqs} yields "
+                        f"{max_num_seqs // pp_size}."
+                    )
+                per_stage = max_num_seqs // pp_size
+                if max_num_seqs % pp_size != 0:
+                    logger.warning(
+                        "max_num_seqs=%d is not a multiple of "
+                        "pipeline_parallel_size=%d; the per-PP-stage decode "
+                        "batch floors to %d, so %d sequence slot(s) of the "
+                        "budget are unused. Set max_num_seqs to a multiple of "
+                        "pipeline_parallel_size to use the full budget.",
+                        max_num_seqs,
+                        pp_size,
+                        per_stage,
+                        max_num_seqs - per_stage * pp_size,
+                    )
+                logger.info(
+                    "PP=%d: max_num_seqs=%d (max concurrent sequences) -> "
+                    "per-PP-stage decode batch = %d (compiled).",
+                    pp_size,
+                    max_num_seqs,
+                    per_stage,
+                )
+
             # FIXME(jiwoo.park) This is a temporary workaround.
             if model_config.enforce_eager:
                 if not USE_DEVICE_TENSOR:

--- a/vllm_rbln/v1/core/rbln_scheduler.py
+++ b/vllm_rbln/v1/core/rbln_scheduler.py
@@ -23,7 +23,11 @@ from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import init_none_hash
 from vllm.v1.core.sched.interface import PauseState
-from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
@@ -38,6 +42,11 @@ from vllm_rbln.v1.core.rbln_kv_cache_manager import (
     RBLNKVCacheManager,
     SubBlockMatch,
 )
+from vllm_rbln.v1.core.utils import (
+    DecodeAdmissionController,
+    num_base_tokens,
+    should_defer_spec_step,
+)
 
 logger = init_logger(__name__)
 
@@ -45,9 +54,19 @@ logger = init_logger(__name__)
 @dataclass
 class RBLNSchedulerOutput(SchedulerOutput):
     """SchedulerOutput extended with KV cache copy operations for sub-block
-    prefix caching."""
+    prefix caching, and a step-level prefill/decode phase anchor."""
 
     kv_cache_copy_ops: list[KVCacheCopyOp] = field(default_factory=list)
+    # NOTE(RBLN): Whether this step runs the prefill graph (True) or the decode
+    # graph (False). RBLN has no mixed batching, so a step is uniformly one or
+    # the other. Stamped by the scheduler (a single authority) from the
+    # authoritative pre-advance Request state, so every PP rank reads an
+    # identical value. The runner MUST use this (via is_prefill_phase()) rather
+    # than re-deriving the phase from its own per-rank input_batch, whose
+    # num_tokens_no_spec is maintained on different paths on the last PP rank
+    # (sampling) vs other ranks (scheduler output) -- a runner-side
+    # classification would diverge across ranks under spec-decode + PP.
+    is_prefill_step: bool = False
 
 
 def is_prefill(request: Request) -> bool:
@@ -113,6 +132,35 @@ class RBLNScheduler(Scheduler):
         # lifecycle hooks clear its pending delta before it can resume with
         # a full block table.
         self._pending_runner_block_deltas: dict[str, KVCacheBlocks] = {}
+
+        # NOTE(RBLN): Per-step decode-batch admission. Under PP the engine keeps
+        # pipeline_parallel_size microbatches in flight, so each step's decode
+        # batch must stay <= max_num_seqs // pp_size (== the runner's compiled
+        # bucket ceiling). The controller produces a per-step budget shared by
+        # the running loop and the waiting-loop remote-KV promotion, and owns
+        # the static-vs-dynamic (PP-balanced) cap choice. See v1/core/utils.py.
+        self._decode_admission = DecodeAdmissionController(
+            max_num_seqs=self.max_num_running_reqs,
+            pipeline_parallel_size=(
+                self.vllm_config.parallel_config.pipeline_parallel_size
+            ),
+            pp_balance_decode=envs.VLLM_RBLN_PP_BALANCE_DECODE_BATCH,
+        )
+
+    def _decode_demand(self) -> int:
+        """Total decode demand for this step's PP-balanced admission cap.
+
+        = running decodes + remote-KV requests ready to be admitted (transfer
+        complete, awaiting promotion). Including the ready remote-KV gives the
+        dynamic cap headroom to ramp the decode batch on the P/D-disaggregated
+        decode side; running-only would stall the ramp. Demand is invariant
+        under admission (promoting a ready remote-KV moves it from ready ->
+        running), so this snapshot is exact even as the running/ready split
+        shifts during the waiting loop. Evaluated only when PP balancing is on.
+        """
+        num_running_decodes = sum(1 for r in self.running if not is_prefill(r))
+        num_ready_remote_kv = len(self.finished_recving_kv_req_ids)
+        return num_running_decodes + num_ready_remote_kv
 
     def _add_pending_runner_block_delta(
         self,
@@ -191,6 +239,16 @@ class RBLNScheduler(Scheduler):
 
         self.kv_cache_manager.new_step_starts()
 
+        # NOTE(RBLN): Per-step decode-batch admission budget shared by the
+        # running loop and the waiting-loop remote-KV promotion. can_admit()
+        # enforces the hard cap (max_num_seqs // pp == compiled bucket ceiling)
+        # plus, under PP with balancing on, a dynamic ceil(demand/pp) soft cap.
+        # In the non-PP / balance-off case this is exactly the old
+        # `len(scheduled_running_reqs) >= max_num_seqs // pp` gate.
+        decode_budget = self._decode_admission.make_budget(
+            demand_fn=self._decode_demand
+        )
+
         # First, schedule the RUNNING requests.
         # NOTE(RBLN): Prioritize prefill requests. Given our constraint that the prefill
         # batch size fixed to 1 if any prefill request is running there must be exactly
@@ -224,6 +282,17 @@ class RBLNScheduler(Scheduler):
                 + request.num_output_placeholders
                 - request.num_computed_tokens
             )
+            # NOTE(RBLN): Under sync-scheduling PP + spec decode, defer a step
+            # with no reconciled base (anchor) token yet -- num_computed_tokens
+            # is optimistically advanced by the drafts, so the RAW num_new_tokens
+            # can still be draft-inflated (drafts held) or negative (post-verify
+            # overshoot). See should_defer_spec_step. Non-spec decode is untouched
+            # (its no-new-tokens case is the plain `<= 0` continue below).
+            if should_defer_spec_step(
+                self.num_spec_tokens, request.spec_token_ids, num_new_tokens
+            ):
+                req_index += 1
+                continue
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
@@ -321,6 +390,10 @@ class RBLNScheduler(Scheduler):
                         if preempted_req in scheduled_running_reqs:
                             preempted_req_id = preempted_req.request_id
                             scheduled_running_reqs.remove(preempted_req)
+                            # NOTE(RBLN): the victim was admitted just below its
+                            # append; un-admit it so the stale (over)count does
+                            # not make can_admit() stop admitting early.
+                            decode_budget.discard()
                             token_budget += num_scheduled_tokens.pop(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
@@ -351,6 +424,11 @@ class RBLNScheduler(Scheduler):
 
             # Schedule the request.
             scheduled_running_reqs.append(request)
+            # NOTE(RBLN): every scheduled running req joins this step's decode
+            # batch; admit() keeps the shared budget's count == batch size so
+            # the can_admit() gate at the loop's end (and the waiting loop)
+            # stops at the cap.
+            decode_budget.admit()
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -392,11 +470,9 @@ class RBLNScheduler(Scheduler):
 
             # NOTE(RBLN): We restrict the decode batch size to
             # (max_num_seqs // pipeline_parallel_size) to prevent pipeline
-            # bubbles.
-            if len(scheduled_running_reqs) >= (
-                self.max_num_running_reqs
-                // self.vllm_config.parallel_config.pipeline_parallel_size
-            ):
+            # bubbles. Enforced via the shared decode budget (hard cap ==
+            # max_num_seqs // pp; optional PP-balanced soft cap on top).
+            if not decode_budget.can_admit():
                 break
 
         # Record the LoRAs in scheduled_running_reqs
@@ -433,6 +509,19 @@ class RBLNScheduler(Scheduler):
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
+
+                # NOTE(RBLN): Gate by the shared decode budget so the combined
+                # decode batch (running loop + waiting-loop remote-KV promotion)
+                # never exceeds max_num_seqs // pp (the runner's compiled bucket)
+                # -- the disagg over-admission fix. The soft (PP-balance) cap
+                # applies only to remote-KV promotions, which are in the demand
+                # snapshot; other joins (local prefix-cache / resumed) face only
+                # the hard cap. Checked before promoting a blocked-waiting
+                # request so a gated remote-KV req stays in WAITING_FOR_REMOTE_KVS
+                # (re-evaluated next step) instead of flipping its status.
+                apply_soft_cap = request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+                if not decode_budget.can_admit(apply_soft_cap=apply_soft_cap):
+                    break
 
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
@@ -780,6 +869,12 @@ class RBLNScheduler(Scheduler):
                         required_backfill = self.num_spec_tokens  # (num_spec+1)-1
                         if required_backfill > tokens_used_in_block:
                             unsafe_backfill_req_ids.add(request.request_id)
+                    # NOTE(RBLN): this decode-ready request has just joined the
+                    # decode batch (any route -- full remote-KV match or full
+                    # local prefix-cache match), so count it against the shared
+                    # per-step cap. A PARTIAL remote-KV match stays is_prefill
+                    # (not here) and is counted via the running loop next step.
+                    decode_budget.admit()
                     # The scheduled new request is added as a decoding-phase req, so
                     # we can continue to schedule the next request.
                     continue
@@ -803,6 +898,10 @@ class RBLNScheduler(Scheduler):
                     self._add_pending_runner_block_delta(req.request_id, evicted_delta)
 
                 scheduled_running_reqs.clear()
+                # NOTE(RBLN): the decode batch was just evicted for a prefill
+                # (no-mixed-batching); clear the admission count so this step
+                # budgets only the lone prefill.
+                decode_budget.reset()
                 token_budget = prefill_token_budget
 
                 # NOTE(RBLN): we restrict the prefill batch size to 1 for now.
@@ -919,6 +1018,16 @@ class RBLNScheduler(Scheduler):
             else None
         )
 
+        # NOTE(RBLN): Stamp the step-level prefill/decode phase from the
+        # pre-advance Request state (num_computed < num_tokens - 1). No mixed
+        # batching makes the step uniform (all decodes, or a lone prefill), so
+        # one representative request decides it -- the first scheduled id
+        # (running reqs are inserted first; otherwise the waiting-loop prefill).
+        # Empty step (no tokens) -> False (decode); the runner early-returns.
+        is_prefill_step = bool(num_scheduled_tokens) and is_prefill(
+            self.requests[next(iter(num_scheduled_tokens))]
+        )
+
         scheduler_output = RBLNSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -935,6 +1044,7 @@ class RBLNScheduler(Scheduler):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            is_prefill_step=is_prefill_step,
         )
 
         # Drain pending copy ops from the KV cache manager.
@@ -974,6 +1084,48 @@ class RBLNScheduler(Scheduler):
         # from the previous running state are stale.
         self._pending_runner_block_deltas.pop(request.request_id, None)
         return super()._preempt_request(request, timestamp)
+
+    def _make_cached_request_data(
+        self,
+        running_reqs: list[Request],
+        resumed_reqs: list[Request],
+        num_scheduled_tokens: dict[str, int],
+        spec_decode_tokens: dict[str, list[int]],
+        req_to_new_blocks: dict[str, KVCacheBlocks],
+    ) -> CachedRequestData:
+        data = super()._make_cached_request_data(
+            running_reqs,
+            resumed_reqs,
+            num_scheduled_tokens,
+            spec_decode_tokens,
+            req_to_new_blocks,
+        )
+        # NOTE(RBLN): multi-accept token propagation to the non-last PP rank
+        # under sync scheduling. The base builds new_token_ids =
+        # all_token_ids[num_computed : num_computed + base] (base =
+        # num_scheduled - drafts). When a prior verify accepted k drafts, the
+        # non-last rank's write cursor (num_tokens_no_spec) lags num_computed by
+        # up to num_spec, so a base-length payload cannot fill
+        # [cursor : num_computed + base] -> stale/garbage tokens on PP0. Extend
+        # the payload backward by num_spec so it always covers the max lag; the
+        # runner writes it by absolute position, idempotently overwriting any
+        # mis-speculated draft slots. Only the sync-PP spec path (where the base
+        # sends a new_token_ids payload) is touched.
+        if (
+            self.use_pp
+            and not self.scheduler_config.async_scheduling
+            and self.num_spec_tokens > 0
+            and data.new_token_ids
+        ):
+            for idx, req in enumerate(itertools.chain(running_reqs, resumed_reqs)):
+                if idx >= len(data.new_token_ids):
+                    break
+                req_id = req.request_id
+                base = num_base_tokens(num_scheduled_tokens, spec_decode_tokens, req_id)
+                lo = max(0, req.num_computed_tokens - self.num_spec_tokens)
+                hi = req.num_computed_tokens + base
+                data.new_token_ids[idx] = req.all_token_ids[lo:hi]
+        return data
 
     def _free_request(
         self, request: Request, delay_free_blocks: bool = False

--- a/vllm_rbln/v1/core/utils.py
+++ b/vllm_rbln/v1/core/utils.py
@@ -1,0 +1,355 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility helpers for the RBLN scheduler (``rbln_scheduler.py``).
+
+A home for small, self-contained, independently-testable pieces of RBLN
+scheduling/engine logic factored out of ``RBLNScheduler`` so that
+``schedule()`` (a large copy of upstream's method with RBLN-specific tweaks)
+stays readable. Unlike ``vllm_rbln.utils`` (general torch-tensor primitives),
+these encode engine/scheduler semantics; some are shared with the runner
+(``RBLNModelRunner``) -- e.g. ``decode_batch_size`` and the spec-decode
+``num_base_tokens`` / ``resolve_propagated_token_write`` token bookkeeping.
+Add further scheduler utilities here.
+
+The speculative-decode + PP helpers -- ``should_defer_spec_step`` (running-loop
+anchor-reconciled deferral), ``num_base_tokens`` and
+``resolve_propagated_token_write`` (non-last-rank token propagation) -- live
+next to their docstrings above/below.
+
+The per-step decode-batch admission budget (``DecodeBatchBudget`` +
+``DecodeCapPolicy``):
+
+Under pipeline parallelism the engine keeps ``pipeline_parallel_size``
+microbatches in flight (one per PP stage). To bound the total in-flight
+decode requests to ``max_num_seqs`` and to never exceed the runner's
+compiled decode-batch bucket, each single step's decode batch must be
+capped at ``max_num_seqs // pipeline_parallel_size`` (==
+``RBLNModelRunner.bucketing_manager.max_batch_size``). ``schedule()`` admits
+decode requests from two places — the running loop and the waiting-loop
+remote-KV promotion
+(P/D-disaggregated decode) — so the cap is centralized into one budget both
+loops share, rather than enforced per-loop.
+"""
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+
+def decode_batch_size(max_num_seqs: int, pipeline_parallel_size: int) -> int:
+    """Per-PP-stage (compiled) decode batch size — the single source of truth.
+
+    ``max_num_seqs`` is the max number of concurrently running sequences (the
+    scheduler's running-queue cap), consistent with upstream vLLM and with the
+    non-PP case; the KV cache is provisioned to hold that many concurrent
+    sequences. Under pipeline parallelism the engine keeps
+    ``pipeline_parallel_size`` microbatches in flight, so to keep total
+    in-flight sequences <= ``max_num_seqs`` the batch RBLN must *compile* for
+    one PP stage is that cap split across stages:
+
+        decode_batch_size = max_num_seqs // pipeline_parallel_size
+
+    Unlike GPU (dynamic batch shapes, no division), RBLN compiles a fixed
+    decode-batch shape, so this derived value — not ``max_num_seqs`` itself —
+    is what the runner buckets to and the scheduler caps at. ``pp_size == 1``
+    returns ``max_num_seqs`` unchanged (non-PP). Callers must ensure
+    ``max_num_seqs >= pipeline_parallel_size`` (validated at config time in
+    ``RBLNPlatform.check_and_update_config``); otherwise this floors to 0.
+    """
+    return max_num_seqs // pipeline_parallel_size
+
+
+def should_defer_spec_step(
+    num_spec_tokens: int,
+    spec_token_ids: list[int],
+    num_new_tokens: int,
+) -> bool:
+    """Whether ``schedule()``'s running loop must defer a speculative-decode
+    step under sync-scheduling PP because it has no reconciled BASE (anchor)
+    token to schedule yet.
+
+    Called with the RAW ``num_new_tokens`` (before the scheduler's caps). The
+    base count is ``num_new_tokens - len(spec_token_ids)``. The branch is on
+    whether the proposer currently holds drafts (``spec_token_ids``), which only
+    selects how the base is tested:
+
+    - Drafts held: ``num_new_tokens`` is draft-inflated, so gate on the base
+      itself. ``base <= 0`` means there is no fresh anchor token for the drafts
+      to verify against yet (the token-producing step has not reconciled);
+      scheduling anyway hands the non-last PP rank an empty token payload.
+    - No drafts held (just consumed, or no proposer match): ``base ==
+      num_new_tokens``, which goes negative only in the post-verify overshoot
+      (num_computed_tokens still optimistically advanced). The mundane ``== 0``
+      (no work this step) and the no-match case are left to the caller's plain
+      upstream defer.
+
+    Returns ``False`` when spec is disabled (``num_spec_tokens <= 0``), so
+    non-spec decode is untouched; also inert for pp=1, where synchronous
+    scheduling keeps the base reconciled.
+    """
+    if num_spec_tokens <= 0:
+        return False
+    if spec_token_ids:
+        return num_new_tokens - len(spec_token_ids) <= 0
+    return num_new_tokens < 0
+
+
+def num_base_tokens(
+    num_scheduled_tokens: dict[str, int],
+    scheduled_spec_decode_tokens: dict[str, list[int]],
+    req_id: str,
+) -> int:
+    """Number of non-draft (anchor / decode) tokens scheduled for ``req_id`` in
+    a step: the total scheduled tokens minus the speculative draft tokens.
+
+    This is the count that advances the request's committed sequence (the base
+    decode token plus any catch-up), as opposed to the unverified drafts. It is
+    the shared notion of "base" used by the scheduler's non-last-rank token
+    propagation and by the runner's token-write / output bookkeeping.
+    """
+    return num_scheduled_tokens.get(req_id, 0) - len(
+        scheduled_spec_decode_tokens.get(req_id, ())
+    )
+
+
+def resolve_propagated_token_write(
+    cursor: int,
+    num_computed_tokens: int,
+    base: int,
+    new_token_ids: list[int],
+) -> tuple[int, list[int]] | None:
+    """Plan the non-last PP rank's write of scheduler-propagated tokens.
+
+    Under sync-scheduling pipeline parallelism the scheduler ships
+    ``new_token_ids`` covering the request's committed-token tail (extended
+    backward by ``num_spec_tokens`` so it always spans a prior verify's
+    multi-accept lag). This rank brings its recorded-token cursor
+    (``num_tokens_no_spec``) up to
+    ``committed_tip = num_computed_tokens + base`` by writing the payload slice
+    that lands at ``[cursor, committed_tip)`` by ABSOLUTE position, idempotently
+    overwriting any mis-speculated slots.
+
+    Returns ``(committed_tip, tokens)`` where ``tokens`` is the length-``span``
+    slice to write at ``token_ids_cpu[cursor:committed_tip]``, or ``None`` if the
+    cursor has already reached ``committed_tip`` (nothing to write).
+
+    Sync-scheduling only: RBLN force-disables async scheduling (platform.py) and
+    the caller asserts a non-empty payload, so ``new_token_ids`` always covers
+    [cursor, committed_tip). Async support would NOT surface here as a per-request
+    empty payload -- it needs the prev_sampled_token_ids GPU-broadcast path plus
+    skipping this propagation block in _update_states entirely.
+    """
+    committed_tip = num_computed_tokens + base
+    if committed_tip <= cursor:
+        return None
+    span = committed_tip - cursor
+    # The payload covers all_token_ids[committed_tip - len : committed_tip], so
+    # the token for absolute position `cursor` sits at offset `lo`.
+    lo = cursor - (committed_tip - len(new_token_ids))
+    # Invariant (sync-scheduling PP): the scheduler extends new_token_ids
+    # backward by num_spec_tokens, so the payload always covers
+    # [cursor, committed_tip) -- a non-last rank never lags num_computed by more
+    # than one verify's worth. If a future scheduler change breaks that, fail
+    # here with a clear signal instead of deep inside _update_states with an
+    # opaque numpy broadcast error at token_ids_cpu[cursor:committed_tip] = tokens.
+    # (lo + span always equals len(new_token_ids), so there is no separate
+    # upper-bound to check.)
+    assert lo >= 0, (
+        f"propagated payload ({len(new_token_ids)}) shorter than the write span "
+        f"({span}): a non-last PP rank's cursor lags num_computed by more than "
+        "num_spec_tokens -- the token-propagation invariant is broken."
+    )
+    return committed_tip, new_token_ids[lo : lo + span]
+
+
+@runtime_checkable
+class DecodeCapPolicy(Protocol):
+    """Supplies the per-step decode-batch cap (max decode requests admitted
+    to one PP microbatch).
+
+    Injected into ``DecodeBatchBudget`` so the admission logic stays fixed
+    while the *sizing* rule can evolve — e.g. a future dynamic policy that
+    splits available decodes across PP stages to avoid microbatch collapse."""
+
+    def cap(self) -> int: ...
+
+
+class StaticDecodeCapPolicy:
+    """Fixed cap = ``max_num_seqs // pipeline_parallel_size``.
+
+    Must equal ``RBLNModelRunner.bucketing_manager.max_batch_size`` so the
+    scheduled decode batch always maps onto a compiled decode-batch bucket.
+    ``pp_size == 1``
+    degenerates to ``max_num_seqs`` (the cap is then a no-op, since the
+    running queue is already bounded by ``max_num_seqs``).
+    """
+
+    def __init__(self, cap: int) -> None:
+        assert cap >= 1, f"decode-batch cap must be >= 1, got {cap}"
+        self._cap = cap
+
+    def cap(self) -> int:
+        return self._cap
+
+
+class DynamicDecodeCapPolicy:
+    """Cap that spreads the decode *demand* across the PP pipeline.
+
+    Avoids PP-depth collapse: after a pipeline drain (e.g. a
+    prefill stall) every decode becomes reschedulable at once, and the static
+    ``max_num_seqs // pp_size`` cap lets them pack into a single microbatch ->
+    the other ``pp_size - 1`` stages idle (depth-1, ~2x decode latency). Sizing
+    each step's batch to ``ceil(demand / pp_size)`` instead spreads the decode
+    demand across ``pp_size`` microbatches so the pipeline stays full.
+
+    ``num_demand_decodes`` is the total decode demand, NOT just the currently
+    running decodes: it must also include remote-KV requests that are ready to
+    join the decode batch (P/D-disaggregated decode). Using running-only would
+    leave no headroom to admit those, stalling the ramp (the cap is fully
+    consumed by the requests already cycling). Crucially, demand is *invariant*
+    under admission -- promoting a ready remote-KV moves it from "ready" to
+    "running" without changing the total -- so a single step-start snapshot is
+    exact even though the running/ready split shifts during the waiting loop.
+
+    The cap is **clamped to** ``static_max_cap`` (== the runner's compiled
+    decode-batch ceiling) so it can only go *lower*, never overflow the bucket;
+    and floored at 1. ``pp_size == 1`` yields ``min(static_max_cap, demand)``,
+    a no-op (only ``demand`` decodes are admittable anyway).
+
+    Constructed per ``schedule()`` call with that step's decode demand.
+    """
+
+    def __init__(
+        self,
+        static_max_cap: int,
+        pipeline_parallel_size: int,
+        num_demand_decodes: int,
+    ) -> None:
+        assert static_max_cap >= 1, f"static_max_cap must be >= 1, got {static_max_cap}"
+        # ceil(num_demand_decodes / pipeline_parallel_size)
+        spread = -(-num_demand_decodes // pipeline_parallel_size)
+        self._cap = max(1, min(static_max_cap, spread))
+
+    def cap(self) -> int:
+        return self._cap
+
+
+class DecodeBatchBudget:
+    """Tracks how many decode requests have been admitted to the current
+    step's batch, shared across ``schedule()``'s running and waiting loops.
+
+    Lifecycle: one instance per ``schedule()`` call. ``admit()`` on every
+    decode added to the step; ``can_admit()`` gates further admissions in
+    both loops; ``reset()`` clears the count when a prefill evicts the
+    decode batch (the "disable mixed batching" path).
+    """
+
+    def __init__(self, cap_policy: DecodeCapPolicy, hard_cap: int) -> None:
+        self._cap_policy = cap_policy
+        # Compiled decode-bucket ceiling (max_num_seqs // pp). The batch may
+        # never exceed it or the runner has no bucket -> crash. The policy's
+        # cap() is the (<=) soft/spreading cap (== hard_cap in static mode).
+        self._hard_cap = hard_cap
+        self._count = 0
+
+    def can_admit(self, *, apply_soft_cap: bool = True) -> bool:
+        """True iff one more decode request may be admitted this step.
+
+        Two limits:
+          * hard cap (always): the compiled bucket ceiling; exceeding it
+            crashes the runner. Applies to every candidate decode join.
+          * soft cap (``apply_soft_cap``): the balance/spreading target
+            ``ceil(demand/pp)`` for the *budgeted* decode demand (running
+            decodes + ready remote-KV). Skip it (``apply_soft_cap=False``) for
+            joins not in the demand snapshot (full local prefix-cache match,
+            resumed-after-eviction) — they only face the hard limit. In static
+            mode the two caps are equal, so the flag has no effect.
+        """
+        if self._count >= self._hard_cap:
+            return False
+        # Soft (spreading) cap for the budgeted demand; skipped for
+        # demand-unbudgeted joins, which then face only the hard cap above.
+        return not (apply_soft_cap and self._count >= self._cap_policy.cap())
+
+    def admit(self, n: int = 1) -> None:
+        """Record ``n`` decode requests as admitted to this step's batch."""
+        self._count += n
+
+    def discard(self, n: int = 1) -> None:
+        """Un-admit ``n`` decode requests dropped from this step's batch.
+
+        Unlike ``reset()`` (whole batch dropped by a prefill eviction), this
+        removes only the requests that left the batch while others remain
+        admitted -- currently the PRIORITY-policy preemption in the running
+        loop, which evicts an already-scheduled decode to free KV blocks.
+        Keeping the count in step with the batch keeps the subsequent
+        ``can_admit()`` gate from stopping early on a stale (over)count.
+        """
+        self._count -= n
+
+    def reset(self) -> None:
+        """Clear the admitted count (decode batch dropped, e.g. by eviction)."""
+        self._count = 0
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    @property
+    def cap(self) -> int:
+        return self._cap_policy.cap()
+
+
+class DecodeAdmissionController:
+    """Per-scheduler factory for per-step decode-batch admission budgets.
+
+    Built once from scheduler config; produces a fresh ``DecodeBatchBudget``
+    for each ``schedule()`` call. It owns the PP decode-cap machinery — the
+    compiled per-stage batch size, the static cap policy, and the choice
+    between the static cap and the PP-balanced dynamic cap — so ``schedule()``
+    only has to supply the demand and use the returned budget.
+
+    Dynamic (demand-spread) capping applies only when ``pp_balance_decode`` is
+    enabled *and* ``pipeline_parallel_size > 1``; otherwise the fixed
+    ``max_num_seqs // pp_size`` cap is used.
+    """
+
+    def __init__(
+        self,
+        max_num_seqs: int,
+        pipeline_parallel_size: int,
+        pp_balance_decode: bool,
+    ) -> None:
+        self._pp_size = pipeline_parallel_size
+        self._max_decode_batch_size = decode_batch_size(
+            max_num_seqs, pipeline_parallel_size
+        )
+        self._static_policy = StaticDecodeCapPolicy(self._max_decode_batch_size)
+        # Demand-spread capping is only meaningful under PP.
+        self._balance = pp_balance_decode and pipeline_parallel_size > 1
+
+    def make_budget(self, demand_fn: Callable[[], int]) -> DecodeBatchBudget:
+        """Return a fresh budget for this step.
+
+        ``demand_fn`` is a zero-arg callable returning the total decode demand
+        (running decodes + ready remote-KV). It is invoked **only** when PP
+        balancing is active, so the static path pays nothing to compute it.
+        """
+        if self._balance:
+            policy: DecodeCapPolicy = DynamicDecodeCapPolicy(
+                self._max_decode_batch_size, self._pp_size, demand_fn()
+            )
+        else:
+            policy = self._static_policy
+        return DecodeBatchBudget(policy, hard_cap=self._max_decode_batch_size)

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -92,7 +92,10 @@ class RBLNEagleProposer(EagleProposer):
         )
 
         assert self.runner is not None
-        is_prefill = self.runner.is_prefill
+        # Use the scheduler-stamped step phase (rank-consistent) rather than the
+        # runner's per-rank is_prefill property, which can diverge across PP
+        # ranks under spec-decode. Drives draft batch padding + draft attn build.
+        is_prefill = self.runner.is_prefill_phase()
 
         # Build attention metadata
         num_reqs = self.runner.input_batch.num_reqs

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -121,6 +121,11 @@ from vllm_rbln.v1.attention.kv_cache_bindings import (
 )
 from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
 from vllm_rbln.v1.core.rbln_scheduler import RBLNSchedulerOutput
+from vllm_rbln.v1.core.utils import (
+    decode_batch_size,
+    num_base_tokens,
+    resolve_propagated_token_write,
+)
 from vllm_rbln.v1.sample.rbln_rejection_sampler import RBLNRejectionSampler
 from vllm_rbln.v1.spec_decode.eagle import RBLNEagleProposer
 from vllm_rbln.v1.spec_decode.medusa import RBLNMedusaProposer
@@ -211,6 +216,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.parallel_config = vllm_config.parallel_config
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
+
+        # Step-level prefill/decode phase, stamped from RBLNSchedulerOutput at
+        # the top of execute_model (see is_prefill_phase()). Scheduler-authored
+        # so it is identical across PP ranks.
+        self._is_prefill_step: bool = False
         # self.observability_config = vllm_config.observability_config
 
         model_config = self.model_config
@@ -402,10 +412,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # (and across the PP / pooling / empty-batch paths).
         self.kv_connector_output: KVConnectorOutput | None = None
 
-        # NOTE(RBLN): Initialize bucketing manager
+        # NOTE(RBLN): Initialize bucketing manager. RBLN compiles a fixed
+        # decode-batch shape, so it buckets to the per-PP-stage decode batch
+        # (max_num_seqs // pp_size) -- the single source of truth shared with
+        # the scheduler's decode admission cap -- not the raw max_num_seqs.
         self.bucketing_manager = get_bucketing_manager(
             envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY,
-            max_batch_size=self.max_num_reqs,
+            max_batch_size=decode_batch_size(
+                self.max_num_reqs, self.parallel_config.pipeline_parallel_size
+            ),
             min_batch_size=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_MIN,
             step=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STEP,
             limit=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT,
@@ -625,9 +640,19 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 new_token_ids = req_data.new_token_ids[i]
                 # Add the sampled token(s) from the previous step (if any).
                 # This doesn't include "unverified" tokens like spec tokens.
-                num_new_tokens = (
-                    num_computed_tokens + len(new_token_ids) - req_state.num_tokens
+                # NOTE(RBLN): new_token_ids is extended backward by num_spec
+                # (multi-accept propagation) and ends at committed_tip =
+                # num_computed + base. The number of NEW output tokens is the
+                # committed delta, computed from base (not len(new_token_ids),
+                # which now includes the backward-extended catch-up window).
+                # new_token_ids[-num_new:] still takes the newest tokens because
+                # the payload ends at committed_tip.
+                base_out = num_base_tokens(
+                    scheduler_output.num_scheduled_tokens,
+                    scheduled_spec_tokens,
+                    req_id,
                 )
+                num_new_tokens = num_computed_tokens + base_out - req_state.num_tokens
                 if num_new_tokens == 1:
                     # Avoid slicing list in most common case.
                     req_state.output_token_ids.append(new_token_ids[-1])
@@ -672,13 +697,32 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # For the last rank, we don't need to update the token_ids_cpu
             # because the sampled tokens are already cached.
             if not is_last_rank:
-                # Add new_token_ids to token_ids_cpu.
-                start_token_index = num_computed_tokens
-                end_token_index = num_computed_tokens + len(new_token_ids)
-                self.input_batch.token_ids_cpu[
-                    req_index, start_token_index:end_token_index
-                ] = new_token_ids
-                self.input_batch.num_tokens_no_spec[req_index] = end_token_index
+                # NOTE(RBLN): bring this rank's recorded-token cursor
+                # (num_tokens_no_spec) up to committed_tip = num_computed + base
+                # by writing the scheduler-propagated tokens at their ABSOLUTE
+                # position. The payload is extended backward by num_spec so it
+                # spans a prior verify's multi-accept lag; the write idempotently
+                # overwrites any mis-speculated draft slots. See
+                # resolve_propagated_token_write.
+                base = num_base_tokens(
+                    scheduler_output.num_scheduled_tokens,
+                    scheduled_spec_tokens,
+                    req_id,
+                )
+                start_token_index = self.input_batch.num_tokens_no_spec[req_index]
+                write = resolve_propagated_token_write(
+                    start_token_index, num_computed_tokens, base, new_token_ids
+                )
+                if write is not None:
+                    committed_tip, tokens = write
+                    if tokens:
+                        self.input_batch.token_ids_cpu[
+                            req_index, start_token_index:committed_tip
+                        ] = tokens
+                    self.input_batch.is_token_ids[
+                        req_index, start_token_index:committed_tip
+                    ] = True
+                    self.input_batch.num_tokens_no_spec[req_index] = committed_tip
 
             # Add spec_token_ids to token_ids_cpu.
             self.input_batch.update_req_spec_token_ids(req_state, scheduled_spec_tokens)
@@ -758,7 +802,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # ngram/suffix steps clear scheduled_spec_decode_tokens and run with
         # the logical query length, usually qlen=1.
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
-        if use_spec_decode and self.num_spec_tokens > 0 and not self.is_prefill:
+        if use_spec_decode and self.num_spec_tokens > 0 and not self.is_prefill_phase():
             target_query_len = self.num_spec_tokens + 1
             query_lengths = np.full(num_reqs, target_query_len, dtype=np.int32)
             backfill = query_lengths - logical_num_tokens
@@ -928,8 +972,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, RBLNEagleProposer):
-                    if self.drafter.kv_cache_gid == kv_cache_gid:
+                # NOTE(RBLN): the drafter lives only on the last PP rank, so
+                # use getattr (like the warmup/load-model paths) -- this runs on
+                # every rank under spec-decode + PP. Non-last ranks (drafter
+                # absent -> None) take the else branch; the resulting
+                # spec_decode_common_attn_metadata is unused there (only the
+                # last rank drafts).
+                drafter = getattr(self, "drafter", None)
+                if isinstance(drafter, RBLNEagleProposer):
+                    if drafter.kv_cache_gid == kv_cache_gid:
                         spec_decode_common_attn_metadata = cm
                 else:
                     spec_decode_common_attn_metadata = cm
@@ -942,7 +993,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 attn_metadata_i = builder.build(
                     common_attn_metadata=cm,
                     positions=self.positions,
-                    is_prefill=self.is_prefill,
+                    is_prefill=self.is_prefill_phase(),
                     batch_pad=num_reqs_padded,
                 )
 
@@ -1161,12 +1212,13 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         else:
             assert intermediate_tensors is not None
 
+        is_prefill_phase = self.is_prefill_phase()
         layout = InputLayout(
             num_reqs=num_reqs,
-            num_reqs_padded=num_reqs if self.is_prefill else num_reqs_padded,
+            num_reqs_padded=num_reqs if is_prefill_phase else num_reqs_padded,
             query_len=input_ids.shape[1],
             query_len_padded=self.max_num_tokens
-            if self.is_prefill
+            if is_prefill_phase
             else input_ids.shape[1],
         )
         staged_model_inputs = self.input_stager.stage(
@@ -1175,7 +1227,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             intermediate_tensors=intermediate_tensors,
             inputs_embeds=inputs_embeds,
             token_indices=logits_indices
-            if self.is_prefill and self.use_wrapped_compute_logits
+            if is_prefill_phase and self.use_wrapped_compute_logits
             else None,
             layout=layout,
         )
@@ -1348,6 +1400,11 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             assert kv_connector_metadata is not None
             get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
 
+        # Stamp this step's prefill/decode phase from the scheduler before any
+        # is_prefill_phase() read or early return, so all PP ranks agree on the
+        # graph they select this step.
+        self._set_step_phase(scheduler_output)
+
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
 
         with record_function_or_nullcontext("rbln_model_runner: preprocess"):
@@ -1421,7 +1478,14 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # When spec decode is enabled, defer connector finalization
         # (wait_for_save + clear metadata) until after the draft model runs
         # in sample_tokens(), so the draft model can also save its KV cache.
-        defer_kv_connector_finalize = self.speculative_config is not None
+        # NOTE(RBLN): gate on the last PP rank -- the deferred finalize runs in
+        # the sample path, which only the last rank reaches, so deferring on
+        # non-last ranks would drop their KV save entirely (every PP rank must
+        # finalize its own layers' KV). Only the last rank drafts, so only it
+        # needs to defer; non-last ranks finalize in-context like non-spec.
+        defer_kv_connector_finalize = (
+            self.speculative_config is not None and get_pp_group().is_last_rank
+        )
         with (
             set_forward_context(
                 attn_metadata,
@@ -1436,7 +1500,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 scheduler_output,
                 defer_finalize=defer_kv_connector_finalize,
             ) as kv_connector_output,
-            self.performance_ctx.profile_model(self.is_prefill),
+            self.performance_ctx.profile_model(self.is_prefill_phase()),
         ):
             model_output = self.model_executable(
                 **staged_model_inputs.as_kwargs(),
@@ -1465,7 +1529,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
 
             sample_hidden_states = hidden_states
             assert self.use_wrapped_compute_logits
-            if not self.is_prefill and spec_decode_metadata is not None:
+            if not self.is_prefill_phase() and spec_decode_metadata is not None:
                 logits = logits[logits_indices]
 
         self.execute_model_state = ExecuteModelState(
@@ -2019,13 +2083,22 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         seq_lens_np[:num_reqs] = num_scheduled_tokens
         seq_lens_np[num_reqs:] = 0
 
-        # NOTE(RBLN): self.is_prefill is derived from num_tokens_no_spec.
-        # For decode warmup, keep it at 1 so multi-token speculative decode
-        # query lengths are not misclassified as prefill.
+        # NOTE(RBLN): num_tokens_no_spec is the per-request no-spec logical
+        # length consumed downstream (query backfill, spec metadata). For decode
+        # warmup keep it at 1 so a multi-token speculative decode query is sized
+        # as decode. The step phase itself is stamped below via _is_prefill_step.
         if is_prefill:
             self.input_batch.num_tokens_no_spec[:num_reqs] = num_scheduled_tokens
         else:
             self.input_batch.num_tokens_no_spec[:num_reqs] = 1
+
+        # Stamp the phase from this dummy's own classification so the graph/phase
+        # selection helpers below (_determine_batch_padding,
+        # _build_attention_metadata) read is_prefill_phase() consistently. This
+        # bypasses execute_model's scheduler stamp and also guards the DP-idle
+        # path (rbln_worker.execute_dummy_batch): a stale value from a prior real
+        # step cannot leak into any is_prefill_phase() read while the dummy runs.
+        self._is_prefill_step = is_prefill
 
         num_reqs_padded, _num_tokens_padded, num_tokens_across_dp = (
             self._determine_batch_padding(num_reqs, num_tokens_unpadded)
@@ -2066,9 +2139,15 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 dtype=self.model_config.dtype,
                 device=self.device,
             )
+            # The empty tensor holds num_tokens_unpadded (= num_reqs *
+            # num_tokens_per_req) rows, so the view must reshape by num_reqs to
+            # keep the trailing hidden dimension intact. Using the DP-padded
+            # count here would over-count the leading dims and split the hidden
+            # size (num_reqs_padded > num_reqs whenever a peer forces padding),
+            # matching input_ids / InputLayout which also stage by num_reqs.
             intermediate_tensors = IntermediateTensors(
                 {
-                    k: v.view(num_reqs_padded, num_tokens_per_req, -1)
+                    k: v.view(num_reqs, num_tokens_per_req, -1)
                     for k, v in intermediate_tensors.items()
                 }
             )
@@ -2752,15 +2831,28 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
     # Only RBLN-Specific Methods
     ####################################################################################################
 
-    @property
-    def is_prefill(self) -> bool:
-        num_computed_tokens = self.input_batch.num_computed_tokens_cpu[0]
-        num_tokens_no_spec = self.input_batch.num_tokens_no_spec[0]
-        return bool(num_computed_tokens < (num_tokens_no_spec - 1))
+    def _set_step_phase(self, scheduler_output: "RBLNSchedulerOutput") -> None:
+        """Record this step's prefill/decode phase from the scheduler stamp."""
+        self._is_prefill_step = scheduler_output.is_prefill_step
+
+    def is_prefill_phase(self) -> bool:
+        """The step's prefill/decode classification, stamped by the scheduler
+        (RBLNSchedulerOutput.is_prefill_step) and stashed at the top of
+        execute_model.
+
+        The single source of truth for all graph/phase selection in the runner.
+        A runner-side re-derivation from num_tokens_no_spec would diverge across
+        PP ranks under spec-decode -- it is updated on the sampling path on the
+        last PP rank but on the scheduler-output path on the others -- so the
+        rank-consistent scheduler value is used instead. On the dummy path
+        (_dummy_run, incl. the DP-idle execute_dummy_batch), _is_prefill_step is
+        stamped from the dummy's own phase instead of a scheduler output.
+        """
+        return self._is_prefill_step
 
     @property
     def is_intermediate_chunked_prefill(self) -> bool:
-        return self.is_prefill and bool(self.discard_request_mask[0])
+        return self.is_prefill_phase() and bool(self.discard_request_mask[0])
 
     @property
     def use_wrapped_compute_logits(self) -> bool:
@@ -2784,9 +2876,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         num_reqs_unpadded: int,
         num_tokens_unpadded: int,
     ) -> tuple[int, int | None, torch.Tensor | None]:
+        is_prefill_phase = self.is_prefill_phase()
         num_reqs_padded = (
             self.bucketing_manager.find_decode_batch_bucket(num_reqs_unpadded)
-            if not self.is_prefill
+            if not is_prefill_phase
             else num_reqs_unpadded
         )
         if self.parallel_config.data_parallel_size == 1:
@@ -2798,7 +2891,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 num_reqs_unpadded,
                 self.parallel_config.data_parallel_size,
                 self.parallel_config.data_parallel_rank,
-                self.is_prefill,
+                is_prefill_phase,
             )
         )
         num_tokens_padded = self.max_num_tokens


### PR DESCRIPTION
> **Step 1 of 3** — split of #838 (*pipeline parallelism across the RBLN scheduler, runner, and NIXL KV-cache transfer*). This PR carries **section A** of #838: the PP-aware scheduler & runner. The NIXL transfer PR is stacked on this branch; the data-parallel decode-shape PR is parallel, also based on this branch.

### 🚀 Summary of Changes

#### Summary

Pipeline parallelism (`pipeline_parallel_size > 1`) on the RBLN path worked for plain decode but broke down the moment decode batching or speculative decoding entered the picture: a step's decode batch could overflow the compiled per-stage bucket, and spec-decode misclassified the prefill/decode phase inconsistently across ranks. This PR reorganizes the scheduler/runner so PP is a first-class, correct, and efficient mode — one PP-aware decode-admission budget, rank-consistent speculative decoding on top of it, prefill/decode phase authority consolidated onto the scheduler, and batch balancing on by default for PP.

#### What changed

**1. PP-aware decode-batch admission (scheduler).** Under PP the engine keeps one decode microbatch in flight per stage, so a single step's decode batch must fit the compiled per-stage bucket (`max_num_seqs // pp_size`). Admission from both the running queue and (in disaggregated serving) KV-transfer-completed requests is centralized into **one per-step budget** (`DecodeAdmissionController` / `DecodeBatchBudget` in `v1/core/utils.py`):
- Hard cap = the compiled bucket size on every decode that joins the batch.
- Optional **demand spreading** across stages (`ceil(demand / pp_size)`) so no stage idles after a pipeline drain.
- Requests that become decode-ready outside the demand snapshot (full local prefix-cache hit, resume-after-eviction) are gated by the hard cap only.
- The admitted count stays consistent when the batch shrinks (cleared on whole-batch eviction, decremented on preemption of an admitted decode).
- `pp_size == 1` degenerates to `max_num_seqs` — unchanged.

**2. Speculative decoding under PP (scheduler + runner).** Enables spec decode (ngram, EAGLE, MTP, …) together with `pp_size > 1`. With `pp_size` microbatches in flight under synchronous scheduling, a verify step — whose query spans `num_spec_tokens + 1` positions and whose accepted tokens are produced only on the last PP rank — stays bit-consistent on every non-last rank one step later via:
- **Uniform per-query-length bookkeeping** — the prefill/decode phase is stamped once on `RBLNSchedulerOutput` and read by every rank (never re-derived per-rank), PP inter-stage tensors are sized per `(bucket, query_len)`, and non-last ranks write propagated tokens from `num_tokens_no_spec`.
- **Anchor-reconciled scheduling** — `should_defer_spec_step` admits a verify only when its base token is reconciled, deciding on the base count. Gated on spec being enabled → non-spec decode untouched.
- **Multi-accept token propagation** — the scheduler extends a lagging rank's `new_token_ids` payload back by `num_spec_tokens`; the runner writes by absolute position (idempotent over mis-speculated slots).

**3. Scheduler as the single phase authority (runner cleanup).** With `RBLNSchedulerOutput` now the unified type every step carries, the legacy per-rank `is_prefills()` classifier (which diverged across PP ranks under spec decode) is removed along with its test and a dangling comment. Defensive `isinstance`/`getattr` fallbacks that hedged for a plain `SchedulerOutput` are dropped: RBLN-only helpers are narrowed to `RBLNSchedulerOutput`, and base-override methods sit behind a single boundary assert.

**4. PP decode-batch balancing on by default.** `VLLM_RBLN_PP_BALANCE_DECODE_BATCH` now defaults to **on**. The dynamic cap only ever caps *lower* than the static one (never overflows the bucket), is floored at 1, matches the static cap at saturation, and is a **no-op for `pp_size == 1`**. Set `=0` to force the static cap.

#### Testing

- **Unit** — PP decode-admission budget and demand-spread contrast (`test_scheduler.py`), anchor-reconciled deferral predicate and multi-accept payload (`test_rbln_model_runner.py`), backfill/slide query-window math (`test_query_backfill.py`).
- `pre-commit run --hook-stage manual` clean (ruff, mypy 3.10–3.13, typos, license); runner/scheduler unit suites green.

#### Risk / compatibility

- `pp_size == 1` and non-spec decode paths are untouched (predicate gated on spec; cap degenerates to `max_num_seqs`; balancing is a no-op).
- The `VLLM_RBLN_PP_BALANCE_DECODE_BATCH` default flip is confined to PP; the escape hatch (`=0`) preserves the old behavior.

#### Affected modules

Platform, Scheduler, Runner.

---

### ✅ Type of Change

* [x] ✨ Feature (`feature`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
