### PR TITLE
feature(nixl): pipeline parallelism for prefill/decode KV-cache transfer

### DIFF
--- a/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
+++ b/tests/torch_compile/unit/v1/core/test_pd_disaggregation.py
@@ -669,6 +669,9 @@ def _build_connector_worker(
 
     vllm_config = MagicMock()
     vllm_config.cache_config = CacheConfig(block_size=block_size)
+    # _check_pp_constraints compares pipeline_parallel_size <= 1; give it a real
+    # int (MagicMock would raise TypeError). 1 == the non-PP default these tests assume.
+    vllm_config.parallel_config.pipeline_parallel_size = 1
     kv_cache_config = MagicMock()
     kv_cache_config.num_blocks = num_blocks
     if kv_cache_specs is not None:
@@ -685,6 +688,9 @@ def _build_connector_worker(
         self.kv_cache_config = kv_cache_config_
         self.kv_buffer_device = kv_buffer_device
         self._block_size = {}
+        # The real NixlConnectorWorker.__init__ sets this to None; register_kv_caches
+        # reads it after super().register_kv_caches(). Stub it so the harness matches.
+        self.xfer_handshake_metadata = None
 
     modules_patch = (
         # Mask `nixl_rbln` from sys.modules so `import nixl_rbln` raises

--- a/tests/torch_compile/unit/v1/core/test_rbln_nixl_handshake_pp.py
+++ b/tests/torch_compile/unit/v1/core/test_rbln_nixl_handshake_pp.py
@@ -1,0 +1,691 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage: RBLN NIXL PP-aware consumer handshake fan-out.
+
+Exercises RblnNixlConnectorWorker._nixl_handshake with the ZMQ side-channel and
+add_remote_agent mocked, so it needs neither a live NIXL peer nor nixl-rbln.
+"""
+
+from collections import defaultdict
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import msgspec
+import pytest
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    NixlHandshakePayload,
+)
+
+import vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.worker as W
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.worker import (
+    RblnNixlConnectorWorker,
+)
+
+
+def _encode_payload(
+    pp_rank,
+    pp_size,
+    *,
+    engine_id="eng",
+    compat="HASH",
+    layers_per_stage=1,
+    layer_names=None,
+):
+    if layer_names is None:
+        layer_names = [
+            f"layer.{pp_rank * layers_per_stage + j}" for j in range(layers_per_stage)
+        ]
+    meta = RblnNixlAgentMetadata(
+        engine_id=engine_id,
+        agent_metadata=b"agent",
+        kv_caches_base_addr=[0x1000],
+        device_id=0,
+        num_blocks=4,
+        block_lens=[8192],
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="RBLN",
+        physical_blocks_per_logical_kv_block=1,
+        pp_rank=pp_rank,
+        pp_size=pp_size,
+        registered_layer_names=list(layer_names),
+    )
+    payload = NixlHandshakePayload(
+        compatibility_hash=compat,
+        agent_metadata_bytes=msgspec.msgpack.Encoder().encode(meta),
+    )
+    return msgspec.msgpack.Encoder().encode(payload)
+
+
+class _FakeSock:
+    """ZMQ REQ stand-in: replies to (GET_META_MSG, rank) with rank's payload.
+
+    TP is 1 in these tests, so global_rank == pp_rank."""
+
+    def __init__(
+        self,
+        pp_size,
+        *,
+        engine_id="eng",
+        compat="HASH",
+        layers_per_stage=1,
+        stage_layers=None,
+    ):
+        self.pp_size = pp_size
+        self.engine_id = engine_id
+        self.compat = compat
+        self.layers_per_stage = layers_per_stage
+        # Optional per-stage layer-name lists (for uneven splits); indexed by
+        # global_rank. When None, stages advertise a uniform layers_per_stage.
+        self.stage_layers = stage_layers
+        self.queried = []
+        self._last = None
+
+    def setsockopt(self, *a):
+        pass
+
+    def send(self, msg):
+        _, rank = msgspec.msgpack.decode(msg)
+        self.queried.append(rank)
+        self._last = rank
+
+    def recv(self):
+        return _encode_payload(
+            self._last,
+            self.pp_size,
+            engine_id=self.engine_id,
+            compat=self.compat,
+            layers_per_stage=self.layers_per_stage,
+            layer_names=(
+                self.stage_layers[self._last] if self.stage_layers is not None else None
+            ),
+        )
+
+
+def _make_worker(*, tp_target_ranks=(0,), sw_ratio=None, compat="HASH"):
+    w = object.__new__(RblnNixlConnectorWorker)
+    w.use_host_buffer = True  # skip current_platform.set_device
+    w.transfer_topo = MagicMock()
+    w.transfer_topo.handshake_target_ranks.return_value = list(tp_target_ranks)
+    w.compat_hash = compat
+    w.enforce_compat_hash = True
+    w._sw_ratio = sw_ratio
+    w._remote_shard_layer_names = defaultdict(dict)
+    w._remote_pp_size = {}
+    w._overlapping_ranks = defaultdict(list)
+    # Full-model consumer: owns every producer stage's layer, so every stage
+    # overlaps (the fan-out default). _FakeSock advertises stage i as "layer.i".
+    w.local_seen_layer_names = ["layer.0", "layer.1", "layer.2"]
+    w.add_remote_agent = MagicMock(side_effect=lambda meta, rank, tps: f"agent-{rank}")
+    # Per-shard local handle building is exercised in TestShardLocalRegions;
+    # stub it here so the fan-out tests stay focused on stage enumeration.
+    w._register_shard_read_state = MagicMock()
+    return w
+
+
+@contextmanager
+def _patched_socket(sock):
+    @contextmanager
+    def fake_zmq_ctx(_type, _path):
+        yield sock
+
+    with (
+        patch.object(W, "zmq_ctx", fake_zmq_ctx),
+        patch.object(W, "make_zmq_path", lambda *a: "tcp://x"),
+        patch.object(W, "current_platform", MagicMock()),
+    ):
+        yield
+
+
+def _handshake(worker, sock, *, remote_tp_size=1, engine_id="eng"):
+    with _patched_socket(sock):
+        return worker._nixl_handshake("h", 1234, remote_tp_size, engine_id)
+
+
+class TestPpHandshakeFanout:
+    def test_single_stage_matches_base_shape(self):
+        """pp_size == 1: one shard queried, keyed by tp_rank (global_rank)."""
+        w = _make_worker()
+        sock = _FakeSock(pp_size=1)
+        result = _handshake(w, sock)
+        assert result == {0: "agent-0"}
+        assert sock.queried == [0]  # bootstrap only
+        assert w.add_remote_agent.call_count == 1
+        assert dict(w._remote_shard_layer_names["eng"]) == {0: ("layer.0",)}
+
+    def test_pp_fans_out_over_stages(self):
+        """pp_size == 2: both stages queried and registered by global_rank."""
+        w = _make_worker()
+        sock = _FakeSock(pp_size=2)
+        result = _handshake(w, sock)
+        assert result == {0: "agent-0", 1: "agent-1"}
+        # rank 0 bootstrap (reused), rank 1 queried once.
+        assert sock.queried == [0, 1]
+        ranks = sorted(c.args[1] for c in w.add_remote_agent.call_args_list)
+        assert ranks == [0, 1]
+        assert dict(w._remote_shard_layer_names["eng"]) == {
+            0: ("layer.0",),
+            1: ("layer.1",),
+        }
+        assert w._remote_pp_size["eng"] == 2
+
+    def test_bootstrap_reuses_first_query(self):
+        """The pp_rank-0 shard is queried exactly once (bootstrap reused)."""
+        w = _make_worker()
+        sock = _FakeSock(pp_size=3)
+        _handshake(w, sock)
+        assert sock.queried == [0, 1, 2]
+        assert sock.queried.count(0) == 1
+
+    def test_handshake_registers_only_overlapping_stages(self):
+        """Decode-PP: this rank owns only layer.1, so of the two producer stages
+        only stage 1 overlaps -> only it is handshaked (add_remote_agent) and
+        registered for reading. The non-overlapping stage 0 is skipped BEFORE
+        add_remote_agent so its base FA-remote build never runs (it would index
+        the local block_len_per_layer out of range under an uneven split);
+        its layer names are still recorded during enumeration."""
+        w = _make_worker()
+        w.local_seen_layer_names = ["layer.1"]  # this decode rank's band
+        sock = _FakeSock(pp_size=2)
+        result = _handshake(w, sock)
+        # Only the overlapping stage (1) is handshaked and read.
+        assert result == {1: "agent-1"}
+        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
+        assert set(w._remote_shard_layer_names["eng"]) == {0, 1}  # both enumerated
+        assert w._overlapping_ranks["eng"] == [1]
+        assert w._register_shard_read_state.call_count == 1
+
+    def test_multiple_ratio_registers_k_stages(self):
+        """prefill_pp=4, decode_pp=2 (k=2): this decode rank owns 2 producer
+        stages' layers, so only those 2 are handshaked/registered; the other
+        two non-overlapping stages are skipped before add_remote_agent."""
+        w = _make_worker()
+        w.local_seen_layer_names = ["layer.0", "layer.1"]  # this rank's band
+        sock = _FakeSock(pp_size=4)  # stages advertise layer.0..layer.3
+        _handshake(w, sock)
+        assert sorted(c.args[1] for c in w.add_remote_agent.call_args_list) == [0, 1]
+        assert w._overlapping_ranks["eng"] == [0, 1]  # only owned stages read
+        assert w._register_shard_read_state.call_count == 2
+
+    def test_symmetric_uneven_skips_larger_nonoverlapping_peer(self):
+        """Symmetric PP with an uneven layer split (e.g. 5 layers / 2 = [3, 2]):
+        this decode rank is the *smaller* last stage and owns only its own
+        layers. The peer producer stage is *larger* and does not overlap, so it
+        must be skipped entirely -- add_remote_agent (and hence the base
+        FA-remote build, which indexes the local block_len_per_layer by the
+        remote region position) never runs on it. Regression for the
+        symmetric-uneven PP4-PP4 handshake out-of-range crash."""
+        w = _make_worker()
+        # stage 0 = 3 layers (larger), stage 1 = 2 layers (this rank, smaller).
+        stage_layers = [["layer.0", "layer.1", "layer.2"], ["layer.3", "layer.4"]]
+        w.local_seen_layer_names = ["layer.3", "layer.4"]  # this rank's own stage
+        sock = _FakeSock(pp_size=2, stage_layers=stage_layers)
+        result = _handshake(w, sock)
+        # Only this rank's own (overlapping) stage is handshaked/registered; the
+        # larger non-overlapping peer (stage 0) is skipped, not crashed.
+        assert result == {1: "agent-1"}
+        assert [c.args[1] for c in w.add_remote_agent.call_args_list] == [1]
+        assert w._overlapping_ranks["eng"] == [1]
+        assert w._register_shard_read_state.call_count == 1
+
+    def test_partial_overlap_raises(self):
+        """Prefill pipeline size not an integer multiple of the decode pipeline
+        size: a producer stage's layer band straddles this decode rank's band
+        (partial overlap) -> reject."""
+        w = _make_worker()
+        # Producer: 2 stages x 2 layers -> stage0=[layer.0,layer.1],
+        # stage1=[layer.2,layer.3]. This decode rank owns a misaligned band
+        # [layer.1, layer.2], so stage0 partially overlaps (owns layer.1 only).
+        w.local_seen_layer_names = ["layer.1", "layer.2"]
+        sock = _FakeSock(pp_size=2, layers_per_stage=2)
+        with pytest.raises(RuntimeError, match="partially overlaps"):
+            _handshake(w, sock)
+
+    def test_swa_plus_pp_raises(self):
+        w = _make_worker(sw_ratio=0.5)
+        sock = _FakeSock(pp_size=2)
+        with pytest.raises(RuntimeError, match="sliding-window"):
+            _handshake(w, sock)
+
+    def test_tp_plus_pp_raises(self):
+        w = _make_worker(tp_target_ranks=(0,))
+        sock = _FakeSock(pp_size=2)
+        with pytest.raises(RuntimeError, match="tensor parallel"):
+            _handshake(w, sock, remote_tp_size=2)
+
+    def test_compat_hash_mismatch_raises(self):
+        w = _make_worker(compat="LOCAL")
+        sock = _FakeSock(pp_size=1, compat="REMOTE")
+        with pytest.raises(RuntimeError, match="compatibility hash"):
+            _handshake(w, sock)
+
+    def test_engine_id_mismatch_raises(self):
+        w = _make_worker()
+        sock = _FakeSock(pp_size=1, engine_id="other")
+        with pytest.raises(RuntimeError, match="engine ID"):
+            _handshake(w, sock, engine_id="eng")
+
+
+class TestLocalRegionIndicesForLayerNames:
+    """Name-based matching of a producer shard's layers to local region
+    indices."""
+
+    @staticmethod
+    def _worker(local_names):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = list(local_names)
+        return w
+
+    def test_contiguous_shard(self):
+        w = self._worker(["l0", "l1", "l2", "l3"])
+        assert w._local_region_indices_for_layer_names(["l2", "l3"]) == [2, 3]
+        assert w._local_region_indices_for_layer_names(["l0", "l1"]) == [0, 1]
+
+    def test_full_model_consumer_maps_all(self):
+        names = [f"l{i}" for i in range(4)]
+        w = self._worker(names)
+        assert w._local_region_indices_for_layer_names(names) == [0, 1, 2, 3]
+
+    def test_repeated_names_resolved_by_occurrence(self):
+        """HMA pools can register a name more than once; match by occurrence."""
+        w = self._worker(["a", "a", "b"])
+        assert w._local_region_indices_for_layer_names(["a", "b", "a"]) == [0, 2, 1]
+
+    def test_zero_overlap_returns_empty(self):
+        """A producer stage entirely outside this rank's band -> empty: the
+        stage is read by whichever rank owns it, not here."""
+        w = self._worker(["l0", "l1"])
+        assert w._local_region_indices_for_layer_names(["l2"]) == []
+
+    def test_decode_shard_maps_only_owned_band(self):
+        """Decode-PP rank owns layers [l4..l7]: producer stages outside its band
+        map empty; stages inside map to this rank's local indices."""
+        w = self._worker(["l4", "l5", "l6", "l7"])
+        assert w._local_region_indices_for_layer_names(["l0", "l1"]) == []
+        assert w._local_region_indices_for_layer_names(["l4", "l5"]) == [0, 1]
+        assert w._local_region_indices_for_layer_names(["l6", "l7"]) == [2, 3]
+
+
+class TestShardLocalRegions:
+    """Layer-name -> local region-index expansion and the per-shard local
+    xfer handle (region subset)."""
+
+    @staticmethod
+    def _worker(local_names, num_regions):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = list(local_names)
+        w.num_regions = num_regions
+        return w
+
+    def test_regions_per_layer(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
+        assert w._regions_per_layer() == 2  # K/V split
+        w2 = self._worker(["l0", "l1"], num_regions=2)
+        assert w2._regions_per_layer() == 1
+
+    def test_regions_per_layer_non_divisible_raises(self):
+        w = self._worker(["l0", "l1", "l2"], num_regions=8)
+        with pytest.raises(AssertionError, match="not divisible"):
+            w._regions_per_layer()
+
+    def test_shard_local_region_ids_kv_split(self):
+        """rpl=2: layer L -> regions [2L, 2L+1] (layer-major)."""
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)
+        assert w._shard_local_region_ids(("l2", "l3")) == [4, 5, 6, 7]
+        assert w._shard_local_region_ids(("l0",)) == [0, 1]
+
+    def test_shard_local_region_ids_no_split(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=4)
+        assert w._shard_local_region_ids(("l1", "l2")) == [1, 2]
+
+    def test_register_shard_local_xfer_handler_covers_subset(self):
+        w = self._worker(["l0", "l1", "l2", "l3"], num_regions=8)  # rpl=2
+        w.block_size = 16
+        w.num_blocks = 4
+        w.device_id = 0
+        w.engine_id = "eng"
+        w.tp_rank = 0
+        w._has_mamba = False
+        w.nixl_memory_type = "DRAM"
+        w.kv_caches_base_addr = {"eng": {0: [1000 * i for i in range(8)]}}
+        w.block_len_per_layer = [64] * 8
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.is_kv_layout_blocks_first = False
+        w.get_backend_aware_kv_block_len = MagicMock(return_value=64)
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.prep_xfer_dlist.return_value = 42
+
+        handle, blocks = w._register_shard_local_xfer_handler(16, ("l2", "l3"))
+
+        assert handle == 42
+        # shard regions [4,5,6,7] x num_blocks 4 = 16 descriptors.
+        assert len(blocks) == 16
+        # first desc: region 4 base addr (4000), block 0.
+        assert blocks[0] == (4000, 64, 0)
+        # block 1 of region 4: base + 1*stride(64).
+        assert blocks[1] == (4000 + 64, 64, 0)
+        # regions used are exactly the shard's (no addr below 4000).
+        assert min(a for a, _, _ in blocks) == 4000
+
+
+class TestShardReadPath:
+    """Per-stage read loop + shard descriptor ids."""
+
+    def test_get_block_descs_ids_for_shard(self):
+        """0-based descs over the shard's regions; group_id picks the block
+        group. Single group -> region_id * num_blocks + block_ids[0]."""
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._shard_region_group_ids = {("eng", 1): (0, 0, 0, 0)}  # 4 regions, group 0
+        descs = w._get_block_descs_ids_for_shard(
+            "eng", 1, num_blocks=10, block_ids=[[2, 5]]
+        )
+        # region r contributes r*10 + [2,5]: [2,5, 12,15, 22,25, 32,35]
+        assert list(descs) == [2, 5, 12, 15, 22, 25, 32, 35]
+
+    def test_get_block_descs_ids_for_shard_empty_group(self):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._shard_region_group_ids = {("eng", 0): (0, 0)}
+        descs = w._get_block_descs_ids_for_shard("eng", 0, num_blocks=4, block_ids=[[]])
+        assert descs.size == 0
+
+    @staticmethod
+    def _read_worker(pp_size):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w._remote_pp_size = {"eng": pp_size}
+        # Full-model decode: every stage overlaps. Decode-PP subsets this (see
+        # test_reads_only_overlapping_stages).
+        w._overlapping_ranks = {"eng": list(range(pp_size))}
+        w._has_mamba = False  # non-Mamba scope: _apply_prefix_caching end-trims
+        w.world_size = 1
+        w.num_blocks = 8
+        w.dst_num_blocks = {"eng": 8}
+        w._recving_transfers = defaultdict(list)
+        # single group, 2 regions per shard
+        w._shard_region_group_ids = {("eng", r): (0, 0) for r in range(pp_size)}
+        w.src_xfer_handles_by_remote = {("eng", r, 16): 100 + r for r in range(pp_size)}
+        w.dst_xfer_side_handles = {"eng": {r: 200 + r for r in range(pp_size)}}
+        w._remote_agents = {"eng": {r: f"agent{r}" for r in range(pp_size)}}
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(
+            remote_tp_size=1, remote_block_size=16, remote_physical_blocks_per_logical=1
+        )
+        topo.tp_ratio.return_value = 1
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        w._logical_to_remote_kernel_block_ids = lambda ids, _n: ids
+        w.nixl_wrapper = MagicMock()
+        w.nixl_wrapper.make_prepped_xfer.side_effect = lambda *a, **k: object()
+        return w
+
+    def _meta(self, local_ids, remote_ids):
+        remote = MagicMock()
+        remote.engine_id = "eng"
+        remote.request_id = "r0"
+        remote.block_ids = remote_ids
+        meta = MagicMock()
+        meta.remote = remote
+        meta.local_physical_block_ids = local_ids
+        return meta
+
+    def test_reads_every_stage(self):
+        """pp_size=2 -> one prepped READ per stage, each with its own shard
+        handles; the request accrues one transfer handle per stage."""
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # stage 0 uses local handle 100 / remote 200; stage 1 -> 101 / 201.
+        calls = w.nixl_wrapper.make_prepped_xfer.call_args_list
+        assert calls[0].args[1] == 100 and calls[0].args[3] == 200
+        assert calls[1].args[1] == 101 and calls[1].args[3] == 201
+        # completion: one handle per stage -> req done only when both finish.
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_prefix_hit_notifies_each_stage_no_read(self):
+        """Full prefix hit (empty local list): no read, one notif per stage."""
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 0
+        assert w.nixl_wrapper.send_notif.call_count == 2
+        assert len(w._recving_transfers["r0"]) == 0
+
+    def test_partial_prefix_hit_trims_remote_per_stage(self):
+        """Partial hit: D allocated only the uncached suffix (1 block) while the
+        remote prompt is 3 blocks, so the remote is end-trimmed to the last
+        block -> local/remote desc counts match per stage and the read fires."""
+        w = self._read_worker(pp_size=2)
+        w._read_blocks_for_req("r0", self._meta([[7]], [[3, 4, 7]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        for c in w.nixl_wrapper.make_prepped_xfer.call_args_list:
+            local_descs, remote_descs = c.args[2], c.args[4]
+            assert len(local_descs) == len(remote_descs)
+            # 2 regions per shard x 1 (trimmed) block = 2 descriptors.
+            assert len(remote_descs) == 2
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_reads_only_overlapping_stages(self):
+        """Decode-PP (m=4, n=2): this rank owns 2 of the 4 producer stages, so
+        it READs only its overlapping stages; the other two are neither read
+        nor notified (another decode rank owns and notifies them)."""
+        w = self._read_worker(pp_size=4)
+        w._overlapping_ranks = {"eng": [0, 1]}  # this rank's band = stages 0,1
+        w._read_blocks_for_req("r0", self._meta([[1, 2]], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 2
+        # only stages 0,1 local handles used (100, 101); never 102/103.
+        used = {c.args[1] for c in w.nixl_wrapper.make_prepped_xfer.call_args_list}
+        assert used == {100, 101}
+        assert w.nixl_wrapper.send_notif.call_count == 0
+        assert len(w._recving_transfers["r0"]) == 2
+
+    def test_prefix_hit_notifies_only_overlapping_stages(self):
+        """Full prefix hit under decode-PP: notify only this rank's stages."""
+        w = self._read_worker(pp_size=4)
+        w._overlapping_ranks = {"eng": [0, 1]}
+        w._read_blocks_for_req("r0", self._meta([], [[3, 4]]))
+        assert w.nixl_wrapper.make_prepped_xfer.call_count == 0
+        assert w.nixl_wrapper.send_notif.call_count == 2  # only stages 0,1
+        notified = {c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list}
+        assert notified == {"agent0", "agent1"}
+
+
+class TestValidateRemoteAgentHandshake:
+    """PP-aware handshake validation. The base
+    ``_validate_remote_agent_handshake`` asserts matching P/D region counts
+    (`len(remote.kv_caches_base_addr) == len(self.block_len_per_layer)`), which
+    a layer-sharded PP producer necessarily violates against a full-model
+    consumer. Regression for that end-to-end AssertionError."""
+
+    @staticmethod
+    def _consumer(*, num_layers=28, dst_num_blocks=8):
+        # Full-model host-bounce consumer: num_regions = num_layers * 2 (K/V),
+        # so regions-per-layer = 2.
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.local_seen_layer_names = [f"l{i}" for i in range(num_layers)]
+        w.num_regions = num_layers * 2
+        w.block_len_per_layer = [64] * (num_layers * 2)
+        w.dst_num_blocks = {"eng": dst_num_blocks}
+        topo = MagicMock()
+        topo.get_engine_info.return_value = MagicMock(remote_tp_size=1)
+        topo.block_size_ratio.return_value = 1
+        w.transfer_topo = topo
+        return w
+
+    @staticmethod
+    def _meta(*, pp_size, n_regions, num_blocks=8, block_size=16):
+        m = MagicMock()
+        m.pp_size = pp_size
+        m.engine_id = "eng"
+        m.kv_caches_base_addr = [1000 * i for i in range(n_regions)]
+        m.num_blocks = num_blocks
+        m.block_size = block_size
+        return m
+
+    def test_pp_shard_wellformed_passes(self):
+        # 28-layer model, PP2 -> each stage owns 14 layers = 28 regions,
+        # a valid sub-multiple of the local 56. Base assert would fire (28!=56).
+        w = self._consumer(num_layers=28)
+        w._validate_remote_agent_handshake(
+            self._meta(pp_size=2, n_regions=28), remote_tp_size=1
+        )  # no raise
+
+    def test_pp_shard_region_count_not_multiple_of_rpl_raises(self):
+        w = self._consumer(num_layers=28)  # regions-per-layer = 2
+        with pytest.raises(AssertionError, match="sub-multiple"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=27), remote_tp_size=1
+            )
+
+    def test_pp_shard_larger_than_full_model_raises(self):
+        w = self._consumer(num_layers=28)  # full model = 56 regions
+        with pytest.raises(AssertionError, match="sub-multiple"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=58), remote_tp_size=1
+            )
+
+    def test_pp_with_tp_raises(self):
+        w = self._consumer()
+        w.transfer_topo.get_engine_info.return_value = MagicMock(remote_tp_size=2)
+        with pytest.raises(AssertionError, match="TP=1"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28), remote_tp_size=2
+            )
+
+    def test_pp_block_size_mismatch_raises(self):
+        w = self._consumer()
+        w.transfer_topo.block_size_ratio.return_value = 2
+        with pytest.raises(AssertionError, match="block sizes"):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28), remote_tp_size=1
+            )
+
+    def test_pp_num_blocks_mismatch_raises(self):
+        w = self._consumer(dst_num_blocks=8)
+        with pytest.raises(AssertionError):
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=2, n_regions=28, num_blocks=16), remote_tp_size=1
+            )
+
+    def test_non_pp_delegates_to_base(self):
+        # pp_size == 1 must fall through to the upstream validation untouched.
+        w = self._consumer()
+        base = RblnNixlConnectorWorker.__bases__[0]
+        with patch.object(base, "_validate_remote_agent_handshake") as base_val:
+            w._validate_remote_agent_handshake(
+                self._meta(pp_size=1, n_regions=56), remote_tp_size=1
+            )
+        base_val.assert_called_once()
+
+
+class TestPpConstraints:
+    """Reject PP + unsupported features early."""
+
+    @staticmethod
+    def _worker(*, pp_size, cross_layers=False, has_mamba=False, sw_ratio=None):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = pp_size
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.cross_layers_blocks = cross_layers
+        w._has_mamba = has_mamba
+        w._sw_ratio = sw_ratio
+        return w
+
+    def test_no_pp_is_noop(self):
+        # pp_size == 1: even with otherwise-unsupported features, no raise.
+        self._worker(
+            pp_size=1, cross_layers=True, has_mamba=True, sw_ratio=2
+        )._check_pp_constraints()
+
+    def test_plain_pp_ok(self):
+        self._worker(pp_size=2)._check_pp_constraints()
+
+    def test_cross_layers_pp_raises(self):
+        with pytest.raises(RuntimeError, match="cross-layer-blocks"):
+            self._worker(pp_size=2, cross_layers=True)._check_pp_constraints()
+
+    def test_mamba_pp_raises(self):
+        with pytest.raises(RuntimeError, match="Mamba"):
+            self._worker(pp_size=2, has_mamba=True)._check_pp_constraints()
+
+    def test_swa_pp_raises(self):
+        with pytest.raises(RuntimeError, match="sliding-window"):
+            self._worker(pp_size=2, sw_ratio=2)._check_pp_constraints()
+
+
+class TestPublishPpHandshakeMetadata:
+    """The shared producer-side helper used by BOTH the D2D and the
+    host-bounce paths, so PP metadata is advertised regardless of transport."""
+
+    @staticmethod
+    def _base_meta():
+        return NixlAgentMetadata(
+            engine_id="eng",
+            agent_metadata=b"agent",
+            kv_caches_base_addr=[0x1000, 0x2000],
+            device_id=0,
+            num_blocks=4,
+            block_lens=[8192, 8192],
+            kv_cache_layout="HND",
+            block_size=16,
+            ssm_sizes=(0, 0),
+            attn_backend_name="RBLN",
+            physical_blocks_per_logical_kv_block=1,
+        )
+
+    def _publish(self, *, pp_rank, pp_size, layer_names):
+        w = object.__new__(RblnNixlConnectorWorker)
+        w.compat_hash = "BASE"
+        # _check_pp_constraints reads these; a plain PP producer passes.
+        w.vllm_config = MagicMock()
+        w.vllm_config.parallel_config.pipeline_parallel_size = pp_size
+        w.transfer_topo = MagicMock()
+        w.transfer_topo.cross_layers_blocks = False
+        w._has_mamba = False
+        w._sw_ratio = None
+        pp_group = MagicMock()
+        pp_group.rank_in_group = pp_rank
+        pp_group.world_size = pp_size
+        with patch.object(W, "get_pp_group", return_value=pp_group):
+            w._publish_pp_handshake_metadata(self._base_meta(), layer_names)
+        return w
+
+    def test_wraps_base_and_folds_compat(self):
+        w = self._publish(pp_rank=1, pp_size=2, layer_names=["l7", "l8"])
+        # compat hash folded with the RBLN PP version and mirrored into payload.
+        assert w.compat_hash == rbln_pp_compat_hash("BASE")
+        assert w.xfer_handshake_metadata.compatibility_hash == w.compat_hash
+        decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            w.xfer_handshake_metadata.agent_metadata_bytes
+        )
+        # base fields preserved ...
+        assert decoded.engine_id == "eng"
+        assert decoded.block_lens == [8192, 8192]
+        assert decoded.kv_caches_base_addr == [0x1000, 0x2000]
+        # ... and PP fields populated.
+        assert (decoded.pp_rank, decoded.pp_size) == (1, 2)
+        assert decoded.registered_layer_names == ["l7", "l8"]
+
+    def test_single_stage_defaults(self):
+        """pp_size == 1 still folds compat but advertises no-PP layer fields."""
+        w = self._publish(pp_rank=0, pp_size=1, layer_names=["l0"])
+        decoded = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            w.xfer_handshake_metadata.agent_metadata_bytes
+        )
+        assert (decoded.pp_rank, decoded.pp_size) == (0, 1)

