### PR TITLE
other(test): add DP e2e and platform coverage to tests/native

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,6 @@
 /vllm_rbln/v1/worker/metrics.py @rebel-eunji @rebel-jonghewk
 /vllm_rbln/v1/worker/rbln_model_runner.py @rebel-cjlee @rebel-minkyu @rebel-jonghewk
 /vllm_rbln/v1/worker/utils.py @rebel-cjlee @rebel-minkyu @rebel-eunji @rebel-jonghewk
+
+# test
+/tests/native @rebel-cjlee

--- a/tests/native/basic_correctness/test_basic_correctness.py
+++ b/tests/native/basic_correctness/test_basic_correctness.py
@@ -31,11 +31,6 @@ MAX_TOKENS = 5
 NUM_LOGPROBS = 5
 
 
-@pytest.fixture(autouse=True)
-def _disable_compile_cache(monkeypatch):
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-
-
 @pytest.mark.model_compile
 @pytest.mark.parametrize("spec", spec_params(MODELS))
 def test_models(hf_runner, vllm_runner, spec: CompileModelSpec, monkeypatch) -> None:

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -376,11 +376,38 @@ def vllm_runner():
 
 
 @pytest.fixture(scope="session")
+def async_vllm_runner():
+    """AsyncVllmRunner class -- the DP-capable runner (lazy import; see
+    vllm_runner)."""
+    from tests.native.runners import AsyncVllmRunner
+
+    return AsyncVllmRunner
+
+
+@pytest.fixture(scope="session")
 def hf_runner():
     """HfRunner class (lazy import; see vllm_runner)."""
     from tests.native.runners import HfRunner
 
     return HfRunner
+
+
+@pytest.fixture(autouse=True)
+def _drop_envs_shadows():
+    """Remove any ``vllm_rbln.envs`` attribute a test left behind.
+
+    `monkeypatch.setattr(envs, NAME, ...)` cannot clean up after itself here: envs
+    serves those names through the module's ``__getattr__``, so monkeypatch records
+    the value that produced and its undo puts it back as a *real* attribute -- which
+    then wins over ``__getattr__`` and freezes that variable for the rest of the
+    session, silently defeating any later monkeypatch.setenv on it.
+    """
+    from vllm_rbln import envs
+
+    before = set(vars(envs))
+    yield
+    for name in set(vars(envs)) - before:
+        delattr(envs, name)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/native/distributed/test_dp_e2e.py
+++ b/tests/native/distributed/test_dp_e2e.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tests.native.model_specs import CompileModelSpec, apply_spec_envs, spec_params
+from tests.native.runners import DPRequest
+from tests.native.utils import (
+    check_outputs_equal,
+    devices_needed,
+    rbln_device_count,
+)
+
+DP_MODELS: list[CompileModelSpec] = [
+    CompileModelSpec(
+        "openai/gpt-oss-20b",
+        {"data_parallel_size": 4},
+        {"VLLM_RBLN_SUB_BLOCK_CACHE": "0"},
+    ),
+]
+
+PROMPT = "The quick brown fox jumps over the lazy dog."
+MAX_TOKENS = 32
+# Finishes mid-decode of a MAX_TOKENS request, so its rank goes idle early.
+SHORT_MAX_TOKENS = 4
+
+# Hang detector, applied per test; the first test of a spec carries that spec's
+# engine build, which compiles once per DP rank.
+_TIMEOUT_S = int(os.environ.get("VLLM_RBLN_TEST_DP_TIMEOUT_S", 3600))
+
+pytestmark = [
+    pytest.mark.model_compile,
+    # thread, not the default signal: a rank blocked in a collective is below
+    # Python and would not handle SIGALRM until it returns.
+    pytest.mark.timeout(_TIMEOUT_S, method="thread"),
+]
+
+
+@dataclass(frozen=True)
+class DPLane:
+    """One engine and the spec it was built from."""
+
+    spec: CompileModelSpec
+    runner: Any
+
+    @property
+    def dp_size(self) -> int:
+        return self.spec.engine_kwargs["data_parallel_size"]
+
+    def generate_greedy(self, requests: list[DPRequest]) -> list[tuple[list[int], str]]:
+        return self.runner.generate_greedy(requests)
+
+
+@pytest.fixture(scope="module", params=spec_params(DP_MODELS))
+def dp_lane(request, async_vllm_runner):
+    spec: CompileModelSpec = request.param
+    needed = devices_needed(spec.engine_kwargs, spec.rsd)
+    available = rbln_device_count()
+    if available < needed:
+        pytest.skip(f"{spec.test_id} needs {needed} NPUs, host has {available}")
+
+    # Module-scoped and parametrized: pytest groups a spec's tests together, so
+    # only one engine holds the devices at a time.
+    #
+    # RBLN_DEVICES is left as the host set it: both branches of
+    # _init_device_env give each DP rank its own slice, and CI runs with it set.
+    with pytest.MonkeyPatch.context() as mp:
+        apply_spec_envs(spec, mp)
+        with async_vllm_runner(spec.model, **spec.engine_kwargs) as runner:
+            assert runner.engine.vllm_config.model_config.is_moe, (
+                f"{spec.model} is not MoE, so this lane runs independent "
+                f"replicas rather than data parallel"
+            )
+            yield DPLane(spec, runner)
+
+
+@pytest.fixture(scope="module")
+def symmetric_outputs(dp_lane):
+    """Every rank busy with the same prompt -- the reference for the asymmetric
+    runs, and the only run here with no idle rank."""
+    return dp_lane.generate_greedy(
+        [DPRequest(PROMPT, MAX_TOKENS, dp_rank=rank) for rank in range(dp_lane.dp_size)]
+    )
+
+
+def test_every_rank_produces_the_same_output(symmetric_outputs) -> None:
+    # Ranks differ only in which NPU slice they hold, so a divergence here is a
+    # per-rank fault: mis-assigned devices, or DP padding leaking into logits.
+    for rank in range(1, len(symmetric_outputs)):
+        check_outputs_equal(
+            outputs_0_lst=[symmetric_outputs[0]],
+            outputs_1_lst=[symmetric_outputs[rank]],
+            name_0="rank0",
+            name_1=f"rank{rank}",
+        )
+
+
+def test_output_survives_idle_peers(dp_lane, symmetric_outputs) -> None:
+    # Every other rank dummy-runs (RBLNModelRunner._dummy_run) for the whole of
+    # rank 0's decode -- the shape #894 got wrong.
+    outputs = dp_lane.generate_greedy([DPRequest(PROMPT, MAX_TOKENS, dp_rank=0)])
+
+    check_outputs_equal(
+        outputs_0_lst=[symmetric_outputs[0]],
+        outputs_1_lst=outputs,
+        name_0="rank0 with every rank busy",
+        name_1=f"rank0 with {dp_lane.dp_size - 1} idle peers",
+    )
+
+
+def test_output_survives_a_peer_finishing_early(dp_lane, symmetric_outputs) -> None:
+    # rank0 drops out mid-flight, so the group's shape changes under the survivor.
+    last = dp_lane.dp_size - 1
+    outputs = dp_lane.generate_greedy(
+        [
+            DPRequest(PROMPT, SHORT_MAX_TOKENS, dp_rank=0),
+            DPRequest(PROMPT, MAX_TOKENS, dp_rank=last),
+        ]
+    )
+    short, long = outputs
+
+    check_outputs_equal(
+        outputs_0_lst=[symmetric_outputs[last]],
+        outputs_1_lst=[long],
+        name_0=f"rank{last} with every rank busy",
+        name_1=f"rank{last} outliving rank0",
+    )
+    # Bounded, not fixed: an earlier EOS still leaves the rank idle early.
+    short_ids = short[0]
+    assert 0 < len(short_ids) <= SHORT_MAX_TOKENS, (
+        f"rank0 asked for at most {SHORT_MAX_TOKENS} tokens, got {len(short_ids)}"
+    )
+    assert short_ids == symmetric_outputs[0][0][: len(short_ids)], (
+        "rank0's tokens changed when it shared the group with a longer request"
+    )

