### PR TITLE
fix(specdec): pass num_speculative_tokens to SuffixDecodingProposer.propose

### DIFF
--- a/tests/native/v1/spec_decode/test_spec_decode_e2e.py
+++ b/tests/native/v1/spec_decode/test_spec_decode_e2e.py
@@ -76,7 +76,6 @@ SPEC_METHODS = {
 # acceptance there would measure model quality, not the code path.
 _EXPECT_ACCEPTANCE = {"ngram", "suffix", "eagle", "eagle3"}
 _XFAIL_REASON = {
-    "suffix": "SuffixDecodingProposer.propose() called with the pre-0.24 signature",
     "eagle3": "RBLNCompileError: RblnTensorAllocateDevTensorKey pass fails on the "
     "eagle3 aux-hidden-state graph",
 }

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1610,7 +1610,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         elif spec_config.method == "suffix":
             assert isinstance(sampled_token_ids, list)
             assert isinstance(self.drafter, SuffixDecodingProposer)
-            draft_token_ids = self.drafter.propose(self.input_batch, sampled_token_ids)
+            draft_token_ids = self.drafter.propose(
+                self.num_spec_tokens, self.input_batch, sampled_token_ids
+            )
         elif spec_config.method == "medusa":
             assert isinstance(sampled_token_ids, list)
             assert isinstance(self.drafter, RBLNMedusaProposer)


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

> *What does this PR do? What feature, fix, or improvement does it bring?*

vLLM 0.24.0 reordered `SuffixDecodingProposer.propose()` to take `num_speculative_tokens` as its first positional argument:
```python
def propose(
    self,
    num_speculative_tokens: int,
    input_batch: InputBatch,
    sampled_token_ids: list[list[int]],
    slot_mappings: ... | None = None,
): ...
```

`RBLNModelRunner` was still calling it with the pre-0.24 signature. This PR passes `self.num_spec_tokens` as the leading argument.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Run `pytest test/native/v1/spec_decode/test_spec_decode_e2e.py -k suffix --model-compile`.
2. Verify the `suffix` case now passes instead of xfailing.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
