### PR TITLE
Log measured per-chiplet device memory against the KV estimate

### DIFF
--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -361,8 +361,47 @@ class RBLNWorker(WorkerBase):
         logger.info(
             "available_memory_estimate = %.2f GiB", available_memory_estimate / 1024**3
         )
+        self._available_memory_estimate = available_memory_estimate
 
         return available_memory_estimate
+
+    def _log_device_memory(self, phase: str) -> None:
+        """Log measured per-chiplet device memory against the KV budget estimate.
+
+        The estimate is per chiplet (`estimate_available_memory` divides by
+        `rsd_replicas`), and a device runs out on its heaviest chiplet.
+        """
+        if not has_torch_rbln:
+            return
+        try:
+            per_chiplet = torch.rbln.memory_stats_per_chiplet()
+        except (AttributeError, RuntimeError) as exc:
+            logger.debug("per-chiplet memory stats unavailable: %s", exc)
+            return
+        if not per_chiplet:
+            return
+
+        chiplets = sorted({int(key.split(".")[1]) for key in per_chiplet})
+        reserved = [
+            per_chiplet.get(f"chiplet.{c}.reserved.current", 0) for c in chiplets
+        ]
+        logger.info(
+            "[%s] device memory reserved per chiplet = %s GiB (max %.2f, total %.2f)",
+            phase,
+            ", ".join(f"{value / 1024**3:.2f}" for value in reserved),
+            max(reserved) / 1024**3,
+            sum(reserved) / 1024**3,
+        )
+
+        estimate = getattr(self, "_available_memory_estimate", None)
+        if estimate:
+            logger.info(
+                "[%s] KV budget estimate = %.2f GiB/chiplet, heaviest chiplet now "
+                "holds %.2f GiB",
+                phase,
+                estimate / 1024**3,
+                max(reserved) / 1024**3,
+            )
 
     def get_kv_connector_handshake_metadata(self) -> dict | None:
         """Get KV connector metadata from this worker if available."""
@@ -399,6 +438,7 @@ class RBLNWorker(WorkerBase):
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
         self.model_runner.initialize_kv_cache(kv_cache_config)
+        self._log_device_memory("after-kv-alloc")
 
     @instrument(span_name="Warmup (NPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
@@ -444,6 +484,7 @@ class RBLNWorker(WorkerBase):
                 )
 
             if is_rbln_oom_error(e.inner_exception):
+                self._log_device_memory("oom")
                 raise RuntimeError(
                     "Not enough memory for "
                     f"{self.model_runner.kv_cache_config.num_blocks} "
@@ -454,6 +495,8 @@ class RBLNWorker(WorkerBase):
         finally:
             # NOTE(RBLN): Apply CPU affinity only after compile/warm-up.
             self._ensure_rbln_cpu_affinity_after_warmup()
+
+        self._log_device_memory("after-warmup")
 
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.


### PR DESCRIPTION
`available_memory_estimate` is logged at startup but never checked against what the run actually consumes, so a wrong estimate surfaces only as an OOM much later. In a DeepSeek-V3 dp8 + MTP case it surfaced **20 minutes after init**, on the first decode step, with no intermediate signal.

## 1. `_log_device_memory(phase)`

Reads `torch.rbln.memory_stats_per_chiplet()` and logs reserved bytes per chiplet plus max and total:

```
[after-warmup] device memory reserved per chiplet = 32.51, 30.44, 30.44, 30.44 GiB (max 32.51, total 123.83)
[after-warmup] KV budget estimate = 7.02 GiB/chiplet, heaviest chiplet now holds 32.51 GiB
```

The estimate and the measurement are logged **side by side and on the same axis**. `estimate_available_memory` divides by `rsd_replicas`, so its output is per chiplet, and a device runs out on its heaviest chiplet — comparing against a device-wide total would hide the imbalance that actually causes the failure.

## Output

Three phases, one line pair each. Numbers reconstructed from the DeepSeek-V3 dp8 run's logs, not a live capture.

```
(Worker_DP3_EP3) INFO [rbln_worker.py] available_memory_estimate = 7.02 GiB

(Worker_DP3_EP3) INFO [after-kv-alloc] device memory reserved per chiplet = 29.42, 28.10, 28.10, 28.10 GiB (max 29.42, total 113.72)
(Worker_DP3_EP3) INFO [after-kv-alloc] KV budget estimate = 7.02 GiB/chiplet, heaviest chiplet now holds 29.42 GiB

(Worker_DP3_EP3) INFO [after-warmup]   device memory reserved per chiplet = 32.51, 30.44, 30.44, 30.44 GiB (max 32.51, total 123.83)
(Worker_DP3_EP3) INFO [after-warmup]   KV budget estimate = 7.02 GiB/chiplet, heaviest chiplet now holds 32.51 GiB
```

What a reader gets that they do not have today:

- **Chiplet 0 is ~2 GiB heavier than the rest, at every phase.** Against a 35.0 GiB per-chiplet capacity that is the number that runs out; the device-wide total (123.83 of 140.0 GiB) looks comfortable and is the figure currently reported.
- **The delta between the two phases** (29.42 → 32.51 GiB on chiplet 0) is what warm-up graphs cost — currently invisible.
- **Only ~2.5 GiB of headroom is left on chiplet 0 after warm-up.** In the DeepSeek case a later runtime-compiled MTP drafter graph asked for 1052 MiB per chiplet and failed. That headroom being printed is the early warning.

On the OOM path the same pair is emitted under `[oom]` before the existing "Not enough memory for N blocks of KV cache" message, so the suggestion to lower `--num-gpu-blocks-override` arrives with the numbers that justify it.

If torch-rbln lacks `memory_stats_per_chiplet()` (or there is no NPU) nothing is logged and the run is unchanged.

## 2. Three call sites

`after-kv-alloc`, `after-warmup`, and the existing `is_rbln_oom_error` handler in `compile_or_warm_up_model`.

The OOM handler alone is not enough: it only catches `BackendCompilerFailed` **during warm-up**, and a graph first compiled at runtime (an MTP drafter shape outside warm-up coverage, for instance) fails well outside it. The `after-warmup` snapshot is what makes that case diagnosable.

## 3. Safe when torch.rbln is absent

Guarded by the existing `has_torch_rbln` flag, catches `AttributeError`/`RuntimeError`, and returns early on empty stats — a host without an NPU, or an older torch-rbln without the new API, is unaffected.

## Dependency

Requires torch-rbln `memory_stats_per_chiplet()` (RBLN-SW/torch-rbln#191), which in turn needs rebel_compiler `rbln_get_memory_stats_per_chiplet()` (rebellions-sw/rebel_compiler#12684). Until those land the `AttributeError` path makes this a no-op rather than a break.

## Verification

pre-commit passed: ruff check, ruff format, mypy, typos, licence headers. Logging only — no behaviour change on any allocation path.

## TODOs

- Run the DeepSeek-V3 dp8 case end to end once the two dependencies land, and confirm the estimate/measurement gap is visible at `after-kv-alloc`.
- The gap this was built to expose is still unfixed: `utils.py:233` `buffer_per_runtime_per_core = 2**28` (256 MiB/runtime) against a measured 1052 MiB/chiplet for an MTP drafter runtime, and `estimate_available_memory` has no notion of chiplet imbalance. Correcting the estimate is a separate PR.