--- a/tests/torch_compile/unit/v1/core/test_rbln_nixl_metadata.py
+++ b/tests/torch_compile/unit/v1/core/test_rbln_nixl_metadata.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for the RBLN NIXL PP metadata extension.
+
+Self-contained: exercises only ``rbln_nixl.metadata`` (base vLLM NIXL +
+msgspec + hash), so it does not require the ``nixl-rbln`` install or a worker.
+"""
+
+import msgspec
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RBLN_NIXL_PP_VERSION,
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
+
+_BASE_FIELDS = dict(
+    engine_id="engine-0",
+    agent_metadata=b"agent-bytes",
+    kv_caches_base_addr=[0x1000, 0x2000],
+    device_id=0,
+    num_blocks=64,
+    block_lens=[8192, 8192],
+    kv_cache_layout="HND",
+    block_size=16,
+    ssm_sizes=(0, 0),
+    attn_backend_name="RBLN_FLASH_ATTN",
+    physical_blocks_per_logical_kv_block=1,
+)
+
+
+def _make(**pp):
+    return RblnNixlAgentMetadata(**_BASE_FIELDS, **pp)
+
+
+class TestRblnNixlAgentMetadata:
+    def test_defaults_are_single_stage(self):
+        """Omitting PP fields yields the pp_size==1 (no-PP) values."""
+        m = _make()
+        assert (m.pp_rank, m.pp_size) == (0, 1)
+        assert m.registered_layer_names == []
+
+    def test_roundtrip_preserves_pp_fields(self):
+        """msgspec encode→decode with the RBLN type preserves PP descriptors."""
+        m = _make(
+            pp_rank=1,
+            pp_size=2,
+            registered_layer_names=["model.layers.14", "model.layers.15"],
+        )
+        enc = msgspec.msgpack.Encoder().encode(m)
+        back = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(enc)
+        assert back == m
+        assert back.pp_rank == 1
+        assert back.pp_size == 2
+        assert back.registered_layer_names == [
+            "model.layers.14",
+            "model.layers.15",
+        ]
+
+    def test_base_consumer_ignores_pp_fields(self):
+        """A blob encoded with the RBLN type decodes cleanly as the base
+        ``NixlAgentMetadata`` (PP fields ignored) — backward compatible."""
+        enc = msgspec.msgpack.Encoder().encode(_make(pp_rank=1, pp_size=2))
+        base = msgspec.msgpack.Decoder(NixlAgentMetadata).decode(enc)
+        assert base.engine_id == "engine-0"
+        assert base.num_blocks == 64
+        assert base.block_lens == [8192, 8192]
+        assert not hasattr(base, "pp_rank")
+
+    def test_registered_layer_names_order_preserved(self):
+        names = [f"model.layers.{i}" for i in range(14, 28)]
+        m = _make(pp_rank=1, pp_size=2, registered_layer_names=names)
+        back = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            msgspec.msgpack.Encoder().encode(m)
+        )
+        assert back.registered_layer_names == names
+
+
+class TestRblnPpCompatHash:
+    def test_deterministic(self):
+        assert rbln_pp_compat_hash("BASE") == rbln_pp_compat_hash("BASE")
+
+    def test_differs_from_base(self):
+        """Folding the PP version must change the hash, so a PP-aware producer
+        and a PP-unaware peer (base hash) do not match."""
+        assert rbln_pp_compat_hash("BASE") != "BASE"
+
+    def test_distinguishes_base_hashes(self):
+        assert rbln_pp_compat_hash("hash-a") != rbln_pp_compat_hash("hash-b")
+
+    def test_version_is_folded(self, monkeypatch):
+        """Bumping RBLN_NIXL_PP_VERSION changes the hash (gates schema drift)."""
+        from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl import (
+            metadata as md,
+        )
+
+        h1 = md.rbln_pp_compat_hash("BASE")
+        monkeypatch.setattr(md, "RBLN_NIXL_PP_VERSION", RBLN_NIXL_PP_VERSION + 1)
+        assert md.rbln_pp_compat_hash("BASE") != h1

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker_handshake.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker_handshake.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for RBLNWorker.get_kv_connector_handshake_metadata.
+
+Verifies the handshake dict is keyed by a flat intra-engine global rank
+(pp_rank * tp_size + tp_rank) so pipeline-parallel stages don't collide when
+EngineCore merges the per-worker dicts, while non-PP behavior (key == tp_rank)
+is unchanged.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import vllm_rbln.v1.worker.rbln_worker as rw
+from vllm_rbln.v1.worker.rbln_worker import RBLNWorker
+
+
+def _handshake(
+    *,
+    pp_rank,
+    tp_rank,
+    tp_size,
+    has_group=True,
+    metadata="META",
+):
+    """Call get_kv_connector_handshake_metadata with the parallel-state and
+    KV-transfer module functions mocked."""
+    worker = object.__new__(RBLNWorker)
+    tp_group = MagicMock()
+    tp_group.rank_in_group = tp_rank
+    tp_group.world_size = tp_size
+    pp_group = MagicMock()
+    pp_group.rank_in_group = pp_rank
+    connector = MagicMock()
+    connector.get_handshake_metadata.return_value = metadata
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(rw, "has_kv_transfer_group", return_value=has_group)
+        )
+        stack.enter_context(
+            patch.object(rw, "get_kv_transfer_group", return_value=connector)
+        )
+        stack.enter_context(patch.object(rw, "get_tp_group", return_value=tp_group))
+        stack.enter_context(patch.object(rw, "get_pp_group", return_value=pp_group))
+        return worker.get_kv_connector_handshake_metadata()
+
+
+class TestHandshakeMetadataKeying:
+    def test_non_pp_key_is_tp_rank(self):
+        """pp_rank == 0 → global_rank == tp_rank (no regression)."""
+        assert _handshake(pp_rank=0, tp_rank=0, tp_size=1) == {0: "META"}
+        assert _handshake(pp_rank=0, tp_rank=2, tp_size=4) == {2: "META"}
+
+    def test_pp_stage_offset(self):
+        """global_rank = pp_rank * tp_size + tp_rank."""
+        # TP=1: each PP stage gets its pp_rank as the key.
+        assert _handshake(pp_rank=0, tp_rank=0, tp_size=1) == {0: "META"}
+        assert _handshake(pp_rank=1, tp_rank=0, tp_size=1) == {1: "META"}
+        # TP=2, PP=2: (pp,tp) -> pp*2+tp.
+        assert _handshake(pp_rank=0, tp_rank=1, tp_size=2) == {1: "META"}
+        assert _handshake(pp_rank=1, tp_rank=0, tp_size=2) == {2: "META"}
+        assert _handshake(pp_rank=1, tp_rank=1, tp_size=2) == {3: "META"}
+
+    def test_pp_stages_do_not_collide_on_merge(self):
+        """Merging per-stage dicts (EngineCore content.update) preserves every
+        stage — the collision that {tp_rank: ...} caused under PP is gone."""
+        merged = {}
+        for pp_rank in range(2):  # pp_size=2, tp_size=1 -> keys 0 and 1
+            merged.update(
+                _handshake(
+                    pp_rank=pp_rank,
+                    tp_rank=0,
+                    tp_size=1,
+                    metadata=f"stage{pp_rank}",
+                )
+            )
+        assert merged == {0: "stage0", 1: "stage1"}
+
+    def test_returns_none_without_kv_transfer_group(self):
+        assert _handshake(pp_rank=0, tp_rank=0, tp_size=1, has_group=False) is None
+
+    def test_returns_none_when_connector_has_no_metadata(self):
+        assert _handshake(pp_rank=1, tp_rank=0, tp_size=1, metadata=None) is None

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/metadata.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RBLN-specific NIXL metadata: pipeline-parallel (PP) extensions.
+
+Isolated from upstream ``NixlAgentMetadata`` so the base struct and its
+compatibility hash stay untouched. Both P and D are RBLN, so there is no
+cross-vendor interop concern -- a private RBLN version tag folded into the NIXL
+compatibility hash (``rbln_pp_compat_hash``) is enough to gate PP-aware peers
+against mismatched ones.
+
+Under pipeline parallelism the producer advertises, per (pp_rank, tp_rank)
+shard, the registered KV-cache layer names it owns. After the side-channel
+handshake the consumer matches each producer stage's shard to its own local KV
+regions by name (the owned layer range is derived locally on each side, not sent
+over the wire).
+"""
+
+from dataclasses import dataclass, field
+
+from vllm.config.utils import hash_factors
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlAgentMetadata
+
+# Bump on any incompatible change to the RBLN PP metadata schema/semantics.
+# Folded into the NIXL compatibility hash so a PP-aware producer and a
+# mismatched consumer fail the handshake cleanly (both ends are RBLN).
+RBLN_NIXL_PP_VERSION: int = 1
+
+
+@dataclass
+class RblnNixlAgentMetadata(NixlAgentMetadata):
+    """``NixlAgentMetadata`` + this producer stage's PP identity and the layer
+    names it owns.
+
+    New fields default to the ``pp_size == 1`` (no-PP) values so a blob decoded
+    by the base/older consumer (which uses ``NixlAgentMetadata`` and ignores the
+    extra fields) degrades to single-stage behavior. A PP-aware consumer decodes
+    with this type to read them and matches ``registered_layer_names`` against
+    its own local layers to place each shard's regions.
+    """
+
+    pp_rank: int = 0
+    pp_size: int = 1
+    # Registered KV-cache layer names, ordered as kv_caches_base_addr / block_lens.
+    registered_layer_names: list[str] = field(default_factory=list)
+
+
+def rbln_pp_compat_hash(base_hash: str) -> str:
+    """Fold the RBLN PP schema version into the upstream NIXL compat hash.
+
+    Keeps PP-aware RBLN peers from handshaking with PP-unaware / mismatched
+    ones without touching upstream ``compute_nixl_compatibility_hash``.
+    """
+    return hash_factors(
+        {"base": base_hash, "rbln_nixl_pp_version": RBLN_NIXL_PP_VERSION}
+    )

