### PR TITLE
fix(metrics): record E2E per execute_model pass instead of per sampler call

### DIFF
--- a/tests/torch_compile/unit/v1/worker/test_metrics_v2.py
+++ b/tests/torch_compile/unit/v1/worker/test_metrics_v2.py
@@ -1,0 +1,364 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for vllm_rbln.v1.worker.metrics_v2.
+
+The invariants that matter here are structural rather than numeric:
+
+* every pass counted in ``MODEL + SAMPLE`` must also be counted in ``E2E``, so
+  that subtracting their means gives the host overhead.
+* ``E2E`` must never fall below ``MODEL + SAMPLE``, since it encloses it.
+* neither level may absorb the engine time between two passes.
+"""
+
+import pytest
+
+import vllm_rbln.v1.worker.metrics_v2 as mv2
+from vllm_rbln.v1.worker.metrics_v2 import (
+    _e2e_ends,
+    _e2e_starts,
+    _NoopPerformanceContext,
+    _PerformanceContext,
+)
+
+MS = 0.001  # tests work in seconds; use milliseconds for readability
+
+
+class FakeClock:
+    """Stand-in for the ``time`` module: only ``perf_counter`` is used."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def perf_counter(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = FakeClock()
+    monkeypatch.setattr(mv2, "time", fake)
+    # Keep the spans on nullcontext even if a real rebel runtime is installed.
+    monkeypatch.setattr(mv2, "_REBEL_HAS_CAPTURE", False)
+    return fake
+
+
+@pytest.fixture
+def ctx(monkeypatch):
+    # _rank_tag() imports vllm.distributed; the tag is irrelevant here.
+    monkeypatch.setattr(mv2, "_rank_tag", lambda: "")
+    return _PerformanceContext("test")
+
+
+def report_lines(ctx, monkeypatch):
+    """print_stats() 가 실제로 찍는 리포트 줄들."""
+    monkeypatch.setattr(mv2.envs, "VLLM_RBLN_METRICS_DIR", "", raising=False)
+    captured: list[str] = []
+    monkeypatch.setattr(mv2.logger, "info", lambda fmt, msg: captured.append(msg))
+    ctx.print_stats()
+    return captured[0].split("\n") if captured else []
+
+
+def run_pass(
+    ctx,
+    clock,
+    *,
+    is_prefill,
+    prepare=0.0,
+    model=0.0,
+    mid=0.0,
+    sample=None,
+    tail=0.0,
+):
+    """Drive one execute_model -> sample_tokens pass the way the runner does.
+
+    ``sample=None`` reproduces a pass that never reaches the sampler: an
+    intermediate chunked prefill, or a non-last PP rank.
+    """
+    ctx.start_e2e()
+    clock.advance(prepare)
+    with ctx.profile_model(is_prefill):
+        clock.advance(model)
+    clock.advance(mid)
+    if sample is not None:
+        with ctx.profile_sampler():
+            clock.advance(sample)
+    clock.advance(tail)
+    ctx.end_e2e()
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants
+# ---------------------------------------------------------------------------
+class TestInvariants:
+    def test_counts_are_in_parity(self, ctx, clock):
+        """Their means get subtracted, so no pass may land in only one."""
+        for _ in range(4):
+            clock.advance(2 * MS)
+            run_pass(ctx, clock, is_prefill=False, model=8 * MS, sample=1 * MS)
+        run_pass(ctx, clock, is_prefill=True, model=10 * MS)  # sampler-less chunk
+        run_pass(ctx, clock, is_prefill=True, model=10 * MS, sample=2 * MS)
+
+        for phase, count in ((False, 4), (True, 2)):
+            assert ctx._metrics[phase].call_count == count
+            assert ctx._e2e[phase].call_count == count
+
+    def test_e2e_is_never_below_model_plus_sample(self, ctx, clock):
+        run_pass(
+            ctx,
+            clock,
+            is_prefill=False,
+            prepare=1 * MS,
+            model=8 * MS,
+            mid=1 * MS,
+            sample=1 * MS,
+            tail=1 * MS,
+        )
+        # E2E - (MODEL + SAMPLE) is the host overhead the report is read for:
+        # 1ms prepare + 1ms between model and sampler + 1ms tail.
+        assert ctx._e2e[False].mean_latency_ms() == pytest.approx(12.0)
+        assert ctx._metrics[False].mean_latency_ms() == pytest.approx(9.0)
+
+
+# ---------------------------------------------------------------------------
+# Chunked prefill
+# ---------------------------------------------------------------------------
+class TestChunkedPrefill:
+    def test_every_chunk_gets_its_own_e2e_record(self, ctx, clock):
+        """The regression this rework fixes: E2E used to skip every chunk but
+        the last, leaving MODEL + SAMPLE at 4 records and E2E at 1."""
+        for _ in range(3):
+            run_pass(
+                ctx, clock, is_prefill=True, prepare=1 * MS, model=10 * MS, tail=1 * MS
+            )
+            clock.advance(1 * MS)
+        run_pass(
+            ctx,
+            clock,
+            is_prefill=True,
+            prepare=1 * MS,
+            model=10 * MS,
+            mid=1 * MS,
+            sample=2 * MS,
+            tail=1 * MS,
+        )
+
+        assert ctx._metrics[True].call_count == 4
+        assert ctx._e2e[True].call_count == 4
+        assert ctx._e2e[True].mean_latency_ms() == pytest.approx(12.75)
+        assert ctx._metrics[True].mean_latency_ms() == pytest.approx(10.5)
+
+    def test_engine_time_between_chunks_is_excluded(self, ctx, clock):
+        run_pass(
+            ctx, clock, is_prefill=True, prepare=1 * MS, model=10 * MS, tail=2 * MS
+        )  # own span: 13ms
+        clock.advance(3 * MS)  # engine time between chunks: must not be counted
+        run_pass(
+            ctx,
+            clock,
+            is_prefill=True,
+            prepare=1 * MS,
+            model=10 * MS,
+            mid=1 * MS,
+            sample=2 * MS,
+            tail=2 * MS,
+        )  # own span: 16ms
+
+        assert ctx._e2e[True].latencies == pytest.approx([13 * MS, 16 * MS])
+
+    def test_idle_between_passes_is_excluded(self, ctx, clock):
+        """Queue/idle wait sits between passes, so it is never measured."""
+        run_pass(ctx, clock, is_prefill=False, model=5 * MS, sample=1 * MS)
+        clock.advance(500 * MS)  # engine idle, waiting for a new request
+        run_pass(ctx, clock, is_prefill=True, model=10 * MS)
+        clock.advance(1 * MS)
+        run_pass(ctx, clock, is_prefill=True, model=10 * MS, sample=2 * MS)
+
+        assert ctx._e2e[True].latencies == pytest.approx([10 * MS, 12 * MS])
+        assert ctx._e2e[False].latencies == pytest.approx([6 * MS])
+
+
+# ---------------------------------------------------------------------------
+# Paths that skip the sampler or the close
+# ---------------------------------------------------------------------------
+class TestPartialPasses:
+    def test_model_only_pass_is_recorded_lazily(self, ctx, clock):
+        """Non-last PP rank / intermediate chunk: no sampler, so E2E lands right
+        away but MODEL + SAMPLE waits for the next profile_model."""
+        run_pass(ctx, clock, is_prefill=False, model=8 * MS, tail=1 * MS)
+        assert ctx._e2e[False].mean_latency_ms() == pytest.approx(9.0)
+        assert ctx._metrics[False].call_count == 0  # still pending
+
+        clock.advance(1 * MS)
+        run_pass(ctx, clock, is_prefill=False, model=8 * MS, sample=1 * MS)
+        assert ctx._metrics[False].call_count == 2
+
+    def test_pass_without_forward_is_dropped(self, ctx, clock):
+        """No scheduled tokens / KV-connector only: nothing to attribute."""
+        ctx.start_e2e()
+        clock.advance(1 * MS)
+        ctx.end_e2e()
+        assert not ctx._e2e
+
+    def test_unended_measurement_does_not_leak_into_the_next(self, ctx, clock):
+        """A pass whose execute_model raised has no end boundary; drop it."""
+        ctx.start_e2e()  # never ended
+        clock.advance(50 * MS)
+        run_pass(ctx, clock, is_prefill=False, model=8 * MS, sample=1 * MS)
+
+        assert ctx._e2e[False].call_count == 1
+        assert ctx._e2e[False].mean_latency_ms() == pytest.approx(9.0)
+
+    def test_ended_by_execute_model_when_no_sampler_follows(self, ctx, clock):
+        """execute_model returns the output itself, so it ends the pass; the
+        sample_tokens early-return must then not record a second time."""
+        ctx.start_e2e()
+        clock.advance(1 * MS)
+        with ctx.profile_model(False):
+            clock.advance(8 * MS)
+        clock.advance(1 * MS)
+        ctx.end_e2e()  # driven by execute_model returning non-None
+        ctx.end_e2e()  # sample_tokens early-returns: must be a no-op
+
+        assert ctx._e2e[False].call_count == 1
+        assert ctx._e2e[False].mean_latency_ms() == pytest.approx(10.0)
+
+    def test_end_without_start_is_a_noop(self, ctx, clock):
+        ctx.end_e2e()
+        assert not ctx._e2e
+
+    def test_is_prefill_does_not_carry_over_to_a_forwardless_pass(self, ctx, clock):
+        """start_e2e must clear is_prefill, or this lands in DECODE."""
+        run_pass(ctx, clock, is_prefill=False, model=8 * MS, sample=1 * MS)
+        ctx.start_e2e()
+        clock.advance(50 * MS)
+        ctx.end_e2e()  # no forward pass ran
+
+        assert ctx._e2e[False].call_count == 1
+        assert ctx._e2e[False].mean_latency_ms() == pytest.approx(9.0)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+class TestReporting:
+    def test_sections_are_grouped_by_metric(self, ctx, clock, monkeypatch):
+        run_pass(ctx, clock, is_prefill=True, model=10 * MS, sample=2 * MS)
+        clock.advance(1 * MS)
+        run_pass(ctx, clock, is_prefill=False, model=8 * MS, sample=1 * MS)
+
+        lines = report_lines(ctx, monkeypatch)
+        assert [ln for ln in lines if ln.endswith("METRICS:")] == [
+            "PREFILL + SAMPLE METRICS:",
+            "DECODE + SAMPLE METRICS:",
+            "PREFILL E2E METRICS:",
+            "DECODE E2E METRICS:",
+        ]
+
+    def test_absent_phase_is_omitted(self, ctx, clock, monkeypatch):
+        run_pass(ctx, clock, is_prefill=False, model=8 * MS, sample=1 * MS)
+        assert not any("PREFILL" in ln for ln in report_lines(ctx, monkeypatch))
+
+    def test_print_stats_with_no_data(self, ctx):
+        ctx.print_stats()  # must not raise
+
+    def test_print_stats_flushes_the_final_pending_span(self, ctx, clock, monkeypatch):
+        monkeypatch.setattr(mv2.envs, "VLLM_RBLN_METRICS_DIR", "", raising=False)
+        ctx.start_e2e()
+        with ctx.profile_model(True):
+            clock.advance(10 * MS)
+        ctx.print_stats()
+        assert ctx._metrics[True].call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Decorators and the no-op context
+# ---------------------------------------------------------------------------
+class TestE2EDecorators:
+    @staticmethod
+    def _runner(calls, execute_returns):
+        class Runner:
+            performance_ctx = type(
+                "C",
+                (),
+                {
+                    "start_e2e": lambda self: calls.append("start"),
+                    "end_e2e": lambda self: calls.append("end"),
+                },
+            )()
+
+            @_e2e_starts
+            def execute_model(self):
+                calls.append("execute")
+                return execute_returns
+
+            @_e2e_ends
+            def sample_tokens(self):
+                calls.append("sample")
+                return "out"
+
+        return Runner()
+
+    def test_sampler_path_ends_in_sample_tokens(self):
+        """execute_model returns None -> sample_tokens owns the end."""
+        calls: list[str] = []
+        runner = self._runner(calls, None)
+        assert runner.execute_model() is None
+        assert runner.sample_tokens() == "out"
+        assert calls == ["start", "execute", "sample", "end"]
+
+    def test_output_path_ends_in_execute_model(self):
+        """execute_model returns an output -> it must end the measurement."""
+        calls: list[str] = []
+        runner = self._runner(calls, "early-output")
+        assert runner.execute_model() == "early-output"
+        assert calls == ["start", "execute", "end"]
+
+    def test_measurement_is_not_ended_twice(self):
+        """sample_tokens still runs after an early output; end must no-op."""
+        calls: list[str] = []
+        runner = self._runner(calls, "early-output")
+        runner.execute_model()
+        runner.sample_tokens()
+        # Two end calls reach the context; end_e2e() no-ops on the second.
+        assert calls == ["start", "execute", "end", "sample", "end"]
+
+    def test_end_runs_even_when_the_body_raises(self):
+        calls: list[str] = []
+
+        class Runner:
+            performance_ctx = type(
+                "C", (), {"end_e2e": lambda self: calls.append("end")}
+            )()
+
+            @_e2e_ends
+            def sample_tokens(self):
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            Runner().sample_tokens()
+        assert calls == ["end"]
+
+    def test_noop_context_matches_the_real_api(self):
+        noop = _NoopPerformanceContext()
+        noop.start_e2e()
+        noop.end_e2e()
+        noop.print_stats()
+        with noop.profile_model(True):
+            pass
+        with noop.profile_sampler():
+            pass