--- a/tests/native/distributed/test_dp_e2e.py
+++ b/tests/native/distributed/test_dp_e2e.py
@@ -31,8 +31,8 @@ from tests.native.utils import (
 DP_MODELS: list[CompileModelSpec] = [
     CompileModelSpec(
         "openai/gpt-oss-20b",
-        {"data_parallel_size": 4},
-        {"VLLM_RBLN_SUB_BLOCK_CACHE": "0"},
+        {"data_parallel_size": 4, "max_num_seqs": 2},
+        {"VLLM_RBLN_SUB_BLOCK_CACHE": "0", "VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT": "2"},
     ),
 ]
 
@@ -113,8 +113,7 @@ def test_every_rank_produces_the_same_output(symmetric_outputs) -> None:
 
 
 def test_output_survives_idle_peers(dp_lane, symmetric_outputs) -> None:
-    # Every other rank dummy-runs (RBLNModelRunner._dummy_run) for the whole of
-    # rank 0's decode -- the shape #894 got wrong.
+    # Every other rank dummy-runs for the whole of rank 0's decode.
     outputs = dp_lane.generate_greedy([DPRequest(PROMPT, MAX_TOKENS, dp_rank=0)])
 
     check_outputs_equal(
@@ -149,4 +148,26 @@ def test_output_survives_a_peer_finishing_early(dp_lane, symmetric_outputs) -> N
     )
     assert short_ids == symmetric_outputs[0][0][: len(short_ids)], (
         "rank0's tokens changed when it shared the group with a longer request"
+    )
+
+
+def test_output_survives_a_peer_at_a_bigger_bucket(dp_lane) -> None:
+    # rank0 decodes two requests at once (bucket 2) while every other rank idles
+    # at bucket 1, so their dummy batches have to pad to the group's bucket. Under
+    # #894 that mismatch was a shape error, so completing at all is the signal;
+    # the batch-2 graph differs from symmetric_outputs' batch-1 one, so those are
+    # not compared.
+    first, second = dp_lane.generate_greedy(
+        [
+            DPRequest(PROMPT, MAX_TOKENS, dp_rank=0),
+            DPRequest(PROMPT, MAX_TOKENS, dp_rank=0),
+        ]
+    )
+
+    assert len(first[0]) == len(second[0]) == MAX_TOKENS
+    check_outputs_equal(
+        outputs_0_lst=[first],
+        outputs_1_lst=[second],
+        name_0="rank0 request 0",
+        name_1="rank0 request 1",
     )

--- a/tests/native/distributed/test_dp_specs.py
+++ b/tests/native/distributed/test_dp_specs.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from vllm.engine.arg_utils import EngineArgs
+
+from tests.native.distributed.test_dp_e2e import DP_MODELS
+from tests.native.model_specs import CompileModelSpec, apply_spec_envs, spec_params
+from tests.native.runners import _RBLN_RUNNER_DEFAULTS
+
+_CARRIER = "Qwen/Qwen3-0.6B"
+
+_STANDALONE = "RBLN_CTX_STANDALONE"
+
+
+@pytest.fixture(autouse=True)
+def isolated_standalone_env(monkeypatch):
+    # The hook writes it directly; monkeypatch can only roll back a key it recorded.
+    monkeypatch.setenv(_STANDALONE, "")
+
+
+@pytest.mark.parametrize("spec", spec_params(DP_MODELS))
+def test_every_dp_spec_passes_the_platform_rules(spec: CompileModelSpec, monkeypatch):
+    apply_spec_envs(spec, monkeypatch)
+    EngineArgs(
+        model=_CARRIER, **{**_RBLN_RUNNER_DEFAULTS, **spec.engine_kwargs}
+    ).create_engine_config()
+
+    assert os.environ[_STANDALONE] == "1"

--- a/tests/native/runners.py
+++ b/tests/native/runners.py
@@ -17,13 +17,17 @@ import lazily from a fixture (after pytest_configure sets the env)."""
 
 from __future__ import annotations
 
+import asyncio
 import gc
+from dataclasses import dataclass
 from typing import Any
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from vllm import LLM, SamplingParams
 from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.v1.engine.async_llm import AsyncLLM
 
 # RBLN requires an explicit block_size; the rest are the known-good native config
 # for these small models (chunked prefill, small batch/token budget).
@@ -88,6 +92,107 @@ class VllmRunner:
         # suppressed, since a failed shutdown would leak the device silently.
         self.llm.llm_engine.engine_core.shutdown()
         del self.llm
+        torch._dynamo.reset()
+        cleanup_dist_env_and_memory()
+
+
+@dataclass(frozen=True)
+class DPRequest:
+    """One request; ``dp_rank=None`` leaves placement to the engine's load
+    balancer, an int pins it to that rank so a test's load is a known quantity."""
+
+    prompt: str
+    max_tokens: int
+    dp_rank: int | None = None
+
+
+async def _build_async_engine(args: AsyncEngineArgs) -> AsyncLLM:
+    # Synchronous work in a coroutine on purpose: AsyncLLM starts its output
+    # handler eagerly only when a loop is already running, and it has to be this
+    # runner's loop.
+    return AsyncLLM.from_engine_args(args)
+
+
+class AsyncVllmRunner:
+    """System under test for data parallel: ``AsyncLLM`` with the native RBLN
+    config; kwargs override, same as VllmRunner.
+
+    Not VllmRunner because the sync ``LLM`` rejects ``data_parallel_size > 1`` --
+    the internal-load-balancing engine client only exists on the async side
+    (``make_async_mp_client`` -> ``DPLBAsyncMPClient``). vLLM then owns rank
+    assignment, the DP master port, the coordinator and the liveness monitor.
+    """
+
+    def __init__(
+        self, model: str, *, request_timeout_s: float = 600.0, **kwargs
+    ) -> None:
+        self.request_timeout_s = request_timeout_s
+        args = AsyncEngineArgs(model=model, **{**_RBLN_RUNNER_DEFAULTS, **kwargs})
+        # One loop for the runner's lifetime; a fresh asyncio.run() per call would
+        # orphan the engine's output handler on a closed loop.
+        self._loop = asyncio.new_event_loop()
+        self.engine = self._loop.run_until_complete(_build_async_engine(args))
+
+    def generate_greedy(self, requests: list[DPRequest]) -> list[tuple[list[int], str]]:
+        """Run every request concurrently, returning results in the order given.
+        Concurrency is the point: DP ranks only interact while more than one of
+        them has -- or pointedly does not have -- work."""
+        return self._loop.run_until_complete(self._generate_all(requests))
+
+    async def _generate_all(self, requests: list[DPRequest]) -> list[Any]:
+        # gather() must be built inside the loop, or its futures attach to
+        # whatever loop asyncio considers current.
+        return list(
+            await asyncio.gather(
+                *(self._generate_one(i, req) for i, req in enumerate(requests))
+            )
+        )
+
+    async def _generate_one(
+        self, index: int, request: DPRequest
+    ) -> tuple[list[int], str]:
+        params = SamplingParams(temperature=0.0, max_tokens=request.max_tokens)
+        stream = self.engine.generate(
+            request.prompt,
+            params,
+            request_id=f"dp-req-{index}",
+            data_parallel_rank=request.dp_rank,
+        )
+
+        async def drain() -> Any:
+            final = None
+            async for output in stream:
+                final = output
+            return final
+
+        # A bound, not a budget: a rank stalled in a collective would otherwise
+        # hang the session. Startup has its own (VLLM_ENGINE_READY_TIMEOUT_S).
+        try:
+            final = await asyncio.wait_for(drain(), timeout=self.request_timeout_s)
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"request {index} (dp_rank={request.dp_rank}) did not finish "
+                f"within {self.request_timeout_s}s"
+            ) from exc
+
+        assert final is not None, (
+            f"request {index} (dp_rank={request.dp_rank}): the engine closed the "
+            f"stream without producing any output"
+        )
+        completion = final.outputs[0]
+        return list(completion.token_ids), completion.text
+
+    def __enter__(self) -> AsyncVllmRunner:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        # Reaps every DP engine core, not just rank 0's. Not suppressed: a failed
+        # shutdown would leak the whole DP group of devices silently.
+        self.engine.shutdown()
+        # Let the cancelled output handler settle, or it is "destroyed but pending".
+        self._loop.run_until_complete(asyncio.sleep(0))
+        self._loop.close()
+        del self.engine
         torch._dynamo.reset()
         cleanup_dist_env_and_memory()
 

