### PR TITLE
fix(worker): read the DP device mapping vLLM 0.24 puts on the config

### DIFF
--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -38,6 +38,7 @@ def _make_vllm_config(
     data_parallel_size=1,
     data_parallel_rank=0,
     world_size_across_dp=1,
+    assigned_physical_gpu_ids=None,
     quantization=None,
     enforce_eager=False,
     profiler=None,
@@ -51,6 +52,7 @@ def _make_vllm_config(
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
             world_size_across_dp=world_size_across_dp,
+            assigned_physical_gpu_ids=assigned_physical_gpu_ids,
             disable_custom_all_reduce=False,
         ),
         model_config=SimpleNamespace(
@@ -108,6 +110,7 @@ def make_worker(monkeypatch):
         data_parallel_size=1,
         data_parallel_rank=0,
         world_size_across_dp=None,
+        assigned_physical_gpu_ids=None,
         num_devices=1,
         num_ray_nodes=1,
         has_torch_rbln=False,
@@ -120,6 +123,7 @@ def make_worker(monkeypatch):
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
             world_size_across_dp=wsd,
+            assigned_physical_gpu_ids=assigned_physical_gpu_ids,
         )
         monkeypatch.setattr(WorkerBase, "__init__", _fake_super_init)
         monkeypatch.setattr(
@@ -256,6 +260,43 @@ class TestInitDeviceEnv:
         os.environ["RBLN_DEVICES"] = "a,b,c,d"
         with pytest.raises(ValueError):
             make_worker(world_size=4, local_rank=0)
+
+    @pytest.mark.parametrize("dp_rank, assigned", [(0, [4]), (2, [6])])
+    def test_dp_mapping_wins_over_env(self, make_worker, dp_rank, assigned):
+        # Under DP the env var holds the whole deployment; vLLM 0.24 puts this
+        # rank's share on the config instead.
+        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        make_worker(
+            world_size=1,
+            data_parallel_size=4,
+            data_parallel_rank=dp_rank,
+            assigned_physical_gpu_ids=assigned,
+        )
+        assert os.environ["RBLN_DEVICES"] == str(assigned[0])
+
+    def test_dp_mapping_expands_by_num_devices(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "0,1,2,3"
+        make_worker(
+            world_size=2,
+            data_parallel_size=2,
+            data_parallel_rank=1,
+            assigned_physical_gpu_ids=[2, 3],
+            num_devices=2,
+            local_rank=1,
+        )
+        assert os.environ["RBLN_DEVICES"] == "6,7"
+
+    def test_no_mapping_falls_back_to_env(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "0,1"
+        make_worker(world_size=2, data_parallel_size=2, data_parallel_rank=1)
+        assert os.environ["RBLN_DEVICES"] == "0"
+
+    def test_dp_mapping_wrong_count_raises(self, make_worker):
+        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        with pytest.raises(AssertionError):
+            make_worker(
+                world_size=1, data_parallel_size=4, assigned_physical_gpu_ids=[4, 5]
+            )
 
 
 def _params():

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -57,11 +57,13 @@ def _make_parallel_config(
     tensor_parallel_size=1,
     pipeline_parallel_size=1,
     world_size_across_dp=1,
+    assigned_physical_gpu_ids=None,
 ):
     return SimpleNamespace(
         world_size=world_size,
         data_parallel_size=data_parallel_size,
         data_parallel_rank=data_parallel_rank,
+        assigned_physical_gpu_ids=assigned_physical_gpu_ids,
         tensor_parallel_size=tensor_parallel_size,
         pipeline_parallel_size=pipeline_parallel_size,
         disable_custom_all_reduce=False,
@@ -108,6 +110,7 @@ def _make_vllm_config(
     data_parallel_rank=0,
     world_size=1,
     world_size_across_dp=1,
+    assigned_physical_gpu_ids=None,
 ):
     return SimpleNamespace(
         profiler_config=_make_profiler_config(profiler_trace_dir),
@@ -116,6 +119,7 @@ def _make_vllm_config(
             data_parallel_size=data_parallel_size,
             data_parallel_rank=data_parallel_rank,
             world_size_across_dp=world_size_across_dp,
+            assigned_physical_gpu_ids=assigned_physical_gpu_ids,
         ),
         model_config=_make_model_config(
             trust_remote_code=trust_remote_code,
@@ -529,6 +533,59 @@ class TestInitDeviceEnv:
         cfg = _make_vllm_config(world_size=2, data_parallel_rank=1)
         _create_worker(vllm_config=cfg, local_rank=0, rank=0, num_devices=2)
         assert os.environ["RBLN_DEVICES"] == "4,5"
+
+    def test_assigned_physical_ids_win_over_the_env_var(self):
+        """Under DP the env var still holds the whole deployment's list.
+
+        vLLM 0.24 stopped narrowing it per rank and puts this rank's share on
+        the config instead, so DP=4/TP=1 sees four entries against a
+        `world_size` of 1 and has to read the mapping.
+        """
+        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        cfg = _make_vllm_config(
+            world_size=1,
+            data_parallel_size=4,
+            data_parallel_rank=2,
+            assigned_physical_gpu_ids=[6],
+        )
+        _create_worker(vllm_config=cfg, local_rank=0, rank=0, num_devices=1)
+        assert os.environ["RBLN_DEVICES"] == "6"
+
+    def test_assigned_physical_ids_expand_by_num_devices(self):
+        """The mapping feeds the same per-local-rank expansion as the env var."""
+        os.environ["RBLN_DEVICES"] = "0,1,2,3"
+        cfg = _make_vllm_config(
+            world_size=2,
+            data_parallel_size=2,
+            data_parallel_rank=1,
+            assigned_physical_gpu_ids=[2, 3],
+        )
+        _create_worker(vllm_config=cfg, local_rank=1, rank=1, num_devices=2)
+        assert os.environ["RBLN_DEVICES"] == "6,7"
+
+    def test_no_assignment_falls_back_to_the_env_var(self):
+        """Without a mapping the pre-0.24 behaviour is kept exactly."""
+        os.environ["RBLN_DEVICES"] = "0,1"
+        cfg = _make_vllm_config(
+            world_size=2,
+            data_parallel_size=2,
+            data_parallel_rank=1,
+            assigned_physical_gpu_ids=None,
+        )
+        _create_worker(vllm_config=cfg, local_rank=0, rank=0, num_devices=1)
+        assert os.environ["RBLN_DEVICES"] == "0"
+
+    def test_assigned_physical_ids_wrong_count_still_asserts(self):
+        """A mapping that does not match `world_size` must not pass silently."""
+        os.environ["RBLN_DEVICES"] = "4,5,6,7"
+        cfg = _make_vllm_config(
+            world_size=1,
+            data_parallel_size=4,
+            data_parallel_rank=0,
+            assigned_physical_gpu_ids=[4, 5],
+        )
+        with pytest.raises(AssertionError, match="should have device count"):
+            _create_worker(vllm_config=cfg, local_rank=0, rank=0, num_devices=1)
 
 
 # ===========================================================================

--- a/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
+++ b/tests/torch_compile/unit/v1/worker/test_rbln_worker.py
@@ -535,12 +535,8 @@ class TestInitDeviceEnv:
         assert os.environ["RBLN_DEVICES"] == "4,5"
 
     def test_assigned_physical_ids_win_over_the_env_var(self):
-        """Under DP the env var still holds the whole deployment's list.
-
-        vLLM 0.24 stopped narrowing it per rank and puts this rank's share on
-        the config instead, so DP=4/TP=1 sees four entries against a
-        `world_size` of 1 and has to read the mapping.
-        """
+        # Under DP the env var holds the whole deployment; vLLM 0.24 puts this
+        # rank's share on the config instead.
         os.environ["RBLN_DEVICES"] = "4,5,6,7"
         cfg = _make_vllm_config(
             world_size=1,
@@ -552,7 +548,6 @@ class TestInitDeviceEnv:
         assert os.environ["RBLN_DEVICES"] == "6"
 
     def test_assigned_physical_ids_expand_by_num_devices(self):
-        """The mapping feeds the same per-local-rank expansion as the env var."""
         os.environ["RBLN_DEVICES"] = "0,1,2,3"
         cfg = _make_vllm_config(
             world_size=2,
@@ -564,7 +559,6 @@ class TestInitDeviceEnv:
         assert os.environ["RBLN_DEVICES"] == "6,7"
 
     def test_no_assignment_falls_back_to_the_env_var(self):
-        """Without a mapping the pre-0.24 behaviour is kept exactly."""
         os.environ["RBLN_DEVICES"] = "0,1"
         cfg = _make_vllm_config(
             world_size=2,
@@ -576,7 +570,6 @@ class TestInitDeviceEnv:
         assert os.environ["RBLN_DEVICES"] == "0"
 
     def test_assigned_physical_ids_wrong_count_still_asserts(self):
-        """A mapping that does not match `world_size` must not pass silently."""
         os.environ["RBLN_DEVICES"] = "4,5,6,7"
         cfg = _make_vllm_config(
             world_size=1,

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -135,16 +135,11 @@ class RBLNWorker(WorkerBase):
             end_idx = start_idx + num_devices
             selected_devices = ",".join(device_ids[start_idx:end_idx])
         else:
-            # Through 0.23 vLLM narrowed the device-control env var itself before
-            # spawning a DP engine -- `set_device_control_env_var()` patched
-            # os.environ for platforms that need env isolation, which includes
-            # RBLN -- so by the time we read it, it already held this rank's
-            # share. 0.24 replaced that with
-            # `set_assigned_physical_gpu_ids_for_dp_rank()`, which leaves the env
-            # var alone and puts the per-rank mapping on the config instead
-            # (vllm/v1/engine/utils.py). Read the mapping when it is there;
-            # `world_size` is TPxPP in both releases, so it is the env var that
-            # changed meaning, not the size.
+            # vLLM 0.24 stopped narrowing the device-control env var per DP rank
+            # and puts the mapping on the config instead, so under DP the env var
+            # now holds the whole deployment's list (vllm/v1/engine/utils.py,
+            # set_assigned_physical_gpu_ids_for_dp_rank). getattr: older vLLM has
+            # no such field.
             assigned = getattr(self.parallel_config, "assigned_physical_gpu_ids", None)
             if assigned:
                 device_ids = [str(i) for i in assigned]

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -135,7 +135,21 @@ class RBLNWorker(WorkerBase):
             end_idx = start_idx + num_devices
             selected_devices = ",".join(device_ids[start_idx:end_idx])
         else:
-            device_ids = os.environ[env_var].split(",")
+            # Through 0.23 vLLM narrowed the device-control env var itself before
+            # spawning a DP engine -- `set_device_control_env_var()` patched
+            # os.environ for platforms that need env isolation, which includes
+            # RBLN -- so by the time we read it, it already held this rank's
+            # share. 0.24 replaced that with
+            # `set_assigned_physical_gpu_ids_for_dp_rank()`, which leaves the env
+            # var alone and puts the per-rank mapping on the config instead
+            # (vllm/v1/engine/utils.py). Read the mapping when it is there;
+            # `world_size` is TPxPP in both releases, so it is the env var that
+            # changed meaning, not the size.
+            assigned = getattr(self.parallel_config, "assigned_physical_gpu_ids", None)
+            if assigned:
+                device_ids = [str(i) for i in assigned]
+            else:
+                device_ids = os.environ[env_var].split(",")
             assert len(device_ids) == world_size, (
                 f"device_ids: {device_ids} should have device count: {world_size}"
             )


### PR DESCRIPTION
### 🚀 Summary of Changes

`_init_device_env`'s explicit branch reads `RBLN_DEVICES` directly. That was correct through vLLM 0.23, where the launcher narrowed the env var itself before spawning each DP engine:

```python
# v0.23.0  vllm/v1/engine/utils.py
def set_device_control_env_var(vllm_config, local_dp_rank):
    value = get_device_indices(evar, local_dp_rank, world_size, local_world_size)
    with patch.dict(os.environ, values=((evar, value),)):
        yield
```

applied under `is_dp and (needs_device_env_isolation or use_ray)`, where `needs_device_env_isolation = not (is_cuda_alike() or is_xpu())` — RBLN qualifies. So the worker always saw a value already scoped to its shard.

0.24 replaced that with `set_assigned_physical_gpu_ids_for_dp_rank()` at the same call site and under the same condition. It leaves the env var alone and puts the per-rank mapping on the config instead:

```python
# v0.24.0  vllm/v1/engine/utils.py
vllm_config.parallel_config.assigned_physical_gpu_ids = physical_gpu_ids
```

Nothing narrows `RBLN_DEVICES` any more, so every rank sees the whole deployment's list:

```
AssertionError: device_ids: ['4', '5', '6', '7'] should have device count: 1
```

(DP=4, TP=1 on `RBLN_DEVICES=4,5,6,7`; `world_size` is 1, so each rank wants one device and gets four.)

This reads the mapping when it is present and falls back to the env var when it is not.

### Why the mapping rather than slicing here

Upstream derives it with `local_dp_rank` and `local_world_size`, so multi-node, hybrid LB and Ray land on the right shard without this file knowing the topology. Slicing here from the global `data_parallel_rank` would get those wrong.

It also covers non-MoE DP, which slicing would miss: the mapping is written in the launcher, before the engine process resets `data_parallel_size` and `data_parallel_rank` to 1/0 for dense models ([core.py](https://github.com/vllm-project/vllm/blob/v0.24.0/vllm/v1/engine/core.py#L1188-L1200)).

`world_size` is TPxPP in both 0.23 and 0.24 — the env var is what changed meaning, not the size. An earlier revision of this PR claimed otherwise; that was wrong.

`getattr` rather than attribute access, so the file still imports against a vLLM that predates the field.

### Testing

`TestInitDeviceEnv` had no case where an explicit device list met DP > 1 — the reason this could break without CI noticing. Four added:

| test | without the fix |
|---|---|
| `assigned_physical_ids_win_over_the_env_var` | fails, production message |
| `assigned_physical_ids_expand_by_num_devices` | fails, production message |
| `no_assignment_falls_back_to_the_env_var` | passes (pins the fallback) |
| `assigned_physical_ids_wrong_count_still_asserts` | passes (pins the guard) |

83 passed / 4 skipped in the file.

End-to-end: this is the behaviour every DP4 EAGLE3 serving run on MiniMax-M2.5 has had locally — HumanEval 164/164, MT-Bench 80/80, ShareGPT 100/100 and a full SWE-bench pass. Without it, the server does not boot.

### 📌 Related Issues / Tickets

Regression from #829 (vLLM 0.24 bump).
