### PR TITLE
fix(dp): pad the dummy decode batch to the DP-agreed bucket

### DIFF
--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -2065,7 +2065,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             token_indices=token_indices,
             layout=InputLayout(
                 num_reqs=num_reqs,
-                num_reqs_padded=num_reqs,
+                num_reqs_padded=num_reqs if self.is_prefill else num_reqs_padded,
                 query_len=num_tokens_per_req,
                 query_len_padded=num_tokens_per_req,
             ),


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Serving `gpt-oss-120b` with `--data-parallel-size 8 --enable-expert-parallel` crashes as soon as one DP rank goes idle and runs a dummy batch:
```
torch._dynamo.exc.TorchRuntimeError: RuntimeError when making fake tensor call
  call_method view(*(FakeTensor(..., size=(1, 64, 64)), 32, 0, 64, 64))
  got RuntimeError("shape '[32, 0, 64, 64]' is invalid for input of size 4096")
  ...
  vllm_rbln/v1/attention/backends/flash_attention.py:417, in forward
```

`_dummy_run` fed `num_reqs_padded` to `_build_attention_metadata` (which uses it as `batch_pad`, padding `seq_lens` /  `block_tables`) but staged the model input with `InputLayout(num_reqs_padded=num_reqs)` - the unpadded value.

With DP > 1 and `VLLM_RBLN_SPECIALIZE_MOE_DECODE` (default on), `num_reqs_padded` is the decode bucket covering the **max `num_reqs` across all DP ranks**, since every rank must execute the same graph shape for the MoE collectives. So an idle rank calling `execute_dummy_batch` (`num_reqs=1`) ended up with:

| | value |
|---|---|
| model input | `(1, 1)` → 1 token |
| `attn_metadata.seq_lens.shape[0]` | 32 |
| `q_len = num_tokens // b_size` | `1 // 32` = **0** |

So this stages the dummy input at `num_reqs_padded` for decode, matching `_preprocess`:
```python
num_reqs_padded=num_reqs if is_prefill else num_reqs_padded,
```

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] 🛠 Bug fix (`fix`)

---

### 🧪 How to Test

1. Run — serve with DP-asymmetric traffic (fewer in-flight requests than DP ranks, so some ranks are guaranteed to go idle and take the `execute_dummy_batch` path):

   ```bash
   RBLN_COMP_DTYPE=dlfloat VLLM_RBLN_USE_VLLM_MODEL=1 \
   VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY=manual \
   VLLM_RBLN_DECODE_BATCH_BUCKET_MANUAL_BUCKETS=1,8,16,32 \
   VLLM_RBLN_COMPILE_STRICT_MODE=1 VLLM_RBLN_MOE_REDUCE_SCATTER=1 \
   VLLM_RBLN_SAMPLER=1 VLLM_RBLN_SORT_BATCH=1 VLLM_RBLN_USE_DEVICE_TENSOR=1 \
   vllm serve openai/gpt-oss-120b \
     --data-parallel-size 8 --enable-expert-parallel --enable-chunked-prefill \
     --block-size 1024 --max-model-len 131072 --max-num-batched-tokens 512 \
     --max-num-seqs 32 --num-gpu-blocks-override 768 --no-enable-prefix-caching

   # run requests
   for i in {1..256]; do
     curl -s localhost:8000/v1/completions -H 'Content-Type: application/json' \
       -d '{"model":"openai/gpt-oss-120b","prompt":"hello","max_tokens":64}' &
   done; wait
   ```

2. Verify output - all requests complete and no worker error raises.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
