### PR TITLE
fix(plugin): avoid CpuPlatform fallback on plugin-first import

### DIFF
--- a/vllm_rbln/__init__.py
+++ b/vllm_rbln/__init__.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from vllm_rbln import envs
+# NOTE(eunji.lee): Keep this module free of top-level imports.
+# vLLM resolves platform plugins lazily on the first
+# `vllm.platforms.current_platform` access, which almost any
+# vLLM import triggers. If importing `vllm_rbln` pulls in vLLM before `register`
+# is bound, the plugin loader re-enters this partially initialized module,
+# `getattr(module, "register")` raises, and vLLM falls back to CpuPlatform.
 
 
 def register():
@@ -26,6 +31,7 @@ def register_model():
 
 def register_ops():
     import vllm_rbln.distributed.ec_transfer.ec_connector.factory  # noqa
+    from vllm_rbln import envs
 
     if envs.VLLM_RBLN_USE_VLLM_MODEL:
         from vllm_rbln.patches import apply_registered_patches, apply_registrations


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

`vllm_rbln/__init__.py` had a top-level `from vllm_rbln import envs`. On vLLM
0.24.0 this makes the RBLN platform plugin fail to load whenever `vllm_rbln` is
imported before any `vllm` module, and vLLM falls back to `CpuPlatform`.

1. `import vllm_rbln` — Python inserts the module object into
   `sys.modules["vllm_rbln"]` before executing the body, so `register` is not
   bound yet.
2. The first statement of the body, `from vllm_rbln import envs`, reaches
   `vllm.envs` and `vllm_rbln.logger`, which import the `vllm` package →
   `vllm.env_override` → `vllm.utils.torch_utils`.
3. `vllm/utils/torch_utils.py:71` evaluates `PIN_MEMORY = is_pin_memory_available()`
   at module scope. This reads `vllm.platforms.current_platform` and triggers
   lazy platform resolution.
4. Re-entrancy: the plugin loader calls `import_module("vllm_rbln")`, finds the
   partially initialized module already in `sys.modules`, and returns it without
   re-executing the body. `getattr(module, "register")` then raises
   `AttributeError: partially initialized module 'vllm_rbln' has no attribute
   'register'`.
5. The exception is caught and logged, but not propagated, so startup continues
   as if the plugin were not installed:

   ```python
   # vllm/plugins/__init__.py:60-64
   try:
       func = plugin.load()          # AttributeError raised here
       plugins[plugin.name] = func
   except Exception:
       logger.exception("Failed to load plugin %s", plugin.name)

6. With no out-of-tree plugin activated, the builtin cpu plugin wins because we
install vllm==0.24.0+cpu. _current_platform is then cached for the lifetime
of the process by the if _current_platform is None guard in
vllm/platforms/__init__.py:275. register does get bound moments later as
the stack unwinds, but nothing re-resolves the platform.

### Why this surfaced on 0.24.0
Until v0.23.0, PIN_MEMORY was a plain WSL
string check with the comment "Logic duplicated here for now to avoid circular
import". Commit 7df3d7dad ([Core] Ensure memory is pinned prior to async h2d
copy, #45424) replaced it with is_pin_memory_available(), so import vllm
now resolves the platform. The top-level import in our __init__.py predates
this and was harmless before.

### Scope
Only files that import vllm_rbln without importing any vllm
module first are affected; isort places vllm before vllm_rbln, so files that
import both are safe, and so is the serving path. 13 test files hit the bad
order, but they assert nothing about the platform, so they passed under
CpuPlatform.

### Fix
Keep vllm_rbln/__init__.py free of top-level imports and move
from vllm_rbln import envs into register_ops(). This matches upstream's
reference plugin (tests/plugins/vllm_add_dummy_platform/.../__init__.py),
which defines functions only.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
5. Verify output: `...`
7. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
