### PR TITLE
other(test): fix native DP/spec-decode specs and narrow env scrubbing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "pytest-xdist",
     "pytest-cov",
     "pytest-timeout",
+    "arctic-inference",
 ]
 build = [
     "build",

--- a/tests/native/distributed/test_dp_e2e.py
+++ b/tests/native/distributed/test_dp_e2e.py
@@ -31,7 +31,7 @@ from tests.native.utils import (
 DP_MODELS: list[CompileModelSpec] = [
     CompileModelSpec(
         "openai/gpt-oss-20b",
-        {"data_parallel_size": 4, "max_num_seqs": 2},
+        {"data_parallel_size": 4, "max_num_seqs": 2, "enable_expert_parallel": True},
         {"VLLM_RBLN_SUB_BLOCK_CACHE": "0", "VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT": "2"},
     ),
 ]

--- a/tests/native/distributed/test_dp_specs.py
+++ b/tests/native/distributed/test_dp_specs.py
@@ -23,8 +23,6 @@ from tests.native.distributed.test_dp_e2e import DP_MODELS
 from tests.native.model_specs import CompileModelSpec, apply_spec_envs, spec_params
 from tests.native.runners import _RBLN_RUNNER_DEFAULTS
 
-_CARRIER = "Qwen/Qwen3-0.6B"
-
 _STANDALONE = "RBLN_CTX_STANDALONE"
 
 
@@ -38,7 +36,7 @@ def isolated_standalone_env(monkeypatch):
 def test_every_dp_spec_passes_the_platform_rules(spec: CompileModelSpec, monkeypatch):
     apply_spec_envs(spec, monkeypatch)
     EngineArgs(
-        model=_CARRIER, **{**_RBLN_RUNNER_DEFAULTS, **spec.engine_kwargs}
+        model=spec.model, **{**_RBLN_RUNNER_DEFAULTS, **spec.engine_kwargs}
     ).create_engine_config()
 
     assert os.environ[_STANDALONE] == "1"

--- a/tests/native/test_utils.py
+++ b/tests/native/test_utils.py
@@ -23,10 +23,8 @@ import pytest
 
 from .test_envs import ENV_SOURCE_ALIASES, RBLN_KEYS
 from .utils import (
-    HOST_ENV_PASSTHROUGH,
     NATIVE_ENV,
     SCRUBBED_EXTRA,
-    SCRUBBED_PREFIXES,
     devices_needed,
     is_scrubbed,
     rbln_device_count,
@@ -37,14 +35,14 @@ from .utils import (
 @pytest.mark.parametrize(
     ("key", "expected"),
     [
-        # A host description, even though it matches the RBLN_ prefix: the
-        # passthrough list takes precedence, which is the whole rule.
-        ("RBLN_DEVICES", False),
-        ("RBLN_FORCE_NPU_NAME", False),
-        # Same prefix, but a behavior knob rather than host description.
-        ("RBLN_CTX_STANDALONE", True),
-        ("RBLN_RUNTIME_FORCE_SYNC", True),
         ("VLLM_RBLN_SORT_BATCH", True),
+        # Bare RBLN_ names belong to the host and the compiler, not to the
+        # package under test, so the shell keeps them.
+        ("RBLN_DEVICES", False),
+        ("RBLN_CTX_STANDALONE", False),
+        ("RBLN_VERBOSE", False),
+        # The exception: VLLM_RBLN_USE_CUSTOM_KERNEL resolves from it.
+        ("RBLN_USE_CUSTOM_KERNEL", True),
         # No RBLN prefix at all; caught only because it is listed explicitly.
         ("VLLM_USE_V2_MODEL_RUNNER", True),
         # An upstream vLLM variable that is NOT listed. Scrubbing is targeted,
@@ -63,14 +61,14 @@ def test_scrub_env_removes_reports_and_preserves():
     """The three observable halves of the contract, in one pass."""
     environ = {
         "VLLM_RBLN_SORT_BATCH": "1",
-        "RBLN_CTX_STANDALONE": "1",
+        "RBLN_USE_CUSTOM_KERNEL": "1",
         "RBLN_DEVICES": "0,1",
         "PATH": "/usr/bin",
     }
     removed = scrub_env(environ)
 
     # Reported with values, so pytest_report_header can show what it took.
-    assert removed == {"VLLM_RBLN_SORT_BATCH": "1", "RBLN_CTX_STANDALONE": "1"}
+    assert removed == {"VLLM_RBLN_SORT_BATCH": "1", "RBLN_USE_CUSTOM_KERNEL": "1"}
     # Mutated in place, and nothing else was touched.
     assert environ == {"RBLN_DEVICES": "0,1", "PATH": "/usr/bin"}
 
@@ -95,24 +93,17 @@ def test_scrub_env_defaults_to_the_process_environment():
         os.environ.update(saved)
 
 
-def test_passthrough_entries_are_real_exceptions():
-    """Every passthrough entry must be something the rule would otherwise scrub;
-    a name no prefix matches is a dead entry."""
-    inert = sorted(
-        k for k in HOST_ENV_PASSTHROUGH if not k.startswith(SCRUBBED_PREFIXES)
-    )
-    assert not inert, f"{inert} are exempted from a rule that never applied to them"
-
-
-def test_passthrough_and_extra_are_disjoint():
-    """Listing a name in both would let passthrough silently win."""
-    assert not (HOST_ENV_PASSTHROUGH & SCRUBBED_EXTRA)
+def test_extra_entries_are_real_additions():
+    """An entry the prefix rule already covers is a dead line."""
+    redundant = sorted(k for k in SCRUBBED_EXTRA if k.startswith("VLLM_RBLN_"))
+    assert not redundant, f"{redundant} are already scrubbed by the prefix rule"
 
 
 def test_native_env_pins_no_host_description():
-    """The suite may pin behavior, never machine identity: pinning a passthrough
-    like RBLN_DEVICES would hard-code one host's topology."""
-    assert not (set(NATIVE_ENV) & HOST_ENV_PASSTHROUGH)
+    """The suite may pin behavior, never machine identity: pinning the device
+    list or the SOC would hard-code one host's topology."""
+    host_description = {"RBLN_DEVICES", "RBLN_FORCE_NPU_NAME", "RBLN_TARGET_SOC"}
+    assert not (set(NATIVE_ENV) & host_description)
 
 
 class TestDeviceInventory:

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -38,38 +38,32 @@ NATIVE_ENV = {
     "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
     "VLLM_RBLN_USE_VLLM_MODEL": "1",
     "VLLM_DISABLE_COMPILE_CACHE": "1",
+    "RBLN_ROOT_IP": "127.0.0.1",
+    "RBLN_LOCAL_IP": "127.0.0.1",
 }
 
-# Host description -- which NPUs exist, what SOC to compile for, OMP threads.
-# CI and developer machines legitimately set these; scrubbing them would break
-# device selection and make compile-only hosts fail in get_device_name().
-HOST_ENV_PASSTHROUGH = frozenset(
-    {
-        "RBLN_DEVICES",
-        "RBLN_FORCE_NPU_NAME",
-        "RBLN_TARGET_SOC",
-        "RBLN_NPUS_PER_DEVICE",
-        "RBLN_NUM_THREADS",
-    }
-)
+SCRUBBED_PREFIXES = ("VLLM_RBLN_",)
 
-SCRUBBED_PREFIXES = ("VLLM_RBLN_", "RBLN_")
-
-# Upstream knobs RblnPlatform itself branches on, so they are part of the
-# native suite's input surface despite not being RBLN-named.
+# Knobs outside that prefix that still decide what the suite runs: two upstream
+# ones RblnPlatform branches on, and the compiler flag VLLM_RBLN_USE_CUSTOM_KERNEL
+# resolves from instead of a private copy.
 SCRUBBED_EXTRA = frozenset(
     {
         "VLLM_USE_V2_MODEL_RUNNER",
         "VLLM_DISABLE_COMPILE_CACHE",
         "VLLM_WORKER_MULTIPROC_METHOD",
+        "RBLN_USE_CUSTOM_KERNEL",
     }
 )
 
 
 def is_scrubbed(key: str) -> bool:
-    """Whether ``key`` is a behavior knob the suite must control itself."""
-    if key in HOST_ENV_PASSTHROUGH:
-        return False
+    """Whether ``key`` is a behavior knob the suite must control itself.
+
+    Bare ``RBLN_*`` names describe the host and drive the compiler (device list,
+    SOC, log verbosity); this suite tests vllm-rbln, so it leaves them to the
+    shell.
+    """
     # The harness's own spawn-control vars (VLLM_RBLN_TEST_SPAWN_*) are not RBLN
     # behavior knobs; scrubbing them in a spawned child would drop the re-entry
     # guard and make the child spawn itself forever.

--- a/tests/native/v1/spec_decode/test_spec_decode_e2e.py
+++ b/tests/native/v1/spec_decode/test_spec_decode_e2e.py
@@ -37,7 +37,7 @@ MAX_TOKENS = 16
 SPEC_METHODS = {
     "ngram": (
         _NGRAM_TARGET,
-        {},
+        {"num_gpu_blocks_override": 32},
         {
             "method": "ngram",
             "prompt_lookup_max": 5,
@@ -47,7 +47,7 @@ SPEC_METHODS = {
     ),
     "suffix": (
         _NGRAM_TARGET,
-        {},
+        {"num_gpu_blocks_override": 32},
         {
             "method": "suffix",
             "suffix_decoding_max_spec_factor": 2.0,

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,12 @@ wheels = [
 ]
 
 [[package]]
+name = "arctic-inference"
+version = "0.2.0"
+source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
+sdist = { url = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/packages/arctic-inference/0.2.0/arctic_inference-0.2.0.tar.gz", hash = "sha256:242755ae3662527dd842b4c3bd0c921e5a969e270daff0c9436b412505af4c4d" }
+
+[[package]]
 name = "astor"
 version = "0.8.1"
 source = { registry = "https://nexus.mgmt.rbln.in/repository/pypi-group-nightly/simple/" }
@@ -2908,6 +2914,7 @@ runtime = [
     { name = "rebel-compiler" },
 ]
 test = [
+    { name = "arctic-inference" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2917,6 +2924,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arctic-inference", marker = "extra == 'test'" },
     { name = "build", marker = "extra == 'build'" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = "<0.137" },


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

Three test-suite fixes. No production code changes.

#### Add `arctic-inference` to the `test` extra (`pyproject.toml`, `uv.lock`)

vLLM's `suffix` speculative decoding requires it at runtime; without it the suffix case in `test_spec_decode_e2e.py` cannot run.

#### Fix test specs (`test/native/`)

- `test_dp_e2e.py`: `gpt-oss-20b` at `data_parallel_size=4` needs `enable_expert_parallel=True` to build a valid engine config.
- `test_dp_specs.py`: check the platform rules against `spec.model` instead of a hardcoded model, so each DP spec is validated with the model it declares.
- `test_spec_decode_e2e.py`: set `num_gpu_block_override=32` for ngram and suffix.

#### Scrub only `VLLM_RBLN_*` from the environment (`test/native/utils.py`)

`scrub_env` deleted every `RBLN_*` name, so compiler environments passed on the command line were silently dropped. The suite owns vllm-rbln's knobs, not the host description or the compiler flags.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ❓ Other (`other`): test-only - specs, test dependency, harness env handling.

---

### 🧪 How to Test

1. `uv sync --extra test`
2. `pytest tests/native/test_utils.py tests/native/test_envs.py -q` → 138 passed
3. `RBLN_VERBOSE=6 VLLM_RBLN_SORT_BATCH=1 pytest tests/native/test_utils.py --collect-only`
   → header reads `native: scrubbed VLLM_RBLN_SORT_BATCH`; `RBLN_VERBOSE` survives
4. `pytest tests/native/v1/spec_decode/test_spec_decode_e2e.py --model-compile -m model_compile`
5. `pytest tests/native/distributed/ --model-compile -m model_compile` (needs 4 NPUs)

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

`NATIVE_ENV` still pins `RBLN_ROOT_IP` / `RBLN_LOCAL_IP`.

---