--- a/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
+++ b/vllm_rbln/distributed/kv_transfer/kv_connector/v1/rbln_nixl/worker.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import msgspec
 import numpy as np
 import rebel
 import torch
+import zmq
 from rebel.kv_cache import aligned_tensor
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
@@ -33,12 +35,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    GET_META_MSG,
     NixlHandshakePayload,
     compute_nixl_compatibility_hash,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     compute_tp_mapping,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import zmq_ctx
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import make_zmq_path
 from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
@@ -46,9 +53,14 @@ from vllm.v1.kv_cache_interface import (
 )
 
 import vllm_rbln.envs as envs
+from vllm_rbln.distributed.kv_transfer.kv_connector.v1.rbln_nixl.metadata import (
+    RblnNixlAgentMetadata,
+    rbln_pp_compat_hash,
+)
 from vllm_rbln.logger import init_logger
 
 if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import ReqMeta
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
@@ -67,6 +79,9 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
     layer (kernel granularity), whose `cache.shape[0]` mismatches
     `num_blocks`. Non-disagg serving is unaffected.
     """
+
+    compat_hash: str | None
+    xfer_handshake_metadata: NixlHandshakePayload | None
 
     def __init__(
         self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
@@ -108,6 +123,27 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
         self.use_host_buffer = self.kv_buffer_device == "cpu"
 
         self._pending_kv_caches: dict[str, torch.Tensor] | None = None
+
+        # --- Pipeline-parallel (PP) P/D state (empty / inert for pp_size == 1) ---
+        # Per remote producer shard, the ordered KV-cache layer names it owns,
+        # keyed by engine_id -> global_rank (= pp_rank * tp_size + tp_rank,
+        # == pp_rank when tensor parallelism is off).
+        self._remote_shard_layer_names: defaultdict[str, dict[int, tuple[str, ...]]] = (
+            defaultdict(dict)
+        )
+        # engine_id -> producer pp_size (discovered at handshake).
+        self._remote_pp_size: dict[str, int] = {}
+        # engine_id -> the producer stages (flat global ranks) whose layers this
+        # rank owns; drives _read_blocks_for_req.
+        self._overlapping_ranks: defaultdict[str, list[int]] = defaultdict(list)
+        # Per producer shard, a local xfer dlist scoped to that shard's local
+        # region subset, keyed by (engine_id, global_rank, block_size); and the
+        # shard's per-region KV-group ids, keyed by (engine_id, global_rank).
+        self.src_xfer_handles_by_remote: dict[tuple[str, int, int], int] = {}
+        self._shard_region_group_ids: dict[tuple[str, int], tuple[int, ...]] = {}
+        # Ordered local KV-cache layer names (one per layer), captured at
+        # register_kv_caches.
+        self.local_seen_layer_names: list[str] = []
 
         # Pin to logical values. Upstream would otherwise multiply by the
         # attention backend's kernel ratio, which doesn't reflect per-spec
@@ -168,6 +204,10 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
         fall straight through to upstream's UCX-backed registration —
         the host xfer buffers are plain DRAM in either case.
         """
