### PR TITLE
other: bump rebel-compiler to 0.11.2.dev158+gbaabdcac.prod

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2101,7 +2101,7 @@ wheels = [
 
 [[package]]
 name = "rebel-compiler"
-version = "0.11.1.dev431+gd747c02e.prod"
+version = "0.11.1.dev532+g6df9a645.prod"
 source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
 dependencies = [
     { name = "attrs" },
@@ -2123,10 +2123,10 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev431+gd747c02e.prod/rebel_compiler-0.11.1.dev431+gd747c02e.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:3e3e4e0e36f5f9c4caeff57cccaca4bc" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev431+gd747c02e.prod/rebel_compiler-0.11.1.dev431+gd747c02e.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:40a840b7ebda0d55734e4b2bab71275c" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev431+gd747c02e.prod/rebel_compiler-0.11.1.dev431+gd747c02e.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:7d9cd80111327ed1a220efd756347d6d" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev431+gd747c02e.prod/rebel_compiler-0.11.1.dev431+gd747c02e.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:5228c0b3fc7c881930a2d4eccbcc19ba" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:327363dc6148df7f823b4a96a1849c3b" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:f5fd1b38e97dddb0babd569f253552c0" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:e9d9ca2d2fdeef5a48c0b7e25262d1e0" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:3c2e91dbbb5744888a61eac675f353d8" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2101,7 +2101,7 @@ wheels = [
 
 [[package]]
 name = "rebel-compiler"
-version = "0.11.1.dev532+g6df9a645.prod"
+version = "0.11.2.dev158+gbaabdcac.prod"
 source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
 dependencies = [
     { name = "attrs" },
@@ -2123,10 +2123,10 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:327363dc6148df7f823b4a96a1849c3b" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:f5fd1b38e97dddb0babd569f253552c0" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:e9d9ca2d2fdeef5a48c0b7e25262d1e0" },
-    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.1.dev532+g6df9a645.prod/rebel_compiler-0.11.1.dev532+g6df9a645.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:3c2e91dbbb5744888a61eac675f353d8" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.2.dev158+gbaabdcac.prod/rebel_compiler-0.11.2.dev158+gbaabdcac.prod-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "md5:aea5c20096fc20fc1d04ec714420e312" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.2.dev158+gbaabdcac.prod/rebel_compiler-0.11.2.dev158+gbaabdcac.prod-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "md5:dfd4bab01025651f6feb9f6935753387" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.2.dev158+gbaabdcac.prod/rebel_compiler-0.11.2.dev158+gbaabdcac.prod-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "md5:a33e2c605a4691cb1da79edc4038b6d5" },
+    { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/rebel-compiler/0.11.2.dev158+gbaabdcac.prod/rebel_compiler-0.11.2.dev158+gbaabdcac.prod-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "md5:e51a8b62fb95676889b655779890cc03" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Lock-only bump of the `rebel-compiler` nightly pin in `uv.lock` to:

`0.11.2.dev158+gbaabdcac.prod`

Net change vs `dev`: `0.11.1.dev431+gd747c02e.prod` → `0.11.2.dev158+gbaabdcac.prod`.

## Details

- Produced with `uv lock --upgrade-package "rebel-compiler==0.11.2.dev158+gbaabdcac.prod"`.
- **`uv.lock` only** — the `pyproject.toml` constraint (`rebel-compiler~=0.11.1.dev0`) is unchanged and still satisfied.
- Diff is limited to the resolved version line and the nexus wheel URLs/hashes (cp310–cp313); no other packages are re-resolved.