### PR TITLE
fix(metrics): sum runtime reports by kind instead of by position

### DIFF
--- a/tests/native/v1/worker/test_metrics_v2.py
+++ b/tests/native/v1/worker/test_metrics_v2.py
@@ -89,27 +89,68 @@ class TestSampleMerged:
         assert merged.prepare is None  # None + None -> None
 
 
+def _timer(host=0, device=0, ccl=0):
+    return {
+        "type": "timer",
+        "total_host": host,
+        "total_device": device,
+        "total_ccl": ccl,
+    }
+
+
+def _prep(prepare_in=0, prepare_out=0):
+    return {
+        "type": "prep",
+        "prepare_input_us": prepare_in,
+        "prepare_output_us": prepare_out,
+    }
+
+
 class TestParseReports:
     def test_none_or_empty_yields_all_none(self):
         assert mm._parse_reports(None) == (None, None, None, None)
         assert mm._parse_reports([]) == (None, None, None, None)
 
-    def test_single_report_has_no_prepare(self):
-        out = mm._parse_reports(
-            [{"total_host": 10, "total_device": 20, "total_ccl": 30}]
-        )
+    def test_timer_only_leaves_prepare_none(self):
+        out = mm._parse_reports([_timer(host=10, device=20, ccl=30)])
         assert out == (10, 20, 30, None)
 
-    def test_second_report_sums_prepare_in_out(self):
-        out = mm._parse_reports(
-            [{"total_host": 10}, {"prepare_input_us": 4, "prepare_output_us": 6}]
-        )
-        assert out == (10, None, None, 10)
+    def test_prep_only_leaves_timings_none(self):
+        out = mm._parse_reports([_prep(prepare_in=4, prepare_out=6)])
+        assert out == (None, None, None, 10)
 
-    def test_missing_prepare_keys_default_to_zero(self):
-        # A second report present but without prepare keys -> 0 + 0, not None.
-        out = mm._parse_reports([{"total_host": 10}, {}])
-        assert out == (10, None, None, 0)
+    def test_one_graph_run(self):
+        out = mm._parse_reports([_timer(host=10), _prep(prepare_in=4, prepare_out=6)])
+        assert out == (10, 0, 0, 10)
+
+    def test_every_graph_run_in_the_window_is_summed(self):
+        # Two runtime.run() calls -> two timer/prep pairs, interleaved as they arrive.
+        out = mm._parse_reports(
+            [
+                _timer(host=10, device=100, ccl=1),
+                _prep(prepare_in=4, prepare_out=6),
+                _timer(host=20, device=200, ccl=2),
+                _prep(prepare_in=40, prepare_out=60),
+            ]
+        )
+        assert out == (30, 300, 3, 110)
+
+    def test_missing_keys_count_as_zero(self):
+        out = mm._parse_reports([{"type": "timer"}, {"type": "prep"}])
+        assert out == (0, 0, 0, 0)
+
+    def test_unknown_report_kinds_are_ignored(self):
+        # RBLN_APPLY_TIMER pushes "buffer_transform" onto the same queue.
+        out = mm._parse_reports(
+            [
+                {"type": "buffer_transform", "wall_us": 999.0},
+                _timer(host=10),
+            ]
+        )
+        assert out == (10, 0, 0, None)
+
+    def test_untyped_reports_contribute_nothing(self):
+        assert mm._parse_reports([{"total_host": 10}]) == (None, None, None, None)
 
 
 class TestMean:

--- a/vllm_rbln/v1/worker/metrics_v2.py
+++ b/vllm_rbln/v1/worker/metrics_v2.py
@@ -380,17 +380,23 @@ def _report_metrics(name: str | None, sections: dict[str, Metrics]) -> None:
 def _parse_reports(
     reports: list[dict] | None,
 ) -> tuple[int | None, int | None, int | None, int | None]:
-    """Extract timing information from rebel.capture_reports() output."""
+    """Sum the timings across every graph run in rebel.capture_reports() output."""
     if not reports:
         return None, None, None, None
-    host_time = reports[0].get("total_host")
-    device_time = reports[0].get("total_device")
-    ccl_time = reports[0].get("total_ccl")
-    prepare_time = (
-        reports[1].get("prepare_input_us", 0) + reports[1].get("prepare_output_us", 0)
-        if len(reports) > 1
-        else None
-    )
+
+    host_time = device_time = ccl_time = prepare_time = None
+    for report in reports:
+        kind = report.get("type")
+        if kind == "timer":
+            host_time = (host_time or 0) + report.get("total_host", 0)
+            device_time = (device_time or 0) + report.get("total_device", 0)
+            ccl_time = (ccl_time or 0) + report.get("total_ccl", 0)
+        elif kind == "prep":
+            prepare_time = (
+                (prepare_time or 0)
+                + report.get("prepare_input_us", 0)
+                + report.get("prepare_output_us", 0)
+            )
     return host_time, device_time, ccl_time, prepare_time
 
 


### PR DESCRIPTION
### 🚀 Summary of Changes

`_parse_reports()` read `reports[0]` and `reports[1]`, which only covers the **first** graph run in the captured window. Every `runtime.run()` appends its own pair of reports -- a `timer` one and a `prep` one -- so a window holding N runs yields 2N entries and everything past the first run was silently dropped.

This is latent today, since each span happens to hold a single run, but it breaks as soon as a span holds more than one (a graph break, a bucket recompile, or merging the model and sampler spans as discussed in #909).

Sum over the report `type` field instead of reading fixed positions. Two details preserved:

* A kind that never appears stays `None` rather than becoming `0`, so a run without `RBLN_RUNTIME_TIMER` reports no timings at all instead of a column of `0.00` values.
* Filtering on `type` also skips `buffer_transform` reports, which share the same runtime queue when `RBLN_APPLY_TIMER` is set.

---

### 📌 Related Issues / Tickets

* Related to #909 (item A)

---

### ✅ Type of Change

* [ ] 🚀 Release (`release`)
* [ ] ✨ Feature (`feature`)
* [ ] 🧠 Model support (`model`)
* [ ] 🧬 Core engine changes (`core`)
* [x] 🛠 Bug fix (`fix`)
* [ ] ⚙️ Performance improvement (`perf`)
* [ ] 🔁 Refactor or code cleanup (`refactor`)
* [ ] 📄 Documentation (`docs`)
* [ ] ❓ Other (`other`): please describe

---

### 🧪 How to Test

1. Unit: `pytest tests/native/v1/worker/test_metrics_v2.py` (53 passed)
2. E2E: run any model with `VLLM_RBLN_METRICS=1` and `RBLN_RUNTIME_TIMER=1`, and check that `Mean prepare time (us)` now accounts for every graph run in the span rather than only the first.
3. Regression: run with `VLLM_RBLN_METRICS=1` alone and confirm the host/device/ccl/prepare lines stay absent.