--- a/tests/native/runners.py
+++ b/tests/native/runners.py
@@ -131,7 +131,14 @@ class AsyncVllmRunner:
         # One loop for the runner's lifetime; a fresh asyncio.run() per call would
         # orphan the engine's output handler on a closed loop.
         self._loop = asyncio.new_event_loop()
-        self.engine = self._loop.run_until_complete(_build_async_engine(args))
+        try:
+            self.engine = self._loop.run_until_complete(_build_async_engine(args))
+        except BaseException:
+            # __exit__ never runs when __init__ raises, and an unclosed loop adds a
+            # ResourceWarning next to the real failure. BaseException so a Ctrl-C
+            # during a long compile is covered too.
+            self._loop.close()
+            raise
 
     def generate_greedy(self, requests: list[DPRequest]) -> list[tuple[list[int], str]]:
         """Run every request concurrently, returning results in the order given.
@@ -188,10 +195,13 @@ class AsyncVllmRunner:
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         # Reaps every DP engine core, not just rank 0's. Not suppressed: a failed
         # shutdown would leak the whole DP group of devices silently.
-        self.engine.shutdown()
-        # Let the cancelled output handler settle, or it is "destroyed but pending".
-        self._loop.run_until_complete(asyncio.sleep(0))
-        self._loop.close()
+        try:
+            self.engine.shutdown()
+            # Let the cancelled output handler settle, or it is "destroyed but
+            # pending".
+            self._loop.run_until_complete(asyncio.sleep(0))
+        finally:
+            self._loop.close()
         del self.engine
         torch._dynamo.reset()
         cleanup_dist_env_and_memory()

--- a/tests/native/test_platform.py
+++ b/tests/native/test_platform.py
@@ -1,0 +1,515 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RblnPlatform on the native path only (VLLM_RBLN_USE_VLLM_MODEL=1). Written
+# against outcomes rather than call paths -- a real config is built so the engine's
+# own entry point (VllmConfig.__post_init__ -> check_and_update_config) does the
+# work, and the assertions read the resulting config, the raised error, or the
+# process env. That survives splitting the optimum and native paths apart.
+
+from __future__ import annotations
+
+import copy
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.config import CompilationMode, VllmConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+import vllm_rbln.platform as platform
+from vllm_rbln.platform import RBLN_DEFAULT_MAX_NUM_SEQS, RblnPlatform
+
+# Small, non-gated and already needed by the spec-decode tests; a config build
+# costs ~1s and never touches the device.
+_MODEL = "JackFram/llama-68m"
+_ENGINE_ARGS = dict(
+    max_model_len=2048,
+    block_size=1024,
+    max_num_batched_tokens=128,
+    enable_chunked_prefill=True,
+)
+
+_STANDALONE = "RBLN_CTX_STANDALONE"
+# Means "the platform did not touch it". Set rather than deleted so monkeypatch
+# has recorded the key and can roll back the platform's direct os.environ write.
+_UNTOUCHED = ""
+
+
+def _build(**engine_kwargs) -> VllmConfig:
+    """A real config, so building it *is* running the platform hook.
+
+    Not vllm_config.make_vllm_config: that pins max_num_seqs, which this file
+    needs unset to observe the RBLN default.
+    """
+    return EngineArgs(
+        model=_MODEL, **{**_ENGINE_ARGS, **engine_kwargs}
+    ).create_engine_config()
+
+
+@pytest.fixture(scope="module")
+def configured() -> VllmConfig:
+    """One plain native config, built once."""
+    return _build()
+
+
+@pytest.fixture
+def reconfigure(configured):
+    """Copy the built config, mutate it, run the hook again.
+
+    For branches EngineArgs cannot express -- an unsupported dtype, chunked
+    prefill off (upstream rejects it first), a LoRA config, more ranks. Re-running
+    is safe because every field the hook writes is already at its final value.
+    """
+
+    def run(mutate) -> VllmConfig:
+        config = copy.deepcopy(configured)
+        mutate(config)
+        RblnPlatform.check_and_update_config(config)
+        return config
+
+    return run
+
+
+@pytest.fixture(autouse=True)
+def isolated_standalone_env(monkeypatch):
+    monkeypatch.setenv(_STANDALONE, _UNTOUCHED)
+
+
+class TestPlatformIdentity:
+    """Values frozen at import: the class body derives them from the env, so a
+    spawned worker re-importing the module must land on the same lane."""
+
+    def test_device_triple_moves_together(self):
+        # A device_type of "rbln" with an empty dist_backend (or the reverse)
+        # would half-enable the device lane.
+        triple = (
+            RblnPlatform.device_name,
+            RblnPlatform.device_type,
+            RblnPlatform.dist_backend,
+        )
+        if platform.USE_DEVICE_TENSOR:
+            assert triple == ("rbln", "rbln", "rbln-ccl")
+        else:
+            assert triple == ("cpu", "cpu", "")
+
+    def test_device_tensor_needs_both_switches(self):
+        assert platform.USE_DEVICE_TENSOR is (
+            platform.envs.VLLM_RBLN_USE_VLLM_MODEL
+            and platform.envs.VLLM_RBLN_USE_DEVICE_TENSOR
+        )
+
+    @pytest.mark.parametrize(
+        ("attribute", "expected"),
+        [
+            # Ops dispatch on CPU even when tensors live on the device.
+            ("dispatch_key", "CPU"),
+            # RBLNWorker._init_device_env narrows this var per rank.
+            ("device_control_env_var", "RBLN_DEVICES"),
+            ("simple_compile_backend", "bypass"),
+        ],
+    )
+    def test_pinned_attributes(self, attribute, expected):
+        assert getattr(RblnPlatform, attribute) == expected
+
+    def test_simple_compile_backend_is_registered(self):
+        # Named at class scope; an unregistered name only fails once vLLM
+        # compiles something.
+        assert torch._dynamo.lookup_backend(RblnPlatform.simple_compile_backend)
+
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [
+            ("is_pin_memory_available", False),
+            ("can_update_inplace", False),
+            ("support_hybrid_kv_cache", True),
+            ("get_nixl_memory_type", "DRAM"),
+            (
+                "get_device_communicator_cls",
+                "vllm_rbln.distributed.rbln_communicator.RblnCommunicator",
+            ),
+        ],
+    )
+    def test_pinned_answers(self, method, expected):
+        assert getattr(RblnPlatform, method)() == expected
+
+    def test_nixl_supported_devices(self):
+        # Upstream rejects any kv_buffer_device not listed here, so both the
+        # host-bounce ("cpu") and D2D ("rbln") pairings must stay.
+        assert RblnPlatform.get_nixl_supported_devices() == {
+            "cpu": ("cpu", "rbln"),
+            "rbln": ("rbln", "cpu"),
+        }
+
+
+class TestRejectedConfigs:
+    def test_v2_model_runner(self, monkeypatch, reconfigure):
+        monkeypatch.setattr(platform.envs, "VLLM_USE_V2_MODEL_RUNNER", True)
+        with pytest.raises(ValueError, match="VLLM_USE_V2_MODEL_RUNNER"):
+            reconfigure(lambda config: None)
+
+    def test_lora(self, reconfigure):
+        with pytest.raises(ValueError, match="LoRA"):
+            reconfigure(lambda config: setattr(config, "lora_config", object()))
+
+    def test_chunked_prefill_off(self, reconfigure):
+        with pytest.raises(ValueError, match="chunked prefill"):
+            reconfigure(
+                lambda config: setattr(
+                    config.scheduler_config, "enable_chunked_prefill", False
+                )
+            )
+
+    def test_dp_needs_a_divisible_token_budget(self, reconfigure):
+        with pytest.raises(ValueError, match="divisible"):
+            reconfigure(_ranks(data_parallel_size=2, max_num_seqs=5))
+
+    @pytest.mark.parametrize("ranks", [dict(data_parallel_size=2), dict(ep=True)])
+    def test_dp_and_ep_need_the_moe_tokens_mask(self, monkeypatch, reconfigure, ranks):
+        monkeypatch.setattr(platform.envs, "VLLM_RBLN_USE_MOE_TOKENS_MASK", False)
+        with pytest.raises(ValueError, match="VLLM_RBLN_USE_MOE_TOKENS_MASK"):
+            reconfigure(_ranks(**ranks))
+
+    def test_tp_inherits_neither_dp_rule(self, monkeypatch, reconfigure):
+        # Both rules guard padding introduced by DP multicast, so TP alone must
+        # pass even with the mask off and an indivisible budget.
+        monkeypatch.setattr(platform.envs, "VLLM_RBLN_USE_MOE_TOKENS_MASK", False)
+        reconfigure(_ranks(tensor_parallel_size=2, max_num_seqs=5))
+
+    def test_moe_tokens_mask_defaults_on(self):
+        # The error above calls 1 the default; a flipped default breaks DP.
+        assert platform.envs.VLLM_RBLN_USE_MOE_TOKENS_MASK is True
+
+
+def _ranks(*, ep: bool = False, max_num_seqs: int | None = None, **parallel):
+    """A mutator that widens a config to more ranks."""
+
+    def mutate(config: VllmConfig) -> None:
+        for field, value in parallel.items():
+            setattr(config.parallel_config, field, value)
+        if ep:
+            config.parallel_config.enable_expert_parallel = True
+        if max_num_seqs is not None:
+            config.scheduler_config.max_num_seqs = max_num_seqs
+
+    return mutate
+
+
+class TestModelParallelSideEffect:
+    @pytest.mark.parametrize(
+        "ranks",
+        [
+            dict(data_parallel_size=2),
+            dict(tensor_parallel_size=2),
+            dict(pipeline_parallel_size=2),
+            dict(ep=True),
+        ],
+        ids=["dp", "tp", "pp", "ep"],
+    )
+    def test_any_model_parallel_axis_sets_standalone_context(self, reconfigure, ranks):
+        reconfigure(_ranks(**ranks))
+        assert os.environ[_STANDALONE] == "1"
+
+    def test_single_rank_leaves_it_alone(self, reconfigure):
+        reconfigure(lambda config: None)
+        assert os.environ[_STANDALONE] == _UNTOUCHED
+
+
+class TestDtype:
+    def test_supported_dtype_is_kept(self):
+        assert _build(dtype="float16").model_config.dtype == torch.float16
+
+    def test_unsupported_dtype_falls_back_to_fp32(self, reconfigure):
+        config = reconfigure(
+            lambda config: setattr(config.model_config, "dtype", torch.float64)
+        )
+        assert config.model_config.dtype == torch.float32
+
+    def test_enforce_fp32_overrides_a_supported_dtype(self, monkeypatch, reconfigure):
+        monkeypatch.setattr(platform.envs, "VLLM_RBLN_ENFORCE_MODEL_FP32", True)
+        config = reconfigure(
+            lambda config: setattr(config.model_config, "dtype", torch.float16)
+        )
+        assert config.model_config.dtype == torch.float32
+
+
+class TestWorkerAndScheduler:
+    def test_auto_worker_becomes_the_rbln_worker(self, configured):
+        assert (
+            configured.parallel_config.worker_cls
+            == "vllm_rbln.v1.worker.rbln_worker.RBLNWorker"
+        )
+
+    def test_an_explicit_worker_is_respected(self):
+        assert (
+            _build(worker_cls="pkg.mod.MyWorker").parallel_config.worker_cls
+            == "pkg.mod.MyWorker"
+        )
+
+    def test_scheduler_is_replaced_unconditionally(self, reconfigure):
+        # Unlike worker_cls there is no "auto" guard: whatever was asked for is
+        # overwritten.
+        config = reconfigure(
+            lambda config: setattr(
+                config.scheduler_config, "scheduler_cls", "pkg.mod.MyScheduler"
+            )
+        )
+        assert (
+            config.scheduler_config.scheduler_cls
+            == "vllm_rbln.v1.core.rbln_scheduler.RBLNScheduler"
+        )
+
+
+class TestCompilation:
+    def test_vllm_compilation_is_disabled(self, configured):
+        # @support_torch_compile is unsupported; RBLN compiles in its own runner.
+        assert configured.compilation_config.mode == CompilationMode.NONE
+
+    def test_a_lone_none_custom_op_is_cleared(self):
+        assert (
+            _build(
+                compilation_config={"custom_ops": ["none"]}
+            ).compilation_config.custom_ops
+            == []
+        )
+
+    def test_only_a_lone_none_is_cleared(self):
+        # Two entries fall outside the guard, so "none" survives as upstream
+        # meant it. (The default list is upstream's business, not ours.)
+        assert _build(
+            compilation_config={"custom_ops": ["none", "+rms_norm"]}
+        ).compilation_config.custom_ops == ["none", "+rms_norm"]
+
+
+class TestSchedulerOverrides:
+    def test_async_scheduling_is_forced_off(self):
+        assert _build(async_scheduling=True).scheduler_config.async_scheduling is False
+
+    def test_cascade_attention_is_disabled(self, configured):
+        assert configured.model_config.disable_cascade_attn is True
+
+    def test_unset_max_num_seqs_takes_the_rbln_default(self, configured):
+        assert configured.scheduler_config.max_num_seqs == RBLN_DEFAULT_MAX_NUM_SEQS
+
+    def test_an_explicit_max_num_seqs_is_respected(self):
+        assert _build(max_num_seqs=8).scheduler_config.max_num_seqs == 8
+
+
+class TestEnforceEager:
+    def test_outcome_follows_the_device_lane(self, reconfigure):
+        mutate = lambda config: setattr(  # noqa: E731
+            config.model_config, "enforce_eager", True
+        )
+        if platform.USE_DEVICE_TENSOR:
+            # Eager needs real device tensors; dtype is forced to fp16 there.
+            assert reconfigure(mutate).model_config.dtype == torch.float16
+        else:
+            with pytest.raises(ValueError, match="VLLM_RBLN_USE_DEVICE_TENSOR"):
+                reconfigure(mutate)
+
+
+def _selector(*, use_mla: bool = False, use_sparse: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(use_mla=use_mla, use_sparse=use_sparse)
+
+
+class TestAttentionBackend:
+    @pytest.mark.parametrize(
+        ("use_mla", "expected"),
+        [
+            (False, AttentionBackendEnum.FLASH_ATTN),
+            (True, AttentionBackendEnum.FLASH_ATTN_MLA),
+        ],
+    )
+    def test_unset_backend_resolves_by_mla(self, use_mla, expected):
+        assert (
+            RblnPlatform.get_attn_backend_cls(None, _selector(use_mla=use_mla))
+            == expected.get_path()
+        )
+
+    @pytest.mark.parametrize(
+        "backend",
+        [AttentionBackendEnum.FLASH_ATTN, AttentionBackendEnum.FLASH_ATTN_MLA],
+    )
+    def test_an_allowed_backend_passes_through(self, backend):
+        assert (
+            RblnPlatform.get_attn_backend_cls(backend, _selector())
+            == backend.get_path()
+        )
+
+    def test_any_other_backend_is_rejected(self):
+        other = next(
+            backend
+            for backend in AttentionBackendEnum
+            if backend
+            not in (
+                AttentionBackendEnum.FLASH_ATTN,
+                AttentionBackendEnum.FLASH_ATTN_MLA,
+            )
+        )
+        with pytest.raises(ValueError, match="Cannot use"):
+            RblnPlatform.get_attn_backend_cls(other, _selector())
+
+    def test_sparse_attention_is_unsupported(self):
+        with pytest.raises(NotImplementedError, match="Sparse"):
+            RblnPlatform.get_attn_backend_cls(
+                AttentionBackendEnum.FLASH_ATTN, _selector(use_sparse=True)
+            )
+
+
+class TestDeviceName:
+    """The NPU name drives compilation, so a compile-only host without an NPU
+    must still be able to name its target."""
+
+    @pytest.fixture(autouse=True)
+    def no_host_override(self, monkeypatch):
+        # Both are host passthrough vars the suite does not scrub.
+        monkeypatch.delenv("RBLN_FORCE_NPU_NAME", raising=False)
+        monkeypatch.delenv("RBLN_TARGET_SOC", raising=False)
+
+    def test_the_driver_answer_wins(self, monkeypatch):
+        monkeypatch.setenv("RBLN_FORCE_NPU_NAME", "RBLN-FROM-ENV")
+        monkeypatch.setattr(platform.rebel, "get_npu_name", lambda *a: "RBLN-CR03")
+        assert RblnPlatform.get_device_name() == "RBLN-CR03"
+
+    @pytest.mark.parametrize("env", ["RBLN_FORCE_NPU_NAME", "RBLN_TARGET_SOC"])
+    def test_env_fallbacks_when_no_npu_is_mounted(self, monkeypatch, env):
+        monkeypatch.setattr(platform.rebel, "get_npu_name", lambda *a: None)
+        monkeypatch.setenv(env, "RBLN-CA25")
+        assert RblnPlatform.get_device_name() == "RBLN-CA25"
+
+    def test_no_npu_and_no_override_raises(self, monkeypatch):
+        monkeypatch.setattr(platform.rebel, "get_npu_name", lambda *a: None)
+        with pytest.raises(RuntimeError, match="RBLN_FORCE_NPU_NAME"):
+            RblnPlatform.get_device_name()
+
+
+class TestAdditionalForwardContext:
+    def test_kv_cache_bases_passes_through(self):
+        bases = object()
+        assert RblnPlatform.set_additional_forward_context(kv_cache_bases=bases) == {
+            "kv_cache_bases": bases
+        }
+
+    @pytest.mark.parametrize("kwargs", [{}, {"kv_bases": 1}, {"attn_metadata": 1}])
+    def test_everything_else_is_dropped(self, kwargs):
+        assert RblnPlatform.set_additional_forward_context(**kwargs) == {}
+
+
+class TestPreRegisterAndUpdate:
+    def test_parser_gains_rbln_and_loses_block_size_choices(self):
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--device", choices=["cuda", "cpu"])
+        parser.add_argument("--block-size", dest="block_size", choices=[8, 16])
+
+        RblnPlatform.pre_register_and_update(parser)
+
+        device, block_size = parser._actions[1], parser._actions[2]
+        assert device.choices is not None and "rbln" in device.choices
+        # RBLN block sizes are not from upstream's list.
+        assert block_size.choices is None
+
+    def test_the_engine_args_patches_are_idempotent(self):
+        # Applied at plugin load already; wrapping twice would stack wrappers.
+        # __func__ because each attribute access rebinds the classmethod.
+        before = EngineArgs.get_batch_defaults.__func__
+        RblnPlatform.pre_register_and_update()
+        assert EngineArgs.get_batch_defaults.__func__ is before
+
+
+class TestCustomKvCacheSpecs:
+    @pytest.fixture(autouse=True)
+    def restore_registry(self):
+        # The registry is a process global with lazy init: it populates itself
+        # only while empty, so leaving it half-filled makes every later test that
+        # builds a scheduler fail with "No manager registered for ...".
+        from vllm.v1 import kv_cache_spec_registry as registry
+
+        saved = dict(registry._REGISTRY_KVCACHESPEC_LIST)
+        yield
+        registry._REGISTRY_KVCACHESPEC_LIST.clear()
+        registry._REGISTRY_KVCACHESPEC_LIST.update(saved)
+
+    def test_the_sliding_window_manager_is_reachable(self, configured):
+        # The runner looks the manager up by spec at KV-cache init; an
+        # unregistered pair only fails there, on a device. Registered through
+        # register_all_kvcache_specs like production does -- it fills in the
+        # built-in specs first and calls the platform hook last.
+        from vllm.v1.core.single_type_kv_cache_manager import (
+            register_all_kvcache_specs,
+        )
+        from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+        from vllm_rbln.v1.kv_cache import (
+            RBLNSlidingWindowManager,
+            RBLNSlidingWindowSpec,
+        )
+
+        register_all_kvcache_specs(configured)
+        spec = RBLNSlidingWindowSpec(
+            block_size=1024,
+            num_kv_heads=2,
+            head_size=8,
+            dtype=torch.float16,
+            sliding_window=512,
+        )
+        assert KVCacheSpecRegistry.get_manager_class(spec) is RBLNSlidingWindowManager
+
+
+def test_running_the_hook_twice_changes_nothing(configured, reconfigure):
+    """The premise every reconfigure() test rests on: each field the hook writes
+    is already at its final value, so a second pass is a no-op. Should the hook
+    start appending instead of assigning, this fails first."""
+    again = reconfigure(lambda config: None)
+
+    assert again.model_config.dtype == configured.model_config.dtype
+    assert again.parallel_config.worker_cls == configured.parallel_config.worker_cls
+    assert (
+        again.scheduler_config.scheduler_cls
+        == configured.scheduler_config.scheduler_cls
+    )
+    assert again.compilation_config.mode == configured.compilation_config.mode
+    assert (
+        again.compilation_config.custom_ops == configured.compilation_config.custom_ops
+    )
+    assert (
+        again.cache_config.enable_prefix_caching
+        == configured.cache_config.enable_prefix_caching
+    )
+
+
+class TestKnownGaps:
+    """Behaviour pinned as-is because it looks unintended; see
+    docs/test_note.log."""
+
+    def test_sliding_window_keeps_prefix_caching_on(self):
+        # disable_unsupported_prefix_caching is only called from the optimum
+        # branch, so its native clause is unreachable. SWA instead surfaces much
+        # later as the sub-block multi-group NotImplementedError in
+        # RBLNModelRunner.initialize_kv_cache, and the workaround in use is
+        # VLLM_RBLN_SUB_BLOCK_CACHE=0.
+        config = _build(
+            enable_prefix_caching=True, hf_overrides={"sliding_window": 512}
+        )
+        assert RblnPlatform._uses_sliding_window(config.model_config.hf_config)
+        assert config.cache_config.enable_prefix_caching is True
+
+    def test_a_non_mp_executor_backend_is_only_warned_about(self, configured):
+        # The warning says "fallback to mp" but nothing assigns, and vLLM's own
+        # default for world_size 1 is "uni" -- so it fires on every single-process
+        # run and Executor.get_class still builds a UniProcExecutor.
+        assert configured.parallel_config.distributed_executor_backend == "uni"

--- a/tests/native/test_runners.py
+++ b/tests/native/test_runners.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The suite's own runners (currently AsyncVllmRunner only): rank pinning,
+# concurrent submission, result ordering, the per-request timeout, shutdown --
+# with the engine faked at AsyncLLM.from_engine_args. A fault here would not fail
+# the DP e2e lane, it would make it answer wrongly.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import tests.native.runners as runners
+from tests.native.runners import AsyncVllmRunner, DPRequest
+
+MODEL = "fake/model-for-args-only"
+
+
+class _FakeCompletion:
+    def __init__(self, token_ids: list[int], text: str) -> None:
+        self.token_ids = token_ids
+        self.text = text
+
+
+class _FakeRequestOutput:
+    def __init__(self, token_ids: list[int], text: str) -> None:
+        self.outputs = [_FakeCompletion(token_ids, text)]
+
+
+class _FakeEngine:
+    """Stands in for AsyncLLM: records submissions, yields streams the test
+    scripts. ``gate`` holds every request until all of them have arrived."""
+
+    def __init__(self) -> None:
+        self.submissions: list[dict] = []
+        self.captured: dict = {}  # AsyncEngineArgs and the loop at build time
+        self.shutdown_calls = 0
+        self.gate: asyncio.Event | None = None
+        self.expected_in_flight: int | None = None
+        self.never_finish: set[str] = set()
+        self.yield_nothing = False
+        self.steps = 2
+
+    async def _stream(self, request_id: str, max_tokens: int):
+        if self.gate is not None:
+            if len(self.submissions) == self.expected_in_flight:
+                self.gate.set()
+            await self.gate.wait()
+        if request_id in self.never_finish:
+            await asyncio.Event().wait()  # pending forever
+        if self.yield_nothing:
+            return
+        # Later requests finish first, so ordering cannot follow completion.
+        await asyncio.sleep(0.01 * (len(self.submissions) - self._index(request_id)))
+        token_ids = list(range(max_tokens))
+        for step in range(self.steps):
+            yield _FakeRequestOutput(token_ids, f"{request_id}-step{step}")
+
+    def _index(self, request_id: str) -> int:
+        ids = [sub["request_id"] for sub in self.submissions]
+        return ids.index(request_id)
+
+    def generate(
+        self,
+        prompt,
+        sampling_params,
+        request_id: str,
+        *,
+        data_parallel_rank: int | None = None,
+        **kwargs,
+    ):
+        self.submissions.append(
+            dict(
+                prompt=prompt,
+                request_id=request_id,
+                dp_rank=data_parallel_rank,
+                temperature=sampling_params.temperature,
+                max_tokens=sampling_params.max_tokens,
+            )
+        )
+        return self._stream(request_id, sampling_params.max_tokens)
+
+    def shutdown(self, timeout: float | None = None) -> None:
+        self.shutdown_calls += 1
+
+
+@pytest.fixture
+def fake_engine(monkeypatch):
+    """Replaces the AsyncLLM the runner builds with a scriptable stand-in."""
+    engine = _FakeEngine()
+
+    class _FakeAsyncLLM:
+        @staticmethod
+        def from_engine_args(args, *rest, **kwargs):
+            engine.captured["args"] = args
+            # Raises unless the engine really is built inside a loop.
+            engine.captured["build_loop"] = asyncio.get_running_loop()
+            return engine
+
+    monkeypatch.setattr(runners, "AsyncLLM", _FakeAsyncLLM)
+    return engine
+
+
+def test_native_defaults_apply_and_kwargs_override(fake_engine):
+    with AsyncVllmRunner(MODEL, data_parallel_size=4, block_size=512):
+        pass
+    args = fake_engine.captured["args"]
+    assert (args.model, args.data_parallel_size) == (MODEL, 4)
+    assert args.max_num_batched_tokens == 128
+    assert args.enable_chunked_prefill is True
+    assert args.block_size == 512
+
+
+class TestSubmission:
+    def test_requests_reach_their_pinned_rank(self, fake_engine):
+        requests = [
+            DPRequest("a", 4, dp_rank=0),
+            DPRequest("b", 8, dp_rank=7),
+            DPRequest("c", 2),  # unpinned: the balancer places it
+        ]
+        with AsyncVllmRunner(MODEL) as runner:
+            runner.generate_greedy(requests)
+
+        submitted = {sub["prompt"]: sub for sub in fake_engine.submissions}
+        assert submitted["a"]["dp_rank"] == 0
+        assert submitted["b"]["dp_rank"] == 7
+        assert submitted["c"]["dp_rank"] is None
+
+    def test_sampling_is_greedy_with_per_request_length(self, fake_engine):
+        with AsyncVllmRunner(MODEL) as runner:
+            runner.generate_greedy([DPRequest("a", 4, 0), DPRequest("b", 32, 1)])
+
+        submitted = fake_engine.submissions
+        assert [sub["temperature"] for sub in submitted] == [0.0, 0.0]
+        assert {sub["prompt"]: sub["max_tokens"] for sub in submitted} == {
+            "a": 4,
+            "b": 32,
+        }
+
+    def test_requests_are_in_flight_together(self, fake_engine):
+        # DP ranks only interact while several have work at once, so a runner
+        # that awaited requests one by one would deadlock on the gate.
+        fake_engine.gate = asyncio.Event()
+        fake_engine.expected_in_flight = 3
+        requests = [DPRequest(str(i), 2, dp_rank=i) for i in range(3)]
+
+        with AsyncVllmRunner(MODEL, request_timeout_s=5.0) as runner:
+            outputs = runner.generate_greedy(requests)
+
+        assert len(outputs) == 3
+
+
+class TestResults:
+    def test_order_follows_the_request_list_not_completion(self, fake_engine):
+        # The fake finishes the last request first (see _stream).
+        requests = [DPRequest("first", 3, 0), DPRequest("second", 5, 1)]
+        with AsyncVllmRunner(MODEL) as runner:
+            outputs = runner.generate_greedy(requests)
+
+        assert [ids for ids, _text in outputs] == [[0, 1, 2], [0, 1, 2, 3, 4]]
+
+    def test_last_streamed_output_wins(self, fake_engine):
+        # A streaming engine yields a growing output; the last one is the answer.
+        fake_engine.steps = 3
+        with AsyncVllmRunner(MODEL) as runner:
+            ((_ids, text),) = runner.generate_greedy([DPRequest("a", 2, 0)])
+
+        assert text.endswith("-step2")
+
+
+class TestFailureModes:
+    def test_timeout_names_the_rank(self, fake_engine):
+        fake_engine.never_finish = {"dp-req-0"}
+        with (
+            AsyncVllmRunner(MODEL, request_timeout_s=0.05) as runner,
+            pytest.raises(TimeoutError, match="dp_rank=3"),
+        ):
+            runner.generate_greedy([DPRequest("a", 2, dp_rank=3)])
+
+    def test_stream_without_output_is_not_a_type_error(self, fake_engine):
+        # A rank whose engine died can close the stream having produced nothing.
+        fake_engine.yield_nothing = True
+        with (
+            AsyncVllmRunner(MODEL) as runner,
+            pytest.raises(AssertionError, match="without producing any output"),
+        ):
+            runner.generate_greedy([DPRequest("a", 2, dp_rank=1)])
+
+
+class TestLifecycle:
+    def test_exit_shuts_the_engine_down_once(self, fake_engine):
+        with AsyncVllmRunner(MODEL) as runner:
+            runner.generate_greedy([DPRequest("a", 2, 0)])
+        assert fake_engine.shutdown_calls == 1
+
+    def test_exit_closes_the_loop(self, fake_engine):
+        with AsyncVllmRunner(MODEL) as runner:
+            loop = runner._loop
+        assert loop.is_closed()
+
+    def test_engine_is_built_on_the_runners_loop(self, fake_engine):
+        # Its output handler must land on the loop later generate calls use.
+        with AsyncVllmRunner(MODEL) as runner:
+            assert fake_engine.captured["build_loop"] is runner._loop

--- a/tests/native/test_runners.py
+++ b/tests/native/test_runners.py
@@ -206,6 +206,31 @@ class TestLifecycle:
             runner.generate_greedy([DPRequest("a", 2, 0)])
         assert fake_engine.shutdown_calls == 1
 
+    def test_a_failed_build_closes_the_loop(self, monkeypatch):
+        # __init__ raising means __exit__ never runs, so the loop has to be closed
+        # on the way out or a ResourceWarning lands next to the real failure.
+        created: list = []
+        real_new_event_loop = asyncio.new_event_loop
+
+        def record_loop():
+            loop = real_new_event_loop()
+            created.append(loop)
+            return loop
+
+        monkeypatch.setattr(asyncio, "new_event_loop", record_loop)
+
+        class _Exploding:
+            @staticmethod
+            def from_engine_args(args, *rest, **kwargs):
+                raise RuntimeError("engine build failed")
+
+        monkeypatch.setattr(runners, "AsyncLLM", _Exploding)
+
+        with pytest.raises(RuntimeError, match="engine build failed"):
+            AsyncVllmRunner(MODEL)
+
+        assert created and created[0].is_closed()
+
     def test_exit_closes_the_loop(self, fake_engine):
         with AsyncVllmRunner(MODEL) as runner:
             loop = runner._loop

--- a/tests/native/test_utils.py
+++ b/tests/native/test_utils.py
@@ -27,7 +27,9 @@ from .utils import (
     NATIVE_ENV,
     SCRUBBED_EXTRA,
     SCRUBBED_PREFIXES,
+    devices_needed,
     is_scrubbed,
+    rbln_device_count,
     scrub_env,
 )
 
@@ -111,6 +113,33 @@ def test_native_env_pins_no_host_description():
     """The suite may pin behavior, never machine identity: pinning a passthrough
     like RBLN_DEVICES would hard-code one host's topology."""
     assert not (set(NATIVE_ENV) & HOST_ENV_PASSTHROUGH)
