### PR TITLE
perf(compile): enable static output for decode model graphs

### DIFF
--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -83,6 +83,7 @@ def compile(
     global_device_id: int | None = None,
     use_cache: bool = True,
     cache_dir: str = "",
+    use_static_output: bool = False,
 ) -> CompiledTarget:
     _ensure_torch_dynamo_configured()
 
@@ -106,6 +107,8 @@ def compile(
     set_option("mode", mode)
     set_option("use_global_ctx", use_global_ctx)
     set_option("global_device_id", global_device_id)
+    if use_static_output:
+        options["use_static_output"] = True
     if use_cache and not envs.VLLM_DISABLE_COMPILE_CACHE:
         set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
 

--- a/vllm_rbln/compilation/compiler.py
+++ b/vllm_rbln/compilation/compiler.py
@@ -107,8 +107,7 @@ def compile(
     set_option("mode", mode)
     set_option("use_global_ctx", use_global_ctx)
     set_option("global_device_id", global_device_id)
-    if use_static_output:
-        options["use_static_output"] = True
+    set_option("use_static_output", use_static_output)
     if use_cache and not envs.VLLM_DISABLE_COMPILE_CACHE:
         set_option("cache_dir", cache_dir or os.path.join(envs.VLLM_CACHE_ROOT, "rbln"))
 

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -1821,6 +1821,9 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 guard_filter_fn=torch.compiler.keep_tensor_guards_unsafe,
                 runtime_holder=self.runtime_holder,
                 mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
+                # Logits are consumed by sampling within the same step, so the
+                # output buffer can be reused across steps even under async scheduling.
+                use_static_output=True,
             )
             # NOTE(RBLN): We compile compute_logits separately to cover cases when
             # `self.use_wrapped_compute_logits` is `False`
@@ -1834,6 +1837,7 @@ class RBLNModelRunner(KVConnectorModelRunnerMixin):
                 guard_filter_fn=torch.compiler.keep_tensor_guards_unsafe,
                 runtime_holder=self.runtime_holder,
                 mode="strict" if envs.VLLM_RBLN_COMPILE_STRICT_MODE else "",
+                use_static_output=True,
             )
 
     def _get_eagle3_aux_layers_from_config(self) -> tuple[int, ...] | None:


### PR DESCRIPTION
### 🚀 Summary of Changes

**Problem — a decoder model that ends in a CCL op pays a large cost without static output.**

Under TP the vocab-parallel logits are gathered across ranks, so the model's final output tensor is also the destination buffer of an `all_gather`. That one tensor is both a **user output and a CCL operand**.

Without static output the runtime allocates a fresh device buffer for that output on every run, so its device address can change. **Whenever the output lands on a new device address, the CCL op has to be re-mapped to it.** That mapping is a synchronizing collective across all ranks and is expensive — tens to hundreds of milliseconds, growing with the number of CCL operands and the rank count.

**Solution.** Pass `use_static_output=True` for the two model-side graphs. The runtime then reuses one device buffer per output index, the output address stops changing, and the re-mapping no longer happens after the initial one.

### Why the sampler is deliberately excluded

Static output is only safe while a graph's output is fully consumed before that same graph runs again.

* **Model forward / `compute_logits`** — logits are read by sampling inside the same step. `execute_model()` and `sample_tokens()` stay a synchronous pair (they hand off through `ExecuteModelState`), so step N+1's forward cannot overwrite step N's logits before step N's sampler has read them. Safe to enable.
* **Sampler graphs** — their token ids leave the step. Under asynchronous scheduling the `.tolist()` that would force the D2H can be deferred past the next forward, which would then overwrite the shared buffer and silently corrupt results. Left off.

So the decision is per graph, not a global switch: no env var and no config toggle, and the unsafe combination cannot be selected by accident.

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [ ] 🛠 Bug fix (`fix`)
* [x] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe