### PR TITLE
other(test): align tests/native metrics_v2 with the per-pass E2E rework

### DIFF
--- a/tests/native/v1/worker/test_metrics_v2.py
+++ b/tests/native/v1/worker/test_metrics_v2.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Pure aggregation, no NPU: the _PerformanceContext state machine is driven by
-# feeding _Sample objects into _submit/_flush_pending directly.
-
 import json
 import types
 
@@ -124,19 +121,45 @@ class TestMean:
 
 
 def _ctx(monkeypatch, **kwargs):
-    # Pin rank_tag so construction never depends on a live distributed group.
+    # Pin rank_tag so construction never depends on a live distributed group,
+    # and keep spans on nullcontext even if a real rebel runtime is installed.
     monkeypatch.setattr(mm, "_rank_tag", lambda: "")
+    monkeypatch.setattr(mm, "_REBEL_HAS_CAPTURE", False)
     return mm._PerformanceContext(name="runner", **kwargs)
 
 
+class _Clock:
+    # Stands in for the time module; only perf_counter is used.
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def perf_counter(self) -> float:
+        return self.now
+
+
+def _fake_clock(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(mm, "time", clock)
+    return clock
+
+
+def _run_pass(ctx, is_prefill, with_sampler=True):
+    """Drive one execute_model pass the way the runner decorators do."""
+    ctx.start_e2e()
+    with ctx.profile_model(is_prefill=is_prefill):
+        pass
+    if with_sampler:
+        with ctx.profile_sampler():
+            pass
+    ctx.end_e2e()
+
+
 class TestPerformanceContextStateMachine:
-    def test_model_then_sampler_merges_records_and_times_e2e(self, monkeypatch):
+    def test_model_then_sampler_merges_and_records(self, monkeypatch):
         ctx = _ctx(monkeypatch)
         ctx._submit(
             mm._Sample(1.0, host=10, device=20, ccl=30, prepare=5, phase=True),
             is_sampler=False,
-            start=100.0,
-            end=100.6,
         )
         # Model span alone stays pending -- nothing recorded yet.
         assert ctx._metrics[True].call_count == 0
@@ -145,42 +168,34 @@ class TestPerformanceContextStateMachine:
         ctx._submit(
             mm._Sample(0.5, host=1, device=2, ccl=3, prepare=4, phase=None),
             is_sampler=True,
-            start=100.6,
-            end=101.0,
         )
         m = ctx._metrics[True]
         assert m.latencies == [1.5]
         assert (m.host_times, m.device_times) == ([11], [22])
         assert (m.ccl_times, m.prepare_times) == ([33], [9])
-        # e2e spans model.start .. sampler.end = 101.0 - 100.0.
-        assert ctx._e2e[True].latencies == [1.0]
-        assert ctx._pending is None and ctx._e2e_start is None
+        assert ctx._pending is None
 
     def test_sampler_without_pending_is_ignored(self, monkeypatch):
         ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True, start=0.0, end=0.5)
+        ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True)
         assert ctx._metrics[True].call_count == 0
         assert ctx._metrics[False].call_count == 0
 
-    def test_flush_pending_records_model_only_without_e2e(self, monkeypatch):
-        # A model step with no following sampler is recorded model-only on flush,
-        # and does NOT emit an e2e sample.
+    def test_flush_pending_records_model_only(self, monkeypatch):
+        # A model step with no following sampler is recorded model-only on flush.
         ctx = _ctx(monkeypatch)
-        ctx._submit(
-            mm._Sample(2.0, host=7, phase=False), is_sampler=False, start=0.0, end=2.0
-        )
+        ctx._submit(mm._Sample(2.0, host=7, phase=False), is_sampler=False)
         ctx._flush_pending()
         assert ctx._metrics[False].latencies == [2.0]
         assert ctx._metrics[False].host_times == [7]
-        assert ctx._e2e[False].call_count == 0
         assert ctx._pending is None
 
     def test_prefill_and_decode_go_to_separate_buckets(self, monkeypatch):
         ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False, start=0.0, end=1.0)
-        ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True, start=1.0, end=1.5)
-        ctx._submit(mm._Sample(0.2, phase=False), is_sampler=False, start=2.0, end=2.2)
-        ctx._submit(mm._Sample(0.1, phase=None), is_sampler=True, start=2.2, end=2.3)
+        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False)
+        ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True)
+        ctx._submit(mm._Sample(0.2, phase=False), is_sampler=False)
+        ctx._submit(mm._Sample(0.1, phase=None), is_sampler=True)
         assert ctx._metrics[True].latencies == [1.5]
         assert ctx._metrics[False].latencies == pytest.approx([0.3])
 
@@ -188,7 +203,7 @@ class TestPerformanceContextStateMachine:
         # Back-to-back model steps: the earlier pending one is flushed (recorded
         # model-only) when the next profile_model starts.
         ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False, start=0.0, end=1.0)