--- a/tests/torch_compile/unit/v1/worker/test_metrics_v2.py
+++ b/tests/torch_compile/unit/v1/worker/test_metrics_v2.py
@@ -65,7 +65,7 @@ def ctx(monkeypatch):
 
 
 def report_lines(ctx, monkeypatch):
-    """print_stats() 가 실제로 찍는 리포트 줄들."""
+    """Lines emitted by print_stats()."""
     monkeypatch.setattr(mv2.envs, "VLLM_RBLN_METRICS_DIR", "", raising=False)
     captured: list[str] = []
     monkeypatch.setattr(mv2.logger, "info", lambda fmt, msg: captured.append(msg))

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import json
 import os
 import time
@@ -153,8 +154,6 @@ class _TimingSpan:
         self._ctx._submit(
             _Sample(latency, host, device, ccl, prepare, self._phase),
             self._is_sampler,
-            self._start,
-            end,
         )
         return False
 
@@ -176,40 +175,49 @@ class _PerformanceContext:
         self._metrics: dict[bool, Metrics] = defaultdict(Metrics)
         self._pending: _Sample | None = None
         self._e2e_start: float | None = None
+        self._e2e_is_prefill: bool | None = None
         self._e2e: dict[bool, Metrics] = defaultdict(Metrics)
         self._runtimes = runtimes if runtimes is not None else []
         self._backlog_drained = False
+
+    def start_e2e(self) -> None:
+        self._e2e_start = time.perf_counter()
+        self._e2e_is_prefill = None
+
+    def end_e2e(self) -> None:
+        end = time.perf_counter()
+        start, self._e2e_start = self._e2e_start, None
+        if start is None:
+            return
+        if self._e2e_is_prefill is None:
+            return  # no forward pass ran: nothing to attribute
+        self._e2e[self._e2e_is_prefill].record(end - start)
 
     def profile_model(self, is_prefill: bool) -> _TimingSpan:
         self._drain_report_backlog()
         # A prior model step with no sampler (intermediate chunked prefill,
         # non-last PP rank) leaves a pending report; record it model-only here.
         self._flush_pending()
+        if self._e2e_start is not None:
+            self._e2e_is_prefill = is_prefill
         return _TimingSpan(self, phase=is_prefill, is_sampler=False)
 
     def profile_sampler(self) -> _TimingSpan:
         return _TimingSpan(self, phase=None, is_sampler=True)
 
-    def _submit(
-        self, sample: _Sample, is_sampler: bool, start: float, end: float
-    ) -> None:
+    def _submit(self, sample: _Sample, is_sampler: bool) -> None:
         if not is_sampler:
             self._pending = sample  # model: stash, wait for the sampler
