### PR TITLE
fix(sampler): avoid softmaxing the greedy one-hot into a near-uniform target

### DIFF
--- a/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
+++ b/tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py
@@ -69,7 +69,6 @@ def _medusa_llm_kwargs(max_num_seqs: int) -> dict:
     }
 
 
-@pytest.mark.xfail(reason="unexpected compilation error in medusa")
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_medusa_matches_base_generation(
     monkeypatch: pytest.MonkeyPatch, batch_size: int

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -525,7 +525,7 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
 
         This function applies temperature scaling to the logits,
         as well as top-k and top-p. For greedy decoding, it returns
-        the original logits.
+        logits collapsed onto the argmax.
 
         Args:
             logits: Input logits tensor to be processed.
@@ -534,16 +534,16 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
                 temperature and whether greedy sampling is used.
 
         Returns:
-            torch.Tensor: Processed logits if non-greedy sampling is used,
-            otherwise returns the original logits.
+            torch.Tensor: Processed logits -- the caller
+            softmaxes the result to build `target_probs`.
         """
         assert logits.ndim == 2
         assert cu_num_draft_tokens.ndim == 1
         if sampling_metadata.all_greedy:
-            # Make One-hot target distribution for the rejection sampler.
+            # -inf except at the argmax, so the caller's softmax yields an exact
+            # one-hot.
             _, max_idx = logits.max(dim=-1, keepdim=True)
-            logits = torch.zeros_like(logits).scatter_(-1, max_idx, 1.0)
-            return logits
+            return torch.full_like(logits, float("-inf")).scatter_(-1, max_idx, 0.0)
 
         num_tokens = logits.shape[0]
         # NOTE(eunji.lee):

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -540,7 +540,7 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         assert logits.ndim == 2
         assert cu_num_draft_tokens.ndim == 1
         if sampling_metadata.all_greedy:
-            return make_one_hot_logits(logits)
+            return logits_for_one_hot_probs(logits)
 
         num_tokens = logits.shape[0]
         # NOTE(eunji.lee):
@@ -569,13 +569,13 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
         ).nonzero(as_tuple=True)[0]
         if greedy_rows.numel() > 0:
             greedy_rows = greedy_rows.to(logits.device)
-            logits[greedy_rows] = make_one_hot_logits(logits[greedy_rows])
+            logits[greedy_rows] = logits_for_one_hot_probs(logits[greedy_rows])
 
         # NOTE(eunji.lee): top_k & top_p are applied together during rejection sampling.
         return logits
 
 
-def make_one_hot_logits(logits: torch.Tensor) -> torch.Tensor:
+def logits_for_one_hot_probs(logits: torch.Tensor) -> torch.Tensor:
     """Return -inf except 0.0 at the argmax, so that softmax gives an exact
     one-hot."""
     _, max_idx = logits.max(dim=-1, keepdim=True)

--- a/vllm_rbln/v1/sample/rbln_rejection_sampler.py
+++ b/vllm_rbln/v1/sample/rbln_rejection_sampler.py
@@ -37,7 +37,6 @@ logger = init_logger(__name__)
 
 PLACEHOLDER_TOKEN_ID = -1
 GREEDY_TEMPERATURE = 0
-GREEDY_EPS = 1e-3
 
 
 # TODO(RBLN): Enable RBLNSampler for
@@ -523,9 +522,10 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
     ) -> torch.Tensor:
         """Process logits based on sampling metadata.
 
-        This function applies temperature scaling to the logits,
-        as well as top-k and top-p. For greedy decoding, it returns
-        logits collapsed onto the argmax.
+        This function applies temperature scaling to the rows of random-sampling
+        requests. Rows of greedy requests are collapsed onto their argmax, so
+        that the caller's softmax turns them into an exact one-hot target
+        distribution. top-k and top-p are left to the rejection sampling op.
 
         Args:
             logits: Input logits tensor to be processed.
@@ -534,35 +534,52 @@ class RBLNRejectionSamplerImpl(RejectionSamplerImpl):
                 temperature and whether greedy sampling is used.
 
         Returns:
-            torch.Tensor: Processed logits -- the caller
-            softmaxes the result to build `target_probs`.
+            torch.Tensor: Processed logits -- the caller softmaxes the result to
+            build `target_probs`.
         """
         assert logits.ndim == 2
         assert cu_num_draft_tokens.ndim == 1
         if sampling_metadata.all_greedy:
-            # -inf except at the argmax, so the caller's softmax yields an exact
-            # one-hot.
-            _, max_idx = logits.max(dim=-1, keepdim=True)
-            return torch.full_like(logits, float("-inf")).scatter_(-1, max_idx, 0.0)
+            return make_one_hot_logits(logits)
 
         num_tokens = logits.shape[0]
         # NOTE(eunji.lee):
         # Upstream vLLM treats any temperature below _SAMPLING_EPS as greedy,
         # sets it to 0, and then overrides it to 1 right before the sampling op.
-        # In rbln_rejection_sampler, random sampling is faster than the greedy path,
-        # so we only treat temperature == GREEDY_TEMPERATURE (0) as greedy decoding.
+        # We do the same here: greedy rows are overwritten below, so the value
+        # their logits are divided by does not matter as long as it is not 0.
         temperature = expand_batch_to_tokens(
             sampling_metadata.temperature,
             cu_num_draft_tokens,
             num_tokens,
             replace_from=GREEDY_TEMPERATURE,
-            replace_to=GREEDY_EPS,
+            replace_to=1,
         )
         # NOTE(woosuk): Update `logits` in place to avoid allocating a new tensor.
         logits.div_(temperature.unsqueeze(-1))
 
+        # NOTE(eunji.lee): The NPU `rbln::rejection_sample` primitive has no
+        # greedy kernel -- every row goes through random rejection sampling. A
+        # greedy row therefore has to carry a one-hot target distribution, which
+        # makes accept-iff-draft-is-argmax the only possible outcome.
+        greedy_rows = expand_batch_to_tokens(
+            sampling_metadata.temperature == GREEDY_TEMPERATURE,
+            cu_num_draft_tokens,
+            num_tokens,
+        ).nonzero(as_tuple=True)[0]
+        if greedy_rows.numel() > 0:
+            greedy_rows = greedy_rows.to(logits.device)
+            logits[greedy_rows] = make_one_hot_logits(logits[greedy_rows])
+
         # NOTE(eunji.lee): top_k & top_p are applied together during rejection sampling.
         return logits
+
+
+def make_one_hot_logits(logits: torch.Tensor) -> torch.Tensor:
+    """Return -inf except 0.0 at the argmax, so that softmax gives an exact
+    one-hot."""
+    _, max_idx = logits.max(dim=-1, keepdim=True)
+    return torch.full_like(logits, float("-inf")).scatter_(-1, max_idx, 0.0)
 
 
 def rbln_rejection_sample(


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

## Problem

`RBLNRejectionSamplerImpl.apply_sampling_constraints` returned a 0/1 one-hot
**probability** tensor for the all-greedy case, but its caller softmaxes the
result to build `target_probs`:

```python
logits = torch.zeros_like(logits).scatter_(-1, max_idx, 1.0)   # probabilities
...
target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)   # caller
```

Softmaxing a 0/1 one-hot keeps the ordering but destroys the distribution: at
vocab 128k the greedy token lands at `p=2.1e-5` against `7.8e-6` for every other
token, i.e. 0.002% of the mass. At `p=2.1e-5` it rejected almost every draft, including
correct ones, and drew the recovered token near-uniformly from the whole
vocabulary.

## Fix

Return `-inf` everywhere and `0.0` at the argmax. Its softmax is an *exact*
one-hot, so a draft token is accepted only when it is the greedy choice, and any
recovered token is that greedy choice.

```python
return torch.full_like(logits, float("-inf")).scatter_(-1, max_idx, 0.0)
```

Only the `all_greedy` branch changes; random sampling is untouched.

## Verification

**Before**

```
"The capital of France is"                  -> ' Paris belirtilen นาง(di"\\ contamination � jose'
"The largest planet in the solar system is" -> ' the(em749_gb LLC depict_conditions<h'
"The chemical symbol for gold is"           -> ' AuTreeView METH.turn appendedapellido River.Dir'
"The first person to walk on the Moon was"  -> ' Neil FAR.setTo.Dir.GetName_supωμάτιο\theader'
```

**After**

```
"The capital of France is"                  -> ' Paris, and it is the most visited'
"The largest planet in the solar system is" -> ' the one that is closest to the sun'
"The chemical symbol for gold is"           -> ' Au. It is a soft, m'
"The first person to walk on the Moon was"  -> ' Neil Armstrong, who was the first man'
```

## How to test

```bash
pytest tests/torch_compile/e2e/v1/spec_decode/test_medusa_correctness.py -v
```

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