+        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False)
         ctx.profile_model(is_prefill=False)  # span not entered; only flushes
         assert ctx._metrics[True].call_count == 1
         assert ctx._pending is None
@@ -202,41 +217,202 @@ class TestPerformanceContextStateMachine:
         ctx._drain_report_backlog()  # idempotent
         assert calls == [1]
 
-    def test_print_stats_labels_all_sections_and_writes_json(
-        self, monkeypatch, tmp_path
-    ):
-        monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
-        ctx = _ctx(monkeypatch)
-        ctx._submit(mm._Sample(1.0, phase=True), is_sampler=False, start=0.0, end=1.0)
-        ctx._submit(mm._Sample(0.5, phase=None), is_sampler=True, start=1.0, end=1.5)
-        ctx._submit(mm._Sample(0.2, phase=False), is_sampler=False, start=2.0, end=2.2)
-        ctx._submit(mm._Sample(0.1, phase=None), is_sampler=True, start=2.2, end=2.3)
-        ctx.print_stats()
 
-        data = json.loads((tmp_path / "metrics.json").read_text())
-        assert set(data["sections"]) == {
-            "PREFILL + SAMPLE",
-            "DECODE + SAMPLE",
-            "PREFILL E2E",
-            "DECODE E2E",
-        }
+class TestE2EWindow:
+    # e2e is bounded by start_e2e/end_e2e -- one execute_model pass -- not by the
+    # spans inside it, and holds whether or not the pass reached a sampler.
+    def test_window_covers_the_pass_not_just_the_spans(self, monkeypatch):
+        clock = _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.start_e2e()
+        clock.now += 1.0  # input preparation, before the model span opens
+        with ctx.profile_model(is_prefill=True):
+            clock.now += 4.0
+        clock.now += 1.0
+        with ctx.profile_sampler():
+            clock.now += 2.0
+        clock.now += 1.0  # output copy, after the sampler span closed
+        ctx.end_e2e()
+        assert ctx._metrics[True].latencies == [6.0]  # the two spans only
+        assert ctx._e2e[True].latencies == [9.0]  # the whole pass
+        assert ctx._e2e_start is None
+
+    def test_time_between_passes_is_excluded(self, monkeypatch):
+        clock = _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        for _ in range(2):
+            ctx.start_e2e()
+            with ctx.profile_model(is_prefill=False):
+                clock.now += 1.0
+            ctx.end_e2e()
+            clock.now += 10.0  # engine and idle time between passes
+        assert ctx._e2e[False].latencies == [1.0, 1.0]
+
+    def test_sampler_less_pass_is_still_timed(self, monkeypatch):
+        # Intermediate chunked prefill / non-last PP rank.
+        clock = _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.start_e2e()
+        with ctx.profile_model(is_prefill=True):
+            clock.now += 3.0
+        ctx.end_e2e()
+        assert ctx._e2e[True].latencies == [3.0]
+
+    def test_pass_without_a_model_span_is_dropped(self, monkeypatch):
+        clock = _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.start_e2e()
+        clock.now += 1.0
+        ctx.end_e2e()
+        assert ctx._e2e == {}
+
+    def test_end_without_start_is_a_noop(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.end_e2e()
+        assert ctx._e2e == {}
+
+    def test_second_end_does_not_record_again(self, monkeypatch):
+        # execute_model closes the window when it returns an output itself;
+        # sample_tokens still runs its own end.
+        clock = _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.start_e2e()
+        with ctx.profile_model(is_prefill=False):
+            clock.now += 1.0
+        ctx.end_e2e()
+        clock.now += 5.0
+        ctx.end_e2e()
+        assert ctx._e2e[False].latencies == [1.0]
+
+    def test_phase_does_not_carry_over_to_the_next_window(self, monkeypatch):
+        clock = _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.start_e2e()
+        with ctx.profile_model(is_prefill=False):
+            clock.now += 1.0
+        ctx.end_e2e()
+        ctx.start_e2e()
+        clock.now += 5.0
+        ctx.end_e2e()  # no model span: must not land in the decode bucket again
+        assert ctx._e2e[False].latencies == [1.0]
+
+    def test_model_span_outside_a_window_is_not_attributed(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        ctx = _ctx(monkeypatch)
+        ctx.profile_model(is_prefill=True)
+        assert ctx._e2e_is_prefill is None
 
 
 class TestTimingSpanWiring:
-    # With rebel capture unavailable the span falls back to nullcontext, so the
-    # real profile_model -> profile_sampler wiring runs without an NPU.
     def test_model_and_sampler_spans_record_one_merged_step(self, monkeypatch):
-        monkeypatch.setattr(mm, "_REBEL_HAS_CAPTURE", False)
         ctx = _ctx(monkeypatch)
-        with ctx.profile_model(is_prefill=True):
-            pass
-        with ctx.profile_sampler():
-            pass
+        _run_pass(ctx, is_prefill=True)
         m = ctx._metrics[True]
         assert m.call_count == 1
         assert m.host_times == []  # no reports captured -> no timing series
         assert ctx._e2e[True].call_count == 1
         assert ctx._pending is None
+
+
+class TestReporting:
+    def test_sections_are_labelled_by_phase_and_metric(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
+        ctx = _ctx(monkeypatch)
+        _run_pass(ctx, is_prefill=True)
+        _run_pass(ctx, is_prefill=False)
+        ctx.print_stats()
+
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        assert list(data["sections"]) == [
+            "PREFILL + SAMPLE",
+            "DECODE + SAMPLE",
+            "PREFILL E2E",
+            "DECODE E2E",
+        ]
+
+    def test_unseen_phase_is_omitted(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
+        ctx = _ctx(monkeypatch)
+        _run_pass(ctx, is_prefill=False)
+        ctx.print_stats()
+
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        assert list(data["sections"]) == ["DECODE + SAMPLE", "DECODE E2E"]
+
+    def test_print_stats_flushes_the_final_pending_span(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(envs, "VLLM_RBLN_METRICS_DIR", str(tmp_path))
+        ctx = _ctx(monkeypatch)
+        _run_pass(ctx, is_prefill=True, with_sampler=False)
+        assert ctx._metrics[True].call_count == 0  # waiting for a sampler
+
+        ctx.print_stats()
+        assert ctx._metrics[True].call_count == 1
+
+
+class TestE2EDecorators:
+    @staticmethod
+    def _runner(calls, execute_output):
+        class Runner:
+            performance_ctx = types.SimpleNamespace(
+                start_e2e=lambda: calls.append("start"),
+                end_e2e=lambda: calls.append("end"),
+            )
+
+            @mm._e2e_starts
+            def execute_model(self):
+                calls.append("execute")
+                return execute_output
+
+            @mm._e2e_ends
+            def sample_tokens(self):
+                calls.append("sample")
+                return "out"
+
+        return Runner()
+
+    def test_window_closes_in_sample_tokens_when_execute_returns_none(self):
+        calls: list = []
+        runner = self._runner(calls, None)
+        assert runner.execute_model() is None
+        assert runner.sample_tokens() == "out"
+        assert calls == ["start", "execute", "sample", "end"]
+
+    def test_window_closes_in_execute_model_when_it_returns_an_output(self):
+        calls: list = []
+        runner = self._runner(calls, "early-output")
+        assert runner.execute_model() == "early-output"
+        assert calls == ["start", "execute", "end"]
+
+    def test_end_runs_even_when_the_body_raises(self):
+        calls = []
+
+        class Runner:
+            performance_ctx = types.SimpleNamespace(
+                end_e2e=lambda: calls.append("end"),
+            )
+
+            @mm._e2e_ends
+            def sample_tokens(self):
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            Runner().sample_tokens()
+        assert calls == ["end"]
+
+    def test_identity_hands_back_the_undecorated_function(self):
+        def fn():
+            return 1
+
+        assert mm._identity(fn) is fn
+
+    def test_module_level_hooks_follow_the_metrics_env(self):
+        expected = (
+            (mm._e2e_starts, mm._e2e_ends)
+            if envs.VLLM_RBLN_METRICS
+            else (mm._identity, mm._identity)
+        )
+        assert (mm.e2e_starts, mm.e2e_ends) == expected
 
 
 class TestWriteMetricsJson:
@@ -331,8 +507,10 @@ class TestNoopVariants:
 
     def test_noop_context_methods_are_inert(self):
         ctx = mm._NoopPerformanceContext("runner", runtimes=[])
+        ctx.start_e2e()
         with ctx.profile_model(True):
             pass
         with ctx.profile_sampler():
             pass
+        ctx.end_e2e()
         ctx.print_stats()  # must not raise


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

#899 moved E2E timing out of `_submit()` and behind the `start_e2e` / `end_e2e` boundaries the runner decorators drive, but only `test/torch_compile` was updated.

- Drop the removed `start=` / `end=` arguments from `_submit()` calls.
- Drive E2E through `start_e2e` / `end_e2e` in the state-machine, span-wiring, `print_stats`, and no-op-context tests.
- Add coverage for the new surface: window-scoped attribution and the `_e2e_starts` / `_e2e_ends` decorators.

Test-only change; no runtime code touched.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ❓ Other (`other`): test fix

---

### 🧪 How to Test

1. Run `pytest tests/native/v1/worker/test_metrics_v2.py -q`
2. Verify output: `45 passed` (before this PR: `TypeError: _PerformanceContext._submit() got an unexpected keyword argument 'start'`)
3. Edge case tested: `end_e2e()` without `start_e2e()`, a second `end_e2e()` after `execute_model` already closed the window, and a pass with no forward — none of them record.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
