### PR TITLE
fix(APC): fix kv cache indexing in KV copy for APC on MLA models

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2949,7 +2949,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                     src = op.src_block_id
                     dst = op.dst_block_id
                     nt = op.num_tokens
-                    kv_cache[:, dst, :, :, :nt, :] = kv_cache[:, src, :, :, :nt, :]
+                    if self.model_config.use_mla:
+                        kv_cache[dst, :nt, :] = kv_cache[src, :nt, :]
+                    else:
+                        kv_cache[:, dst, :, :, :nt, :] = kv_cache[:, src, :, :, :nt, :]
 
 
 def _pad_rows(t: torch.Tensor | None, bucket: int) -> torch.Tensor | None:


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

APC on MLA models results in the following error:

```
rbln_model_runner.py:2949 in _process_kv_cache_copy_ops
  kv_cache[:, dst, :, :, :nt, :] = kv_cache[:, src, :, :, :nt, :]
IndexError: too many indices for tensor of dimension 3
```

#### Reason & Fix

`_process_kv_cache_copy_ops` hardcoded the non-MLA KV cache layout:

```
(2, num_blocks, num_kv_heads, 1, block_size, head_size)   # 6-D, RBLNFlashAttentionBackend
```

but `RBLNFlashAttnMLABackend.get_kv_cache_shape` returns:

```
(num_blocks, block_size, head_size)                        # 3-D
```

Select the subscript from `model_config.use_mla`, so the block and token axes match the
backend's actual layout.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