-            self._e2e_start = start
             return
         if self._pending is None:
             return  # sampler with no preceding model step; ignore
         self._record(self._pending.merged(sample))
-        if self._e2e_start is not None:
-            self._e2e[bool(self._pending.phase)].record(end - self._e2e_start)
         self._pending = None
-        self._e2e_start = None
 
     def _flush_pending(self) -> None:
         if self._pending is not None:
             self._record(self._pending)
             self._pending = None
-        self._e2e_start = None
 
     def _record(self, s: _Sample) -> None:
         self._metrics[bool(s.phase)].record(
@@ -240,6 +248,12 @@ class _PerformanceContext:
 
 class _NoopPerformanceContext:
     def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def start_e2e(self) -> None:
+        pass
+
+    def end_e2e(self) -> None:
         pass
 
     def profile_model(self, *args, **kwargs) -> _NoopSpan:
@@ -380,9 +394,40 @@ def _parse_reports(
     return host_time, device_time, ccl_time, prepare_time
 
 
+def _e2e_starts(fn):
+    @functools.wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        ctx = self.performance_ctx
+        ctx.start_e2e()
+        output = fn(self, *args, **kwargs)
+        if output is not None:
+            ctx.end_e2e()
+        return output
+
+    return wrapper
+
+
+def _e2e_ends(fn):
+    @functools.wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return fn(self, *args, **kwargs)
+        finally:
+            self.performance_ctx.end_e2e()
+
+    return wrapper
+
+
+def _identity(fn):
+    return fn
+
+
 # Resolved once at import time via VLLM_RBLN_METRICS env var.
 # When disabled, _NoopPerformanceContext is assigned so every profile()
-# call returns a zero-overhead no-op span.
+# call returns a zero-overhead no-op span, and the decorators hand back
+# the undecorated function.
 PerformanceContext: type[_PerformanceContext | _NoopPerformanceContext] = (
     _PerformanceContext if envs.VLLM_RBLN_METRICS else _NoopPerformanceContext
 )
+e2e_starts = _e2e_starts if envs.VLLM_RBLN_METRICS else _identity
+e2e_ends = _e2e_ends if envs.VLLM_RBLN_METRICS else _identity

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -125,7 +125,11 @@ from vllm_rbln.v1.spec_decode.eagle import RBLNEagleProposer
 from vllm_rbln.v1.spec_decode.medusa import RBLNMedusaProposer
 from vllm_rbln.v1.worker.bucketing import get_bucketing_manager
 from vllm_rbln.v1.worker.input_stager import InputLayout, InputStager, StagedModelInputs
-from vllm_rbln.v1.worker.metrics_v2 import PerformanceContext
+from vllm_rbln.v1.worker.metrics_v2 import (
+    PerformanceContext,
+    e2e_ends,
+    e2e_starts,
+)
 from vllm_rbln.v1.worker.utils import (
     get_kv_cache_names,
     prepare_kernel_block_sizes,
@@ -1313,6 +1317,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
             req_id_to_index_output_copy,
         )
 
+    @e2e_starts
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1462,6 +1467,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
         self.kv_connector_output = kv_connector_output
         return None
 
+    @e2e_ends
     @torch.inference_mode()
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"


### PR DESCRIPTION
### 🚀 Summary of Changes

#### Problem

**DP=1 chunked prefill** — E2E was only recorded where the sampler span ended, so every intermediate chunk was dropped: `_sample()` returns early, before `profile_sampler()`, when `is_intermediate_chunked_prefill` is true. On a 4-prompt × 4-chunk run `PREFILL + SAMPLE` counted 16 while `PREFILL E2E` kept 4 — and each of those 4 covered only that request's **last chunk**.

**DP>1 chunked prefill** — On top of the same loss, the E2E anchor sat at the model span start, so the `num_tokens_across_dp` all_reduce in `_determine_batch_padding()` fell outside the measured window. Rank skew from that host-blocking barrier was invisible in E2E, and it is also where `PREFILL E2E` came out *below* `mean_device_time`.

#### Solution

Move the E2E boundary from the model span to the whole **pass** (`execute_model` entry → `sample_tokens` return).

```
before   [ model ]· · ·[ sampler ]       E2E = model start → sampler end (nothing recorded without a sampler)

after    start_e2e ┃ prepare + DP barrier + [ model ] + postprocess + [ sampler ] + bookkeeping ┃ end_e2e
                   └─────────────────────────────────────E2E────────────────────────────────────┘
```

* Both levels are now recorded **per pass**, so their call counts match and subtracting the two means gives `E2E − (MODEL + SAMPLE)` = the host overhead around the compiled graph.
* The boundary is taken by two decorators on the runner (`@e2e_starts` / `@e2e_ends`). `execute_model` returning `None` is exactly equivalent to `sample_tokens` following (see `EngineCore.step()`), so on a non-None return the pass is closed in `execute_model` instead — that is the path taken by a non-last PP rank and by pooling models.
* prepare, the DP barrier, postprocess and bookkeeping now fall inside E2E. Engine-side work *between* passes (`schedule()`, `update_from_output()`, the DP unfinished-reqs barrier) is deliberately excluded, so E2E stays below the latency a serving benchmark reports by that margin.

---

### 📌 Related Issues / Tickets

* No linked issue (self-contained metrics instrumentation fix)

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Unit: `pytest tests/torch_compile/unit/v1/worker/test_metrics_v2.py` (20 passed)
2. E2E: run gpt-oss-20b (4 layers) with `VLLM_RBLN_METRICS=1`. For chunked prefill use `--max-batched 256 --input-len 1024` (4 chunks), `--num-prompts 4 --max-tokens 32`.
3. What to check: for each phase, `Total call counts` must be equal under `+ SAMPLE` and `E2E`, and the `E2E` mean must be greater than or equal to the `+ SAMPLE` mean.

---

### 📸 Screenshots / Logs (if applicable)

| case | phase | count (`+ SAMPLE` vs `E2E`) | model+sample | E2E | host overhead |
|---|---|---|---|---|---|
| DP=1 chunked | PREFILL | 16 vs 16 | 14.33 ms | 15.45 ms | 1.11 ms (7.2%) |
| | DECODE | 31 vs 31 | 7.94 ms | 10.14 ms | 2.20 ms (21.7%) |
| DP=2 chunked, DP0 | PREFILL | 16 vs 16 | 16.90 ms | 18.50 ms | 1.59 ms (8.6%) |
| | DECODE | 31 vs 31 | 8.12 ms | 11.00 ms | 2.87 ms (26.1%) |
| DP=2 chunked, DP1 | PREFILL | 16 vs 16 | 16.81 ms | 23.01 ms | 6.19 ms (26.9%) |
| | DECODE | 31 vs 31 | 7.93 ms | 11.00 ms | 3.07 ms (28.0%) |

Before this change, `PREFILL E2E` on chunked prefill reported 4 instead of 16. In the DP=2 rows, `model+sample` is effectively identical across the two ranks (16.90 / 16.81) while `PREFILL E2E` diverges (18.50 / 23.01) — that gap is the DP barrier skew, which this change makes visible for the first time.

---

### 📋 Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes
