### PR TITLE
perf(attention): reuse device buffers instead of allocating per step

### DIFF
--- a/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
+++ b/tests/torch_compile/unit/v1/spec_decode/test_eagle.py
@@ -144,8 +144,6 @@ def make_common_attn_metadata(
         query_start_loc=query_start_loc,
         query_start_loc_cpu=query_start_loc.cpu(),
         seq_lens=seq_lens,
-        _seq_lens_cpu=seq_lens.cpu(),
-        _num_computed_tokens_cpu=torch.zeros_like(seq_lens),
         num_reqs=seq_lens.shape[0],
         num_actual_tokens=total_num_tokens,
         max_query_len=int((query_start_loc[1:] - query_start_loc[:-1]).max().item()),
@@ -185,6 +183,7 @@ def make_eagle_stub(
         max_num_tokens, hidden_size, dtype=torch.float32, device=DEVICE
     )
     stub.arange = torch.arange(max_num_tokens + 1, dtype=torch.int32, device=DEVICE)
+    stub.arange_cpu = torch.arange(max_num_tokens + 1, dtype=torch.int32)
     stub.vllm_config = SimpleNamespace(
         speculative_config=SimpleNamespace(enforce_eager=enforce_eager),
         parallel_config=SimpleNamespace(data_parallel_size=1),
@@ -418,6 +417,7 @@ def test_init_rejects_multimodal_inputs(monkeypatch):
 def test_init_stores_runner(monkeypatch):
     def fake_super_init(self, vllm_config, device, runner):
         self.supports_mm_inputs = False
+        self.arange = torch.arange(4, dtype=torch.int32, device=DEVICE)
 
     monkeypatch.setattr(EagleProposer, "__init__", fake_super_init)
     runner = object()

--- a/tests/torch_compile/unit/v1/spec_decode/test_utils.py
+++ b/tests/torch_compile/unit/v1/spec_decode/test_utils.py
@@ -88,8 +88,6 @@ def test_prepare_inputs_padded_matches_upstream_tuple_contract():
         query_start_loc=query_start_loc,
         query_start_loc_cpu=query_start_loc_cpu,
         seq_lens=seq_lens,
-        _seq_lens_cpu=seq_lens.cpu(),
-        _num_computed_tokens_cpu=torch.tensor([7, 7, 11, 9], dtype=torch.int32),
         num_reqs=4,
         num_actual_tokens=query_start_loc_cpu[-1].item(),
         max_query_len=4,

--- a/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_model_runner.py
@@ -1382,7 +1382,7 @@ def test_prepare_inputs_pads_query_start_loc_and_seq_lens(rbln_model_runner, dis
     ib.num_computed_tokens_cpu[:2] = [3, 3]
 
     # Poison the tail with stale values to prove they get overwritten.
-    rbln_model_runner.query_start_loc.cpu.fill_(999)
+    rbln_model_runner.query_start_loc.fill_(999)
     rbln_model_runner.seq_lens.fill_(999)
 
     sched = RBLNSchedulerOutput(
@@ -1399,7 +1399,7 @@ def test_prepare_inputs_pads_query_start_loc_and_seq_lens(rbln_model_runner, dis
 
     rbln_model_runner._prepare_inputs(sched, np.array([1, 1], dtype=np.int32))
 
-    qsl = rbln_model_runner.query_start_loc.cpu
+    qsl = rbln_model_runner.query_start_loc
     sl = rbln_model_runner.seq_lens
 
     # Real part: [0, cu...] = [0, 1, 2]; seq_lens = computed + scheduled = [4, 4].
@@ -1976,7 +1976,7 @@ def test_get_prompt_logprobs_dict_chunked_and_final(
     monkeypatch.setattr(rbln_model_runner, "model", FakeModel(), raising=False)
     monkeypatch.setattr(rbln_model_runner, "sampler", FakeSampler())
 
-    rbln_model_runner.query_start_loc.cpu[0] = 0
+    rbln_model_runner.query_start_loc[0] = 0
 
     # First chunk: create and keep in-progress prompt logprobs.
     req_state.num_computed_tokens = 0
@@ -3505,11 +3505,10 @@ def test_build_attention_metadata_returns_per_layer_metadata_and_attaches_kv_bin
     ib.num_computed_tokens_cpu[:2] = [3, 3]
     ib.num_tokens_no_spec[:2] = [4, 4]
 
-    rbln_model_runner.query_start_loc.cpu[:3] = torch.tensor(
+    rbln_model_runner.query_start_loc[:3] = torch.tensor(
         [0, 1, 2],
-        dtype=rbln_model_runner.query_start_loc.cpu.dtype,
+        dtype=rbln_model_runner.query_start_loc.dtype,
     )
-    rbln_model_runner.query_start_loc.copy_to_gpu()
     rbln_model_runner.seq_lens[:2] = torch.tensor(
         [4, 4],
         dtype=rbln_model_runner.seq_lens.dtype,

--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -174,12 +174,15 @@ class RBLNFlashAttentionMetadataBuilder(
         is_prefill: bool,
     ) -> RBLNFlashAttentionMetadata:
         num_reqs = common_attn_metadata.num_reqs
-        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
-        seq_lens = common_attn_metadata._seq_lens_cpu
+        # NOTE(RBLN): vllm-rbln keeps attention metadata on the host and copies
+        # to the device only when constructing RBLNFlashAttentionMetadata below.
+        # See RBLNModelRunner._build_attention_metadata.
+        query_start_loc_cpu = common_attn_metadata.query_start_loc
+        seq_lens_cpu = common_attn_metadata.seq_lens
         block_tables_tensor = common_attn_metadata.block_table_tensor
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        num_computed_tokens = seq_lens - query_seq_lens_cpu
+        num_computed_tokens = seq_lens_cpu - query_seq_lens_cpu
         seq_idx = positions[query_start_loc_cpu[:num_reqs]].view(-1, 1)
         max_seq_len = self.model_config.max_model_len
 
@@ -221,7 +224,7 @@ class RBLNFlashAttentionMetadataBuilder(
                     max_seq_len,
                     dtype=torch.float16 if self.enforce_eager else torch.float32,
                 )
-                for batch_index, batch_step in enumerate(seq_lens):
+                for batch_index, batch_step in enumerate(seq_lens_cpu):
                     decode_attention_mask[batch_index, :, :, :, : batch_step + 1] = 1
                 attn_masks = decode_attention_mask
                 attn_masks = attn_masks.to(self.device)
@@ -232,7 +235,7 @@ class RBLNFlashAttentionMetadataBuilder(
         swa_attn_masks = None
         if sliding_window := getattr(self.kv_cache_spec, "sliding_window", None):
             num_computed_tokens = num_computed_tokens[:num_reqs].view(-1, 1)
-            seq_lens = seq_lens[:num_reqs].view(-1, 1)
+            seq_lens = seq_lens_cpu[:num_reqs].view(-1, 1)
             query_lens = seq_lens - num_computed_tokens
             cache_seq_lens = torch.clamp(num_computed_tokens, max=sliding_window)
             cache_offsets = cache_seq_lens + query_lens

--- a/vllm_rbln/v1/attention/backends/flash_attention.py
+++ b/vllm_rbln/v1/attention/backends/flash_attention.py
@@ -161,6 +161,29 @@ class RBLNFlashAttentionMetadataBuilder(
         self.enforce_eager = get_current_vllm_config().model_config.enforce_eager
         self.is_causal = envs.VLLM_RBLN_FLASH_CAUSAL_ATTN
 
+        self._staged: dict[tuple, torch.Tensor] = {}
+
+    def _stage(self, t: torch.Tensor | None, slot: str) -> torch.Tensor | None:
+        """Copy a host tensor into this builder's persistent device buffer.
+
+        `slot` must be unique per logical tensor: cache_seq_lens and
+        cache_offsets share both shape and dtype, so keying on those alone
+        would silently make them share one buffer.
+
+        The returned tensor is overwritten by the next build() call, so the
+        caller must run the forward pass before building again. That holds
+        because each AttentionGroup owns its own builder instance and every
+        build() is immediately followed by a forward.
+        """
+        if t is None:
+            return None
+        key = (slot, t.shape, t.dtype)
+        if (buf := self._staged.get(key)) is None:
+            buf = torch.empty(t.shape, dtype=t.dtype, device=self.device)
+            self._staged[key] = buf
+        buf.copy_(t)
+        return buf
+
     def reorder_batch(
         self, input_batch: "InputBatch", scheduler_output: "SchedulerOutput"
     ) -> bool:
@@ -211,7 +234,6 @@ class RBLNFlashAttentionMetadataBuilder(
                     causal_mask
                 )
                 attn_masks = chunked_attention_mask
-                attn_masks = attn_masks.to(self.device)
         else:
             seq_idx = rbln_utils.pad(seq_idx, 0, batch_pad)
             block_tables_tensor = rbln_utils.pad(block_tables_tensor, 0, batch_pad)
@@ -227,7 +249,6 @@ class RBLNFlashAttentionMetadataBuilder(
                 for batch_index, batch_step in enumerate(seq_lens_cpu):
                     decode_attention_mask[batch_index, :, :, :, : batch_step + 1] = 1
                 attn_masks = decode_attention_mask
-                attn_masks = attn_masks.to(self.device)
 
         cache_seq_lens = None
         cache_offsets = None
@@ -252,22 +273,14 @@ class RBLNFlashAttentionMetadataBuilder(
             local_block_tables = block_tables_tensor[..., :1]
 
         attn_metadata = RBLNFlashAttentionMetadata(
-            seq_lens=seq_idx.to(self.device),
-            block_tables=block_tables_tensor.to(self.device),
+            seq_lens=self._stage(seq_idx, "seq_idx"),
+            block_tables=self._stage(block_tables_tensor, "block_tables"),
             is_prefill=is_prefill,
-            attn_masks=attn_masks,
-            cache_seq_lens=cache_seq_lens.to(self.device)
-            if cache_seq_lens is not None
-            else None,
-            cache_offsets=cache_offsets.to(self.device)
-            if cache_offsets is not None
-            else None,
-            local_block_tables=local_block_tables.to(self.device)
-            if local_block_tables is not None
-            else None,
-            swa_attn_masks=swa_attn_masks.to(self.device)
-            if swa_attn_masks is not None
-            else None,
+            attn_masks=self._stage(attn_masks, "attn_masks"),
+            cache_seq_lens=self._stage(cache_seq_lens, "cache_seq_lens"),
+            cache_offsets=self._stage(cache_offsets, "cache_offsets"),
+            local_block_tables=self._stage(local_block_tables, "local_block_tables"),
+            swa_attn_masks=self._stage(swa_attn_masks, "swa_attn_masks"),
         )
 
         return attn_metadata

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -61,6 +61,7 @@ class RBLNEagleProposer(EagleProposer):
             raise NotImplementedError
 
         self.runner = runner
+        self.arange_cpu = torch.arange(self.arange.shape[0], dtype=torch.int32)
 
     def propose(
         self,
@@ -168,10 +169,12 @@ class RBLNEagleProposer(EagleProposer):
         # Generate the remaining draft tokens.
         draft_token_ids_list = [draft_token_ids]
 
+        # it mutates seq_lens in place; detach from the runner's persistent buffer.
+        common_attn_metadata.seq_lens = common_attn_metadata.seq_lens.clone()
         common_attn_metadata.num_actual_tokens = num_reqs
         common_attn_metadata.max_query_len = 1
-        common_attn_metadata.query_start_loc = self.arange[: num_reqs + 1]
-        common_attn_metadata.query_start_loc_cpu = self.arange[: num_reqs + 1].cpu()
+        common_attn_metadata.query_start_loc = self.arange_cpu[: num_reqs + 1]
+        common_attn_metadata.query_start_loc_cpu = self.arange_cpu[: num_reqs + 1]
 
         # In padded drafter batch, we need to adjust the sequence lengths
         # to remove the "padding" (i.e. rejected tokens).
@@ -179,9 +182,6 @@ class RBLNEagleProposer(EagleProposer):
         # (i.e., not the first proposal).
         if self.num_speculative_tokens > 1 and num_rejected_tokens is not None:
             common_attn_metadata.seq_lens -= num_rejected_tokens
-            # Invalidate the CPU-side shadows to avoid H<>D sync.
-            # common_attn_metadata._seq_lens_cpu = None
-            # common_attn_metadata._num_computed_tokens_cpu = None
 
         num_reqs_padded, num_padded_tokens, num_tokens_across_dp = (
             self._determine_draft_batch_padding(num_reqs, num_reqs, False)
@@ -322,29 +322,22 @@ class RBLNEagleProposer(EagleProposer):
         token_indices_to_sample, num_rejected_tokens = eagle_prepare_inputs_padded(
             spec_decode_metadata.cu_num_draft_tokens,
             valid_sampled_tokens_count,
-            common_attn_metadata.query_start_loc_cpu,
+            common_attn_metadata.query_start_loc,
         )
 
-        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
-        seq_lens_cpu = (
-            common_attn_metadata._seq_lens_cpu
-            if common_attn_metadata._seq_lens_cpu is not None
-            else common_attn_metadata.seq_lens.cpu()
-        )
-        new_query_len_per_req = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-
-        total_num_tokens = query_start_loc_cpu[-1].item()
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        new_query_len_per_req = query_start_loc[1:] - query_start_loc[:-1]
+        total_num_tokens = query_start_loc[-1].item()
 
         spec_common_attn_metadata = CommonAttentionMetadata(
-            query_start_loc=common_attn_metadata.query_start_loc,
-            seq_lens=common_attn_metadata.seq_lens,
-            query_start_loc_cpu=query_start_loc_cpu,
-            _seq_lens_cpu=common_attn_metadata._seq_lens_cpu,
-            _num_computed_tokens_cpu=common_attn_metadata._num_computed_tokens_cpu,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            query_start_loc_cpu=query_start_loc,
             num_reqs=common_attn_metadata.num_reqs,
             num_actual_tokens=total_num_tokens,
             max_query_len=new_query_len_per_req.max().item(),
-            max_seq_len=seq_lens_cpu.max().item(),
+            max_seq_len=seq_lens.max().item(),
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=torch.tensor(0),  # dummy,
             causal=True,
@@ -424,10 +417,9 @@ class RBLNEagleProposer(EagleProposer):
         query_start_loc[1 : num_reqs + 1] = torch.from_numpy(cum_num_tokens)
 
         return CommonAttentionMetadata(
-            query_start_loc=query_start_loc.to(self.device),
+            query_start_loc=query_start_loc,
             query_start_loc_cpu=query_start_loc,
-            seq_lens=seq_lens.to(self.device),
-            _seq_lens_cpu=seq_lens,
+            seq_lens=seq_lens,
             num_reqs=num_reqs,
             num_actual_tokens=num_tokens,
             max_query_len=num_tokens_per_req,
@@ -513,14 +505,9 @@ class RBLNEagleProposer(EagleProposer):
 
         common_attn_metadata.num_actual_tokens = num_reqs
         common_attn_metadata.max_query_len = 1
-        common_attn_metadata.query_start_loc = self.arange[: num_reqs + 1]
-        common_attn_metadata.query_start_loc_cpu = (
-            common_attn_metadata.query_start_loc.cpu()
-        )
-        common_attn_metadata._seq_lens_cpu += 1
-        common_attn_metadata.seq_lens = common_attn_metadata._seq_lens_cpu.to(
-            self.device
-        )
+        common_attn_metadata.query_start_loc = self.arange_cpu[: num_reqs + 1]
+        common_attn_metadata.query_start_loc_cpu = self.arange_cpu[: num_reqs + 1]
+        common_attn_metadata.seq_lens += 1
 
         num_reqs_padded, dp_padded, num_tokens_across_dp = (
             self._determine_draft_batch_padding(num_reqs, num_reqs, False)

--- a/vllm_rbln/v1/spec_decode/eagle.py
+++ b/vllm_rbln/v1/spec_decode/eagle.py
@@ -260,7 +260,7 @@ class RBLNEagleProposer(EagleProposer):
             )
 
         if token_indices_to_sample is None:
-            token_indices_to_sample = cad.query_start_loc[1:] - 1
+            token_indices_to_sample = (cad.query_start_loc[1:] - 1).to(self.device)
 
         num_tokens = target_token_ids.shape[0]
         self.input_ids[: num_tokens - 1] = target_token_ids[1:]

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -888,7 +888,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             query_start_loc=self.query_start_loc[: num_reqs + 1],
             query_start_loc_cpu=self.query_start_loc[: num_reqs + 1],
             seq_lens=self.seq_lens[:num_reqs],
-            _seq_lens_cpu=self.seq_lens[:num_reqs],
             num_reqs=num_reqs,
             num_actual_tokens=num_tokens,
             max_query_len=max_query_len,

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -85,7 +85,7 @@ from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
-from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
+from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.kv_connector_model_runner_mixin import (
     KVConnectorModelRunnerMixin,
@@ -358,10 +358,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # Persistent buffers
         self.input_ids = torch.zeros(self.max_num_tokens, dtype=torch.int32)
         self.positions = torch.zeros(self.max_num_tokens, dtype=torch.int64)
-        self.query_start_loc = self._make_buffer(
-            self.max_num_reqs + 1, dtype=torch.int32
-        )
+        self.query_start_loc = torch.zeros(self.max_num_reqs + 1, dtype=torch.int32)
+        self.query_start_loc_np = self.query_start_loc.numpy()
         self.seq_lens = torch.zeros(self.max_num_tokens, dtype=torch.int32)
+        self.seq_lens_np = self.seq_lens.numpy()
         self.discard_request_mask = torch.zeros(self.max_num_reqs, dtype=torch.bool)
         self.input_stager = InputStager(self.device)
 
@@ -431,17 +431,6 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
     def _get_positions(self, num_tokens: Any):
         assert not isinstance(num_tokens, int)
         return self.positions[:num_tokens]
-
-    def _make_buffer(
-        self, *size: int | torch.SymInt, dtype: torch.dtype, numpy: bool = True
-    ) -> CpuGpuBuffer:
-        return CpuGpuBuffer(
-            *size,
-            dtype=dtype,
-            device=self.device,
-            pin_memory=self.pin_memory,
-            with_numpy=numpy,
-        )
 
     def _init_model_kwargs(self):
         model_kwargs = dict[str, Any]()
@@ -810,17 +799,14 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         )
 
         # Prepare the attention metadata.
-        query_start_loc_np = self.query_start_loc.np
-        query_start_loc_np[0] = 0
-        query_start_loc_np[1 : num_reqs + 1] = cu_num_tokens
-        query_start_loc_np[num_reqs + 1 :].fill(cu_num_tokens[-1])
-        self.query_start_loc.copy_to_gpu()
+        self.query_start_loc_np[0] = 0
+        self.query_start_loc_np[1 : num_reqs + 1] = cu_num_tokens
+        self.query_start_loc_np[num_reqs + 1 :].fill(cu_num_tokens[-1])
 
-        seq_lens_np = self.seq_lens.numpy()
-        seq_lens_np[:num_reqs] = (
+        self.seq_lens_np[:num_reqs] = (
             self.input_batch.num_computed_tokens_cpu[:num_reqs] + logical_num_tokens
         )
-        seq_lens_np[num_reqs:].fill(0)
+        self.seq_lens_np[num_reqs:].fill(0)
 
         num_tokens = [self.requests[r].num_tokens for r in self.input_batch.req_ids]
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
@@ -828,7 +814,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         # Record which requests should not be sampled,
         # so that we could clear the sampled tokens before returningj
         discard_request_mask_np = self.discard_request_mask.numpy()
-        discard_request_mask_np[:num_reqs] = seq_lens_np[:num_reqs] < num_tokens_np
+        discard_request_mask_np[:num_reqs] = self.seq_lens_np[:num_reqs] < num_tokens_np
 
         if not use_spec_decode:
             # NOTE(woosuk): Due to chunked prefills, the batch may contain
@@ -836,7 +822,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # from these partial requests, we do so for simplicity.
             # We will ignore the sampled tokens from the partial requests.
             # TODO: Support prompt logprobs.
-            logits_indices = self.query_start_loc.cpu[1 : num_reqs + 1] - 1
+            logits_indices = self.query_start_loc[1 : num_reqs + 1] - 1
             spec_decode_metadata = None
         else:
             # Get the number of draft tokens for each request.
@@ -899,8 +885,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             return blk_table_tensor
 
         cm_base = CommonAttentionMetadata(
-            query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],
-            query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs + 1],
+            query_start_loc=self.query_start_loc[: num_reqs + 1],
+            query_start_loc_cpu=self.query_start_loc[: num_reqs + 1],
             seq_lens=self.seq_lens[:num_reqs],
             _seq_lens_cpu=self.seq_lens[:num_reqs],
             num_reqs=num_reqs,
@@ -1940,7 +1926,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             # If this is a partial request (i.e. chunked prefill),
             # then there is prompt logprob generated for each index.
             req_idx = self.input_batch.req_id_to_index[req_id]
-            offset = self.query_start_loc.cpu[req_idx].item()
+            offset = self.query_start_loc[req_idx].item()
             prompt_hidden_states = hidden_states[offset : offset + num_logits]
             logits = self.model.compute_logits(prompt_hidden_states)
 
@@ -2015,9 +2001,8 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         num_scheduled_tokens = np.array(num_scheduled_tokens_list, dtype=np.int32)
         num_tokens_unpadded = int(num_scheduled_tokens.sum())
 
-        seq_lens_np = self.seq_lens.numpy()
-        seq_lens_np[:num_reqs] = num_scheduled_tokens
-        seq_lens_np[num_reqs:] = 0
+        self.seq_lens_np[:num_reqs] = num_scheduled_tokens
+        self.seq_lens_np[num_reqs:] = 0
 
         # NOTE(RBLN): self.is_prefill is derived from num_tokens_no_spec.
         # For decode warmup, keep it at 1 so multi-token speculative decode
@@ -2032,9 +2017,10 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         )
         num_tokens_padded = num_tokens_padded or _num_tokens_padded
 
-        cum_num_tokens, _ = self._get_cumsum_and_arange(num_scheduled_tokens)
-        query_start_loc_np = self.query_start_loc.np
-        query_start_loc_np[1 : num_reqs + 1] = cum_num_tokens
+        cu_num_tokens, _ = self._get_cumsum_and_arange(num_scheduled_tokens)
+        self.query_start_loc_np[0] = 0
+        self.query_start_loc_np[1 : num_reqs + 1] = cu_num_tokens
+        self.query_start_loc_np[num_reqs + 1 :].fill(cu_num_tokens[-1])
 
         attn_metadata, _ = self._build_attention_metadata(
             num_tokens=num_tokens_unpadded,


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

#### Remove per-step device allocation from attention metadata construction

`RBLNFlashAttentionMetadataBuilder.build()` allocated a fresh device tensor for every metadata field via `.to(self.device)`. Since `build()` runs on every step, that is one device allocation per tensor per step, and the RBLN allocator does not reuse them; the cost lands directly in prepare time. Models with SWA pay it for more tensors across more KV cache groups, so they are hit hardest.

This takes the same approach as #548, #778 (`_to_device_inplace`): copy into persistent device buffers instead of reallocating. The difference is how the buffers are looked up. #548 keeps one buffer per attribute, so it can only hold a single shape at a time; a shape mismatch reallocates and overwrites that slot. Prefill and decode use different layouts, so every prefill/decode transition reallocates the tensors that appear in both phases, which is exactly what the buffer was meant to avoid. Here the buffers live in a dict keyed on `(slot, shape, dtype)`, so both layouts stay resident and allocations drop to zero after warm-up.

#### Unify attention metadata on host tensors

`CommonAttentionMetadata` carried 4 tensors for two values (`query_start_loc`/`query_start_loc_cpu`, `seq_lens`/`_seq_lens_cpu`), and call sites disagreed about which to read. The metadata builder read the `_cpu` twins while `RBLNEagleProposer` mixed both, and `query_start_loc` was staged to the device through a `CpuGpuBuffer` on every step even though nothing ever read the device copy.

All metadata arithmetic now stays on the host, with a single tensor per value, and the H2D copy happens once at the point where the backend metadata is constructed. This removes a per-step H2D copy from the runner and a per-`propose` D2H copy from the EAGLE drafter, and it makes the device-copy boundary a single place that is easy to keep correct. `_seq_lens_cpu` and `_num_computed_tokens_cpu` are no longer passed at all (upstream has deprecated both for removal).

#### Result

On gpt-oss-120b, mean prepare time drops by roughly **90% for decode** and **25% for prefill**. Device time is unchanged, so the gain is entirely host-side. The improvement is also present on models without SWA, but smaller, since fewer tensors are staged per step.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

Run the offline benchmark with metrics and the runtime timer enabled, and compare the reported mean prepare time against the base branch. Worth checking both a sliding-window model and a non-sliding-window one, and both a fresh compile and a cached-model run.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