+
+
+class TestDeviceInventory:
+    """The guard that keeps a multi-device test off a host with too few NPUs."""
+
+    def test_visible_list_wins_over_the_nodes(self, monkeypatch):
+        monkeypatch.setenv("RBLN_DEVICES", "3,4")
+        assert rbln_device_count() == 2
+
+    @pytest.mark.parametrize("blank", ["", " "])
+    def test_blank_visible_list_falls_back_to_the_nodes(self, monkeypatch, blank):
+        # Read as zero it would skip every device test on a host that has them.
+        monkeypatch.delenv("RBLN_DEVICES", raising=False)
+        mounted = rbln_device_count()
+        monkeypatch.setenv("RBLN_DEVICES", blank)
+        assert rbln_device_count() == mounted
+
+    @pytest.mark.parametrize(
+        ("kwargs", "rsd", "expected"),
+        [
+            ({}, 1, 1),
+            ({"tensor_parallel_size": 2, "data_parallel_size": 4}, 1, 8),
+            ({"pipeline_parallel_size": 2}, 2, 4),
+        ],
+    )
+    def test_devices_needed_multiplies_every_axis(self, kwargs, rsd, expected):
+        assert devices_needed(kwargs, rsd) == expected
 
 
 def test_scrub_covers_every_name_the_env_table_reads():

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -186,7 +186,14 @@ def rbln_device_count() -> int:
 def devices_needed(engine_kwargs: dict, rsd: int = 1) -> int:
     """NPUs an engine built with ``engine_kwargs`` will occupy. Mirrors
     RBLNWorker._init_device_env: DP ranks do not share, and every (tp x pp) rank
-    takes VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK devices."""
+    takes ``rsd`` devices.
+
+    ``rsd`` is a spec's ``CompileModelSpec.rsd``, i.e. the
+    VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK the engine will run with. It is an
+    argument rather than an env read because the caller checks the budget *before*
+    ``apply_spec_envs`` publishes it, and because the suite scrubs that name from
+    the parent's environment anyway.
+    """
     return (
         engine_kwargs.get("tensor_parallel_size", 1)
         * engine_kwargs.get("pipeline_parallel_size", 1)

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import glob
 import json
 import os
 import signal
@@ -30,12 +31,13 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import ParamSpec
 
-# What "native" means: the switch that selects vLLM modelling over optimum.
-# Deliberately nothing else -- pinning a knob to the value the source already
-# defaults to would mean a flipped default goes unnoticed.
+# What "native" means: the switch that selects vLLM modelling over optimum, plus
+# the knobs whose source default the suite must not take. Nothing that merely
+# repeats a default -- pinning those would hide the day one is flipped.
 NATIVE_ENV = {
     "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
     "VLLM_RBLN_USE_VLLM_MODEL": "1",
+    "VLLM_DISABLE_COMPILE_CACHE": "1",
 }
 
 # Host description -- which NPUs exist, what SOC to compile for, OMP threads.
@@ -163,7 +165,36 @@ def check_logprobs_close(
             break
 
 
-# -- per-test process isolation -------------------------------------------------
+# The driver exposes one node per NPU.
+_RBLN_DEVICE_NODES = "/dev/rbln*"
+
+
+def rbln_device_count() -> int:
+    """How many NPUs this session may use. ``RBLN_DEVICES`` wins when set, since a
+    job may be given two of eight. Otherwise the device nodes are counted rather
+    than asking the driver: this runs in the parent pytest process, which must not
+    open the device (that would pin it for the whole session)."""
+    visible = [
+        entry
+        for entry in os.environ.get("RBLN_DEVICES", "").split(",")
+        if entry.strip()
+    ]
+    # Exported but empty means "no restriction", not "no devices".
+    return len(visible) or len(glob.glob(_RBLN_DEVICE_NODES))
+
+
+def devices_needed(engine_kwargs: dict, rsd: int = 1) -> int:
+    """NPUs an engine built with ``engine_kwargs`` will occupy. Mirrors
+    RBLNWorker._init_device_env: DP ranks do not share, and every (tp x pp) rank
+    takes VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK devices."""
+    return (
+        engine_kwargs.get("tensor_parallel_size", 1)
+        * engine_kwargs.get("pipeline_parallel_size", 1)
+        * engine_kwargs.get("data_parallel_size", 1)
+        * rsd
+    )
+
+
 # Ported from vLLM tests/utils.py (issue #41415). The RBLN SDK accumulates
 # device/runtime state across LLM instantiations in one process, so each
 # engine-using test must run in a fresh interpreter (dev-legacy #629:

--- a/tests/native/v1/worker/test_kv_sharing_fast_prefill_e2e.py
+++ b/tests/native/v1/worker/test_kv_sharing_fast_prefill_e2e.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Placeholder: KV sharing is unsupported on RBLN (both attention impls raise on
-# kv_sharing_target_layer_name), so there is nothing to exercise yet. See NOTE.md.
+# kv_sharing_target_layer_name), so there is nothing to exercise yet.
 
 import pytest
 

--- a/tests/native/v1/worker/test_rbln_model_runner.py
+++ b/tests/native/v1/worker/test_rbln_model_runner.py
@@ -16,6 +16,7 @@
 # what each method reads. Methods that need the real runner's buffers live in
 # test_rbln_model_runner_states / _inputs / _kv_cache.
 
+import contextlib
 from types import SimpleNamespace
 
 import numpy as np
@@ -31,6 +32,9 @@ from vllm.v1.worker.kv_connector_model_runner_mixin import (
 
 import vllm_rbln.v1.worker.rbln_model_runner as mr
 from vllm_rbln.v1.core.rbln_kv_cache_manager import KVCacheCopyOp
+from vllm_rbln.v1.worker.bucketing.exponential_bucketing_manager import (
+    ExponentialBucketingManager,
+)
 from vllm_rbln.v1.worker.rbln_model_runner import (
     ExecuteModelState,
     RBLNModelRunner,
@@ -344,6 +348,95 @@ class TestDetermineBatchPadding:
     def test_single_dp_returns_no_token_padding(self):
         _, tok, across = self._runner(is_prefill=False)._determine_batch_padding(3, 30)
         assert tok is None and across is None
+
+
+class TestDummyRunPadding:
+    # _dummy_run under DP: the decode layout must carry the group-agreed bucket,
+    # not this rank's own count. #894 was the layout keeping num_reqs while the
+    # attention metadata already used num_reqs_padded.
+    @staticmethod
+    def _runner(monkeypatch, *, reqs_across_dp, specialized=True):
+        captured: dict = {}
+
+        def fake_across_dp(num_tokens, num_reqs, dp_size, dp_rank, is_prefill):
+            reqs = torch.tensor(reqs_across_dp, dtype=torch.int32)
+            # The real one returns no per-rank counts while any rank prefills.
+            return reqs.clone(), None if is_prefill else reqs
+
+        monkeypatch.setattr(
+            mr, "get_pp_group", lambda: SimpleNamespace(is_first_rank=True)
+        )
+        monkeypatch.setattr(
+            mr, "set_forward_context", lambda *a, **kw: contextlib.nullcontext()
+        )
+        monkeypatch.setattr(
+            mr, "build_kv_cache_forward_context_kwargs", lambda *a, **kw: {}
+        )
+        monkeypatch.setattr(
+            mr.RBLNDPMetadata,
+            "num_tokens_and_reqs_across_dp",
+            staticmethod(fake_across_dp),
+        )
+
+        def stage(**kwargs):
+            captured["layout"] = kwargs["layout"]
+            return SimpleNamespace(as_kwargs=lambda: {})
+
+        runner = _make_runner_stub(
+            # Two buckets, so a padded count can differ from a raw one at all.
+            bucketing_manager=ExponentialBucketingManager(
+                max_batch_size=2, min_batch_size=1, limit=2, step=2
+            ),
+            parallel_config=SimpleNamespace(data_parallel_size=4, data_parallel_rank=0),
+            specialized_moe_decode=specialized,
+            input_batch=SimpleNamespace(
+                num_tokens_no_spec=np.zeros(8, dtype=np.int32),
+                num_computed_tokens_cpu=np.zeros(8, dtype=np.int32),
+            ),
+            max_num_tokens=128,
+            max_num_reqs=8,
+            seq_lens_np=np.zeros(8, dtype=np.int32),
+            query_start_loc_np=np.zeros(16, dtype=np.int32),
+            arange_np=np.arange(128),
+            input_ids=torch.zeros(128, dtype=torch.int32),
+            positions=torch.zeros(128, dtype=torch.int32),
+            # use_wrapped_compute_logits is a property over this.
+            is_pooling_model=True,
+            speculative_config=None,
+            kv_cache_bases=None,
+            vllm_config=None,
+            input_stager=SimpleNamespace(stage=stage),
+            model_executable=lambda **kwargs: None,
+            _build_attention_metadata=lambda **kwargs: (
+                captured.setdefault("attn", kwargs),
+                None,
+            ),
+        )
+        return runner, captured
+
+    def test_decode_layout_takes_the_group_bucket(self, monkeypatch):
+        runner, captured = self._runner(monkeypatch, reqs_across_dp=[2, 1, 1, 1])
+        runner._dummy_run(1, 1, is_prefill=False)
+
+        assert captured["layout"].num_reqs == 1
+        assert captured["layout"].num_reqs_padded == 2
+        # Both halves must agree; they disagreeing is the shape error.
+        assert captured["attn"]["num_reqs_padded"] == 2
+
+    def test_prefill_layout_keeps_the_raw_count(self, monkeypatch):
+        runner, captured = self._runner(monkeypatch, reqs_across_dp=[2, 1, 1, 1])
+        runner._dummy_run(1, 4, is_prefill=True)
+
+        assert captured["layout"].num_reqs_padded == 1
+
+    def test_without_specialised_decode_no_group_agreement(self, monkeypatch):
+        runner, captured = self._runner(
+            monkeypatch, reqs_across_dp=[2, 1, 1, 1], specialized=False
+        )
+        runner._dummy_run(1, 1, is_prefill=False)
+
+        # Each rank keeps its own bucket, so a peer at bucket 2 disagrees.
+        assert captured["layout"].num_reqs_padded == 1
 
 
 class TestProcessKvCacheCopyOps:

--- a/tests/native/v1/worker/test_rbln_worker.py
+++ b/tests/native/v1/worker/test_rbln_worker.py
@@ -117,7 +117,13 @@ def make_worker(monkeypatch):
         device_name="RBLN-CA25",
         vllm_config=None,
     ):
-        wsd = world_size if world_size_across_dp is None else world_size_across_dp
+        # vLLM leaves dp_size out of world_size (it sizes one DP replica) and
+        # multiplies it back in for world_size_across_dp.
+        wsd = (
+            world_size * data_parallel_size
+            if world_size_across_dp is None
+            else world_size_across_dp
+        )
         vllm_config = vllm_config or _make_vllm_config(
             world_size=world_size,
             data_parallel_size=data_parallel_size,


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Adds three test lanes to `tests/native`:

- `test_platform.py`: `RblnPlatform` on the native path (`VLLM_RBLN_USE_VLLM_MODEL=1`). Asserts on the resulting config, the raised error, or the process env rather than on which helper ran.
- `distributed/test_dp_e2e.py`: DP behavior with requests pinned to chosen ranks, so an idle rank has to dummy-run. `distributed/test_dp_specs.py` checks every DP spec against the platform rules without a device.
- `test_runners.py`: `AsyncVllmRunner`, the runner DP needs, against a faked `AsyncLLM`.

`TestDummyRunPadding` in `v1/worker/test_rbln_runner.py` pins the decode layout that #894 fixed.

Also:
- `VLLM_DISABLE_COMPILE_CACHE=1` for the whole suite, so a compile test compiles instead of hitting a cache.
- an autouse fixture that removes `vllm_rbln.envs` attributes a test leaves behind (`monkeypatch.setattr` on that module freezes the value for the rest of the session).
- a CODEOWNERS entry for `tests/native`.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Default lane: `pytest tests/native` - all green.
2. DP e2e (4 NPUs): `pytest tests/native/distributed/test_dp_e2e.py --model-compile`

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [ ] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