+        # Capture the ordered local layer names before any deferral so the PP
+        # metadata publish (and the consumer-side name->region matching) can
+        # use them; the D2D path re-uses these at finalize time.
+        self.local_seen_layer_names = list(kv_caches.keys())
         if self.kv_buffer_device == "rbln":
             self._pending_kv_caches = kv_caches
             logger.info(
@@ -181,6 +221,13 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
 
             nixl_rbln.ensure_rbln_backend(self.nixl_wrapper, device_id=0)
         super().register_kv_caches(kv_caches)
+        # Re-wrap the base-published handshake metadata with this stage's PP
+        # identity + owned layer names (no-op degrade for pp_size == 1).
+        if self.xfer_handshake_metadata is not None:
+            base_agent_metadata = msgspec.msgpack.Decoder(NixlAgentMetadata).decode(
+                self.xfer_handshake_metadata.agent_metadata_bytes
+            )
+            self._publish_pp_handshake_metadata(base_agent_metadata, kv_caches.keys())
 
     def finalize_kv_cache_registration(self) -> None:
         """Run the deferred D2D registration. No-op on host-bounce and
@@ -402,11 +449,10 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
                 self._physical_blocks_per_logical_kv_block
             ),
         )
-        assert self.compat_hash is not None
-        encoder = msgspec.msgpack.Encoder()
-        self.xfer_handshake_metadata = NixlHandshakePayload(
-            compatibility_hash=self.compat_hash,
-            agent_metadata_bytes=encoder.encode(agent_metadata),
+        # Publish the handshake metadata wrapped with this stage's PP identity
+        # and owned layer names (degrades to no-PP for pp_size == 1).
+        self._publish_pp_handshake_metadata(
+            agent_metadata, self.device_kv_caches.keys()
         )
 
     # ------------------------------------------------------------------
@@ -446,10 +492,20 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
     def register_local_xfer_handler(
         self,
         block_size: int,
+        *,
+        registered_layer_names: tuple[str, ...] | list[str] | None = None,
     ) -> tuple[int, list[tuple[int, int, int]]]:
         if self._sw_ratio is None:
-            # No SWA view opt: upstream's Full-only desc layout applies.
-            return super().register_local_xfer_handler(block_size)
+            if registered_layer_names is None:
+                # No SWA view opt, no PP shard: upstream's Full-only layout.
+                return super().register_local_xfer_handler(block_size)
+            # PP shard — register only this producer stage's local regions.
+            return self._register_shard_local_xfer_handler(
+                block_size, registered_layer_names
+            )
+        assert registered_layer_names is None, (
+            "RBLN NIXL: SWA view-opt is not supported with pipeline parallelism"
+        )
         assert self.transfer_topo is not None
         assert not self.transfer_topo.is_kv_layout_blocks_first, (
             "RBLN NIXL connector only supports FA layout (K and V in "
@@ -663,3 +719,414 @@ class RblnNixlConnectorWorker(NixlConnectorWorker):
             group_arr = np.asarray(group)[None, :]
             all_descs.append((region_ids * num_blocks + group_arr + offset).flatten())
         return np.concatenate(all_descs) if all_descs else np.empty(0, dtype=int)
+
+    # ------------------------------------------------------------------
+    # Pipeline-parallel (PP) P/D over NIXL
+    # ------------------------------------------------------------------
+    #
+    # Under sync-scheduling PP the producer runs pipeline_parallel_size
+    # stages, each owning a contiguous band of layers. Every stage
+    # advertises its (pp_rank, tp_rank) shard and the KV-cache layer names
+    # it registered; the consumer matches each shard to its own local KV
+    # regions BY NAME (the owned layer range is derived locally on each
+    # side, never sent over the wire) and reads each overlapping shard with
+    # a shard-scoped local/remote descriptor pair. All of this collapses to
+    # the upstream single-stage path for pp_size == 1.
+
+    def _check_pp_constraints(self) -> None:
+        if self.vllm_config.parallel_config.pipeline_parallel_size <= 1:
+            return
+        assert self.transfer_topo is not None
+        if self.transfer_topo.cross_layers_blocks:
+            raise RuntimeError(
+                "RBLN NIXL: cross-layer-blocks mode is not supported with "
+                "pipeline_parallel_size > 1."
+            )
+        if self._has_mamba:
+            raise RuntimeError(
+                "RBLN NIXL: hybrid (Mamba/SSM) models are not supported with "
+                "pipeline_parallel_size > 1 over NIXL P/D."
+            )
+        if self._sw_ratio is not None:
+            raise RuntimeError(
+                "RBLN NIXL: sliding-window view-opt (VLLM_RBLN_NIXL_SWA_VIEW_OPT) "
+                "is not supported with pipeline_parallel_size > 1."
+            )
+
+    def _publish_pp_handshake_metadata(
+        self, base_meta: NixlAgentMetadata, registered_layer_names
+    ) -> None:
+        self._check_pp_constraints()
+        pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+        pp_rank = get_pp_group().rank_in_group if pp_size > 1 else 0
+        pp_meta = RblnNixlAgentMetadata(
+            engine_id=base_meta.engine_id,
+            agent_metadata=base_meta.agent_metadata,
+            device_id=base_meta.device_id,
+            kv_caches_base_addr=base_meta.kv_caches_base_addr,
+            num_blocks=base_meta.num_blocks,
+            block_lens=base_meta.block_lens,
+            kv_cache_layout=base_meta.kv_cache_layout,
+            block_size=base_meta.block_size,
+            ssm_sizes=base_meta.ssm_sizes,
+            attn_backend_name=base_meta.attn_backend_name,
+            physical_blocks_per_logical_kv_block=(
+                base_meta.physical_blocks_per_logical_kv_block
+            ),
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+            registered_layer_names=list(registered_layer_names),
+        )
+        base_hash = self.compat_hash
+        assert base_hash is not None
+        self.compat_hash = rbln_pp_compat_hash(base_hash)
+        self.xfer_handshake_metadata = NixlHandshakePayload(
+            compatibility_hash=self.compat_hash,
+            agent_metadata_bytes=msgspec.msgpack.Encoder().encode(pp_meta),
+        )
+
+    def _query_agent_meta(
+        self, sock: "zmq.Socket", remote_rank: int, expected_engine_id: str
+    ) -> RblnNixlAgentMetadata:
+        sock.send(msgspec.msgpack.encode((GET_META_MSG, remote_rank)))
+        handshake_payload = msgspec.msgpack.Decoder(NixlHandshakePayload).decode(
+            sock.recv()
+        )
+        assert self.compat_hash is not None
+        if (
+            self.enforce_compat_hash
+            and handshake_payload.compatibility_hash != self.compat_hash
+        ):
+            raise RuntimeError(
+                "NIXL compatibility hash mismatch "
+                f"(local={self.compat_hash}, "
+                f"remote={handshake_payload.compatibility_hash}). Prefill and "
+                "decode instances have incompatible configurations."
+            )
+        metadata = msgspec.msgpack.Decoder(RblnNixlAgentMetadata).decode(
+            handshake_payload.agent_metadata_bytes
+        )
+        if metadata.engine_id != expected_engine_id:
+            raise RuntimeError(
+                "Remote NIXL agent engine ID mismatch. "
+                f"Expected {expected_engine_id}, received {metadata.engine_id}."
+            )
+        return metadata
+
+    def _nixl_handshake(
+        self,
+        host: str,
+        port: int,
+        remote_tp_size: int,
+        expected_engine_id: str,
+    ) -> dict[int, str]:
+        # Background thread needs a device context (see base _nixl_handshake).
+        if not self.use_host_buffer:
+            current_platform.set_device(self.device_id)
+
+        assert self.transfer_topo is not None
+        p_remote_tp_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
+        path = make_zmq_path("tcp", host, port)
+        remote_rank_to_agent_name: dict[int, str] = {}
+
+        with zmq_ctx(zmq.REQ, path) as sock:
+            sock.setsockopt(zmq.RCVTIMEO, 5000)  # ms; avoid hang on dead server
+
+            # Bootstrap: the first shard (pp_rank 0) advertises pp_size.
+            first_rank = p_remote_tp_ranks[0]
+            metas = {
+                first_rank: self._query_agent_meta(sock, first_rank, expected_engine_id)
+            }
+            pp_size = metas[first_rank].pp_size
+
+            if pp_size > 1:
+                if self._sw_ratio is not None:
+                    raise RuntimeError(
+                        "RBLN NIXL: sliding-window attention combined with "
+                        "pipeline-parallel P/D is not supported."
+                    )
+                if remote_tp_size > 1:
+                    raise RuntimeError(
+                        "RBLN NIXL: tensor parallelism (remote_tp_size>1) "
+                        "combined with pipeline-parallel P/D is not supported."
+                    )
+
+            for pp_rank in range(pp_size):
+                for remote_tp_rank in p_remote_tp_ranks:
+                    global_rank = pp_rank * remote_tp_size + remote_tp_rank
+                    if global_rank in metas:
+                        metadata = metas[global_rank]
+                    else:
+                        metadata = self._query_agent_meta(
+                            sock, global_rank, expected_engine_id
+                        )
+                    names = tuple(metadata.registered_layer_names)
+                    self._remote_shard_layer_names[expected_engine_id][global_rank] = (
+                        names
+                    )
+                    if pp_size == 1:
+                        # No pipeline parallelism: single-stage registration,
+                        # exactly as the non-PP path (read path also delegates to
+                        # base for pp_size == 1).
+                        remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                            metadata, global_rank, remote_tp_size
+                        )
+                        continue
+
+                    # PP: only build/register producer stages whose layers this
+                    # rank actually owns. base.add_remote_agent -> _build_fa_remote
+                    # indexes the *local* block_len_per_layer by the *remote*
+                    # region position, so it is only safe when n_remote <= n_local.
+                    # Overlapping stages satisfy that (symmetric same-stage: equal;
+                    # asymmetric fan-in: remote is a sub-band of this larger band);
+                    # a non-overlapping peer stage may be larger under an uneven
+                    # split (e.g. 62 layers / 4 = 16/16/15/15) and would index out
+                    # of range -- and this rank never reads it -- so skip it.
+                    indices = self._local_region_indices_for_layer_names(names)
+                    if 0 < len(indices) < len(names):
+                        raise RuntimeError(
+                            f"RBLN NIXL PP: producer stage {global_rank} "
+                            f"({len(names)} layers) partially overlaps this "
+                            f"decode rank's band ({len(indices)} owned). "
+                            "The prefill pipeline-parallel size must be >= "
+                            "the decode pipeline-parallel size and an integer "
+                            "multiple of it."
+                        )
+                    if not indices:
+                        continue
+                    remote_rank_to_agent_name[global_rank] = self.add_remote_agent(
+                        metadata, global_rank, remote_tp_size
+                    )
+                    self._register_shard_read_state(
+                        expected_engine_id,
+                        global_rank,
+                        metadata.block_size,
+                        names,
+                    )
+                    self._overlapping_ranks[expected_engine_id].append(global_rank)
+        self._remote_pp_size[expected_engine_id] = pp_size
+        return remote_rank_to_agent_name
+
+    def _register_shard_read_state(
+        self,
+        engine_id: str,
+        global_rank: int,
+        block_size: int,
+        registered_layer_names: tuple[str, ...],
+    ) -> None:
+        handle, _ = self.register_local_xfer_handler(
+            block_size, registered_layer_names=registered_layer_names
+        )
+        self.src_xfer_handles_by_remote[(engine_id, global_rank, block_size)] = handle
+        assert len(self.kv_cache_config.kv_cache_groups) == 1, (
+            "RBLN NIXL PP currently supports a single KV-cache group"
+        )
+        region_ids = self._shard_local_region_ids(registered_layer_names)
+        self._shard_region_group_ids[(engine_id, global_rank)] = tuple(
+            0 for _ in region_ids
+        )
+
+    def _local_region_indices_for_layer_names(
+        self, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> list[int]:
+        positions_by_name: dict[str, list[int]] = defaultdict(list)
+        for local_idx, layer_name in enumerate(self.local_seen_layer_names):
+            positions_by_name[layer_name].append(local_idx)
+
+        occurrences_by_name: dict[str, int] = defaultdict(int)
+        local_indices: list[int] = []
+        for layer_name in registered_layer_names:
+            occurrence = occurrences_by_name[layer_name]
+            occurrences_by_name[layer_name] += 1
+            matches = positions_by_name.get(layer_name, [])
+            if occurrence >= len(matches):
+                continue
+            local_indices.append(matches[occurrence])
+        return local_indices
+
+    def _regions_per_layer(self) -> int:
+        num_layers = len(self.local_seen_layer_names)
+        assert num_layers > 0 and self.num_regions % num_layers == 0, (
+            f"num_regions={self.num_regions} not divisible by num_layers={num_layers}"
+        )
+        return self.num_regions // num_layers
+
+    def _shard_local_region_ids(
+        self, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> list[int]:
+        rpl = self._regions_per_layer()
+        layer_indices = self._local_region_indices_for_layer_names(
+            registered_layer_names
+        )
+        return [layer_idx * rpl + k for layer_idx in layer_indices for k in range(rpl)]
+
+    def _register_shard_local_xfer_handler(
+        self, block_size: int, registered_layer_names: tuple[str, ...] | list[str]
+    ) -> tuple[int, list[tuple[int, int, int]]]:
+        assert self.transfer_topo is not None
+        assert not self.transfer_topo.is_kv_layout_blocks_first, (
+            "RBLN NIXL connector only supports FA layout (K and V in separate "
+            "regions), not FlashInfer."
+        )
+        assert not self._has_mamba, "RBLN NIXL connector does not support Mamba."
+
+        block_size_ratio = self.block_size // block_size
+        num_blocks = self.num_blocks * block_size_ratio
+        all_base_addrs = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        region_ids = self._shard_local_region_ids(registered_layer_names)
+
+        blocks_data: list[tuple[int, int, int]] = []
+        for region_id in region_ids:
+            base_addr = all_base_addrs[region_id]
+            kv_block_len = (
+                self.get_backend_aware_kv_block_len(
+                    layer_idx=region_id, first_split=True, mamba_view=False
+                )
+                // block_size_ratio
+            )
+            stride = self.block_len_per_layer[region_id] // block_size_ratio
+            for block_id in range(num_blocks):
+                blocks_data.append(
+                    (base_addr + block_id * stride, kv_block_len, self.device_id)
+                )
+
+        descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
+        return (
+            self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs),
+            blocks_data,
+        )
+
+    def _get_block_descs_ids_for_shard(
+        self,
+        engine_id: str,
+        global_rank: int,
+        num_blocks: int,
+        block_ids: BlockIds,
+    ) -> np.ndarray:
+        region_group_ids = self._shard_region_group_ids[(engine_id, global_rank)]
+        desc_ids: list[np.ndarray] = []
+        for region_id, group_id in enumerate(region_group_ids):
+            group_arr = np.asarray(block_ids[group_id], dtype=np.int64)
+            if group_arr.size == 0:
+                continue
+            desc_ids.append(region_id * num_blocks + group_arr)
+        if not desc_ids:
+            return np.empty(0, dtype=np.int64)
+        return np.concatenate(desc_ids)
+
+    def _validate_remote_agent_handshake(
+        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+    ) -> None:
+        if getattr(nixl_agent_meta, "pp_size", 1) <= 1:
+            super()._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+            return
+
+        assert self.transfer_topo is not None
+        remote_engine_id = nixl_agent_meta.engine_id
+        remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
+        assert remote_info.remote_tp_size == remote_tp_size == 1, (
+            "PP over NIXL P/D requires TP=1 on both sides."
+        )
+        assert self.transfer_topo.block_size_ratio(nixl_agent_meta.block_size) == 1, (
+            "PP over NIXL P/D requires equal P/D block sizes."
+        )
+        assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
+        rpl = self._regions_per_layer()
+        n_remote = len(nixl_agent_meta.kv_caches_base_addr)
+        assert (
+            n_remote > 0
+            and n_remote % rpl == 0
+            and n_remote <= len(self.block_len_per_layer)
+        ), (
+            f"PP shard advertised {n_remote} KV regions, not a valid "
+            f"sub-multiple of this consumer's {len(self.block_len_per_layer)} "
+            f"regions (regions/layer={rpl})."
+        )
+
+    def _read_blocks_for_req(self, req_id: str, meta: "ReqMeta") -> None:
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        pp_size = self._remote_pp_size.get(engine_id, 1)
+        if pp_size == 1:
+            return super()._read_blocks_for_req(req_id, meta)
+
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        assert self.transfer_topo.tp_ratio(remote_info.remote_tp_size) == 1, (
+            "RBLN NIXL PP read path supports TP=1 only"
+        )
+        assert (
+            self.transfer_topo.block_size_ratio(remote_info.remote_block_size) == 1
+        ), "RBLN NIXL PP read path requires equal P/D block sizes"
+        remote_block_size = remote_info.remote_block_size
+
+        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
+            meta.remote.block_ids, remote_info.remote_physical_blocks_per_logical
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+        prefix_hit = len(local_block_ids) == 0
+        n_prompt_blocks = sum(len(g) for g in remote_block_ids)
+
+        if not prefix_hit:
+            local_block_ids, remote_block_ids = self._apply_prefix_caching(
+                local_block_ids,
+                remote_block_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+
+        n_read_blocks = sum(len(g) for g in local_block_ids)
+        logger.info(
+            "PP read req %s: pp_size=%d prompt_blocks=%d read_blocks=%d "
+            "prefix_skipped=%d%s",
+            req_id,
+            pp_size,
+            n_prompt_blocks,
+            n_read_blocks,
+            n_prompt_blocks - n_read_blocks,
+            " (full prefix hit, notif only)" if prefix_hit else "",
+        )
+
+        for global_rank in self._overlapping_ranks[engine_id]:
+            if prefix_hit:
+                agent_name = self._remote_agents[engine_id][global_rank]
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+                continue
+
+            remote_descs = self._get_block_descs_ids_for_shard(
+                engine_id,
+                global_rank,
+                self.dst_num_blocks[engine_id],
+                remote_block_ids,
+            )
+            local_descs = self._get_block_descs_ids_for_shard(
+                engine_id, global_rank, self.num_blocks, local_block_ids
+            )
+            assert len(local_descs) == len(remote_descs)
+            local_handle = self.src_xfer_handles_by_remote[
+                (engine_id, global_rank, remote_block_size)
+            ]
+            remote_handle = self.dst_xfer_side_handles[engine_id][global_rank]
+
+            handle = None
+            try:
+                handle = self.nixl_wrapper.make_prepped_xfer(
+                    "READ",
+                    local_handle,
+                    local_descs,
+                    remote_handle,
+                    remote_descs,
+                    notif_msg=notif_id,
+                )
+                self.nixl_wrapper.transfer(handle)
+                self._recving_transfers[req_id].append(handle)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="transfer_setup_failed",
+                    req_id=req_id,
+                    msg="Marking blocks as invalid",
+                    error=e,
+                    dst_engine_id=engine_id,
+                    remote_pp_rank=global_rank,
+                )
+                self._handle_failed_transfer(req_id, handle)

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """A RBLN worker class."""
 
-import copy
 import os
 import time
 from types import NoneType
@@ -52,7 +51,6 @@ from vllm.tracing import instrument
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
-    EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
     DraftTokenIds,
     ModelRunnerOutput,
@@ -376,8 +374,18 @@ class RBLNWorker(WorkerBase):
         if (metadata := connector.get_handshake_metadata()) is None:
             return None
 
-        tp_rank = get_tp_group().rank_in_group
-        return {tp_rank: metadata}
+        # Key by the flat global rank (pp_rank * tp_size + tp_rank), NOT tp_rank
+        # alone: under pipeline parallelism every PP stage has tp_rank 0, so a
+        # tp_rank key would collide across stages and the scheduler-side
+        # handshake listener would serve only one shard's metadata (the others
+        # KeyError). This mirrors the consumer's global_rank keying in
+        # RblnNixlConnectorWorker._nixl_handshake. Reduces to tp_rank for
+        # pp_size == 1 (pp_rank 0).
+        tp_group = get_tp_group()
+        global_rank = (
+            get_pp_group().rank_in_group * tp_group.world_size + tp_group.rank_in_group
+        )
+        return {global_rank: metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()
@@ -501,21 +509,12 @@ class RBLNWorker(WorkerBase):
         # NOTE(RBLN): DO NOT all_gather_group for RBLN pp
         get_pp_group().send_tensor_dict(output.tensors)
 
-        # For PP with a KV connector, surface the connector output the
-        # model runner attached to the intermediate tensors so finished
-        # send/recv notifications still propagate from non-last ranks.
-        kv_connector_output = output.kv_connector_output
-        if not kv_connector_output:
-            return None
-        if (
-            not kv_connector_output.finished_sending
-            and not kv_connector_output.finished_recving
-        ):
-            return EMPTY_MODEL_RUNNER_OUTPUT
-
-        empty_output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
-        empty_output.kv_connector_output = kv_connector_output
-        return empty_output
+        # Non-last PP rank: the model runner already surfaces this rank's
+        # KV-connector output through the two-phase sample_tokens() path
+        # (mirroring the upstream model runner). The engine consumes this
+        # execute_model result only for error propagation, so return None
+        # rather than emitting the same finished send/recv notifications here.
+        return None
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()


### PR DESCRIPTION
> **Step 2 of 3** — split of #838 (*pipeline parallelism across the RBLN scheduler, runner, and NIXL KV-cache transfer*). This PR carries **section B** of #838: NIXL KV-cache transfer under PP. **Stacked on #856** (PP-aware scheduler & runner) — review/merge that first; the diff here is only the NIXL changes.

### 🚀 Summary of Changes

#### Summary

Extend prefill→decode KV-cache transfer over NIXL to work when either side runs with pipeline parallelism. Before this, a reader would connect to producer stages it does not read from and index per-stage descriptors out of range. Each pipeline stage now advertises its own band of layers in the handshake, and a reader connects to — and builds descriptors for — only the producer stages whose layers fall within the band it owns.

#### What changed

**1. Per-stage layer-band handshake.** Each pipeline stage advertises its own band of layers in the handshake metadata; a reader connects to and pulls from only the producer stages whose layers fall within the band it owns. This covers both the **symmetric layout** (prefill and decode share a pipeline size, stage matched to stage) and the **fan-in layout** (a reader without pipeline parallelism aggregates several producer stages).

**2. Overlap-aware remote descriptor build.** Per-stage remote descriptors are built assuming a producer exposes no more regions than the reader owns — which holds only for the stages the reader actually reads from. Stages outside the reader's band (which can expose more regions when the layer count does not divide evenly across stages) are **skipped before that build**, so it never indexes out of range.

**3. Non-last-rank KV output via the two-phase path.** The KV-connector output for a non-last PP rank is surfaced through the runner's two-phase `sample_tokens()` path; `RBLNWorker.execute_model` returns `None` on non-last ranks instead of re-emitting the same finished send/recv notifications from an empty output, so every rank saves its own layers' KV exactly once.

**4. Unsupported combinations rejected at handshake.** TP together with PP, sliding-window attention together with PP, and unequal prefill/decode block sizes are rejected during the handshake. Transfers without pipeline parallelism keep the existing single-stage path unchanged.

#### Testing

- **Unit** — PP disaggregation (`test_pd_disaggregation.py`), the NIXL per-stage layer-band handshake and overlap-skip (`test_rbln_nixl_handshake_pp.py`), handshake metadata PP fields (`test_rbln_nixl_metadata.py`), worker-side handshake (`test_rbln_worker_handshake.py`), and the non-last-rank `execute_model` return contract (`test_rbln_worker.py::TestExecuteModel`).
- `pre-commit run --hook-stage manual` clean; connector/worker unit suites green.

#### Risk / compatibility

- NIXL transfers with `pipeline_parallel_size == 1` on both sides take the unchanged single-stage path.
- Unsupported PP combinations fail fast at the handshake rather than mis-transferring.

#### Affected modules

NIXL KV connector, Worker.

---

### ✅ Type of Change

* [x] ✨ Feature (`feature`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
