### PR TITLE
other: add VLLM_RBLN_NUM_HIDDEN_LAYERS to build only the first N layers

### DIFF
--- a/tests/native/compile/models.py
+++ b/tests/native/compile/models.py
@@ -21,5 +21,7 @@ from tests.native.model_specs import CompileModelSpec
 MODELS: list[CompileModelSpec] = [
     CompileModelSpec("Qwen/Qwen3-30B-A3B", {"tensor_parallel_size": 8}),
     CompileModelSpec("Qwen/Qwen1.5-MoE-A2.7B", {"tensor_parallel_size": 8}),
-    CompileModelSpec("openai/gpt-oss-20b", {"tensor_parallel_size": 8}),
+    CompileModelSpec(
+        "openai/gpt-oss-20b", {"tensor_parallel_size": 8}, num_hidden_layers=4
+    ),
 ]

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -415,6 +415,14 @@ def hf_runner():
     return HfRunner
 
 
+@pytest.fixture(scope="session")
+def whole_model(pytestconfig) -> bool:
+    """Whether every decoder layer is built (--num-hidden-layers 0). A truncated
+    model still compiles and runs, but its logits are meaningless -- an assertion
+    that depends on output quality has to gate on this."""
+    return pytestconfig.getoption("--num-hidden-layers") == 0
+
+
 @pytest.fixture(autouse=True)
 def _drop_envs_shadows():
     """Remove any ``vllm_rbln.envs`` attribute a test left behind.

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -22,11 +22,14 @@ import pytest
 from tests.native.utils import (
     _SPAWN_CHILD_ENV,
     _SPAWN_RESULTS_ENV,
+    LAYERS_PINNABLE_ENV,
     NATIVE_ENV,
     ModuleSpawn,
     read_log_tail,
     scrub_env,
 )
+
+_DEFAULT_NUM_HIDDEN_LAYERS = 3
 
 _scrubbed: dict[str, str] = {}
 
@@ -127,16 +130,25 @@ def pytest_addoption(parser):
     parser.addoption(
         "--num-hidden-layers",
         type=int,
-        default=4,
+        default=None,
         help=(
             "VLLM_RBLN_NUM_HIDDEN_LAYERS for the whole session: build only the "
             "first N decoder layers, cutting compile time in the "
             "--model-compile lane. hf_runner truncates to the same N, so "
             "correctness comparisons stay like-for-like. 0 runs the whole "
             "model. An exported value is scrubbed like every other "
-            "VLLM_RBLN_* knob; this option is the way in."
+            f"VLLM_RBLN_* knob; this option is the way in. Defaults to "
+            f"{_DEFAULT_NUM_HIDDEN_LAYERS}, and only then does a spec's own "
+            "num_hidden_layers apply."
         ),
     )
+
+
+def _session_layers(config) -> int:
+    """The option's value, or the default when it was left off. Not `or`: an
+    explicit 0 is the whole model, not a missing value."""
+    layers = config.getoption("--num-hidden-layers")
+    return _DEFAULT_NUM_HIDDEN_LAYERS if layers is None else layers
 
 
 def pytest_collection_modifyitems(config, items):
@@ -236,7 +248,7 @@ def _spawn_for(item) -> ModuleSpawn:
         nodeid_prefix=item.nodeid.split("::", 1)[0],
         device_tensor=config.getoption("--device-tensor"),
         model_compile=config.getoption("--model-compile"),
-        num_hidden_layers=config.getoption("--num-hidden-layers"),
+        num_hidden_layers=_session_layers(config),
         tb_style=config.getoption("tbstyle", None),
         maxfail=config.getoption("maxfail", 0),
         stream_output=config.getoption("capture") == "no",
@@ -342,9 +354,16 @@ def pytest_configure(config):
         os.environ["VLLM_RBLN_USE_DEVICE_TENSOR"] = device_tensor
 
     # Also before the import below: the get_pp_indices patch conditions on this.
-    os.environ["VLLM_RBLN_NUM_HIDDEN_LAYERS"] = str(
-        config.getoption("--num-hidden-layers")
-    )
+    os.environ["VLLM_RBLN_NUM_HIDDEN_LAYERS"] = str(_session_layers(config))
+
+    # Parent only -- the child is handed the resolved value, so its own view of
+    # the option is always "given". Cleared rather than merely left unset, or an
+    # exported one would pin behind an explicit option's back.
+    if os.environ.get(_SPAWN_CHILD_ENV) != "1":
+        if config.getoption("--num-hidden-layers") is None:
+            os.environ[LAYERS_PINNABLE_ENV] = "1"
+        else:
+            os.environ.pop(LAYERS_PINNABLE_ENV, None)
 
     # Platform plugins activate on their own when current_platform is first
     # touched, but the patches live in the general_plugins group and nothing
@@ -381,9 +400,12 @@ def pytest_report_header(config):
         f"native: env {', '.join(f'{k}={v}' for k, v in NATIVE_ENV.items())}",
         f"native: device_type={RblnPlatform.device_type} ({origin})",
     ]
-    num_hidden_layers = config.getoption("--num-hidden-layers")
+    num_hidden_layers = _session_layers(config)
+    pinnable = (
+        " (a spec may pin its own)" if os.environ.get(LAYERS_PINNABLE_ENV) else ""
+    )
     header.append(
-        f"native: num_hidden_layers={num_hidden_layers or 'whole model'}",
+        f"native: num_hidden_layers={num_hidden_layers or 'whole model'}{pinnable}",
     )
     if _scrubbed:
         header.append(f"native: scrubbed {', '.join(sorted(_scrubbed))}")

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -127,7 +127,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--num-hidden-layers",
         type=int,
-        default=3,
+        default=4,
         help=(
             "VLLM_RBLN_NUM_HIDDEN_LAYERS for the whole session: build only the "
             "first N decoder layers, cutting compile time in the "
@@ -439,6 +439,19 @@ def _drop_envs_shadows():
     yield
     for name in set(vars(envs)) - before:
         delattr(envs, name)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rbln_ctx_standalone():
+    """Clear the one env var the code under test writes to the process env.
+
+    RblnPlatform.validate_and_setup_prerequisite sets RBLN_CTX_STANDALONE=1 for
+    any TP/DP/PP/EP config and never clears it. The rebel runtime reads it on
+    every context creation, so one test building such a config leaves every later
+    test -- and every spawned child, which inherits the env -- unable to register
+    a device at all. Mirrors tests/torch_compile/conftest.py."""
+    os.environ.pop("RBLN_CTX_STANDALONE", None)
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -124,6 +124,19 @@ def pytest_addoption(parser):
             "default is what gets exercised."
         ),
     )
+    parser.addoption(
+        "--num-hidden-layers",
+        type=int,
+        default=3,
+        help=(
+            "VLLM_RBLN_NUM_HIDDEN_LAYERS for the whole session: build only the "
+            "first N decoder layers, cutting compile time in the "
+            "--model-compile lane. hf_runner truncates to the same N, so "
+            "correctness comparisons stay like-for-like. 0 runs the whole "
+            "model. An exported value is scrubbed like every other "
+            "VLLM_RBLN_* knob; this option is the way in."
+        ),
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -223,6 +236,7 @@ def _spawn_for(item) -> ModuleSpawn:
         nodeid_prefix=item.nodeid.split("::", 1)[0],
         device_tensor=config.getoption("--device-tensor"),
         model_compile=config.getoption("--model-compile"),
+        num_hidden_layers=config.getoption("--num-hidden-layers"),
         tb_style=config.getoption("tbstyle", None),
         maxfail=config.getoption("maxfail", 0),
         stream_output=config.getoption("capture") == "no",
@@ -327,6 +341,11 @@ def pytest_configure(config):
     if device_tensor is not None:
         os.environ["VLLM_RBLN_USE_DEVICE_TENSOR"] = device_tensor
 
+    # Also before the import below: the get_pp_indices patch conditions on this.
+    os.environ["VLLM_RBLN_NUM_HIDDEN_LAYERS"] = str(
+        config.getoption("--num-hidden-layers")
+    )
+
     # Platform plugins activate on their own when current_platform is first
     # touched, but the patches live in the general_plugins group and nothing
     # loads those implicitly. Without this the suite runs half-applied:
@@ -362,6 +381,10 @@ def pytest_report_header(config):
         f"native: env {', '.join(f'{k}={v}' for k, v in NATIVE_ENV.items())}",
         f"native: device_type={RblnPlatform.device_type} ({origin})",
     ]
+    num_hidden_layers = config.getoption("--num-hidden-layers")
+    header.append(
+        f"native: num_hidden_layers={num_hidden_layers or 'whole model'}",
+    )
     if _scrubbed:
         header.append(f"native: scrubbed {', '.join(sorted(_scrubbed))}")
     return header

--- a/tests/native/distributed/test_dp_e2e.py
+++ b/tests/native/distributed/test_dp_e2e.py
@@ -36,6 +36,7 @@ DP_MODELS: list[CompileModelSpec] = [
         "openai/gpt-oss-20b",
         {"data_parallel_size": 4, "max_num_seqs": 2, "enable_expert_parallel": True},
         {"VLLM_RBLN_SUB_BLOCK_CACHE": "0", "VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT": "2"},
+        num_hidden_layers=4,
     ),
 ]
 

--- a/tests/native/distributed/test_dp_e2e.py
+++ b/tests/native/distributed/test_dp_e2e.py
@@ -23,6 +23,9 @@ import pytest
 from tests.native.model_specs import CompileModelSpec, apply_spec_envs, spec_params
 from tests.native.runners import DPRequest
 from tests.native.utils import (
+    TokensText,
+    TokensTextLogprobs,
+    check_logprobs_close,
     check_outputs_equal,
     devices_needed,
     rbln_device_count,
@@ -40,6 +43,7 @@ PROMPT = "The quick brown fox jumps over the lazy dog."
 MAX_TOKENS = 32
 # Finishes mid-decode of a MAX_TOKENS request, so its rank goes idle early.
 SHORT_MAX_TOKENS = 4
+NUM_LOGPROBS = 5
 
 # Hang detector, applied per test; the first test of a spec carries that spec's
 # engine build, which compiles once per DP rank.
@@ -64,8 +68,13 @@ class DPLane:
     def dp_size(self) -> int:
         return self.spec.engine_kwargs["data_parallel_size"]
 
-    def generate_greedy(self, requests: list[DPRequest]) -> list[tuple[list[int], str]]:
+    def generate_greedy(self, requests: list[DPRequest]) -> list[TokensText]:
         return self.runner.generate_greedy(requests)
+
+    def generate_greedy_logprobs(
+        self, requests: list[DPRequest]
+    ) -> list[TokensTextLogprobs]:
+        return self.runner.generate_greedy_logprobs(requests, NUM_LOGPROBS)
 
 
 @pytest.fixture(scope="module", params=spec_params(DP_MODELS))
@@ -94,8 +103,9 @@ def dp_lane(request, async_vllm_runner):
 @pytest.fixture(scope="module")
 def symmetric_outputs(dp_lane):
     """Every rank busy with the same prompt -- the reference for the asymmetric
-    runs, and the only run here with no idle rank."""
-    return dp_lane.generate_greedy(
+    runs, and the only run here with no idle rank. Carries logprobs because the
+    rank-to-rank comparison needs them; the asymmetric runs compare ids only."""
+    return dp_lane.generate_greedy_logprobs(
         [DPRequest(PROMPT, MAX_TOKENS, dp_rank=rank) for rank in range(dp_lane.dp_size)]
     )
 
@@ -103,8 +113,11 @@ def symmetric_outputs(dp_lane):
 def test_every_rank_produces_the_same_output(symmetric_outputs) -> None:
     # Ranks differ only in which NPU slice they hold, so a divergence here is a
     # per-rank fault: mis-assigned devices, or DP padding leaking into logits.
+    # Expert parallelism splits the experts across the ranks and recombines them,
+    # so rank-local accumulation order is not bit-identical; only a near-tie flip
+    # is tolerated, and a wrong slice is nowhere near a tie.
     for rank in range(1, len(symmetric_outputs)):
-        check_outputs_equal(
+        check_logprobs_close(
             outputs_0_lst=[symmetric_outputs[0]],
             outputs_1_lst=[symmetric_outputs[rank]],
             name_0="rank0",
@@ -116,8 +129,9 @@ def test_output_survives_idle_peers(dp_lane, symmetric_outputs) -> None:
     # Every other rank dummy-runs for the whole of rank 0's decode.
     outputs = dp_lane.generate_greedy([DPRequest(PROMPT, MAX_TOKENS, dp_rank=0)])
 
+    ref_ids, ref_text, _ = symmetric_outputs[0]
     check_outputs_equal(
-        outputs_0_lst=[symmetric_outputs[0]],
+        outputs_0_lst=[(ref_ids, ref_text)],
         outputs_1_lst=outputs,
         name_0="rank0 with every rank busy",
         name_1=f"rank0 with {dp_lane.dp_size - 1} idle peers",
@@ -135,8 +149,9 @@ def test_output_survives_a_peer_finishing_early(dp_lane, symmetric_outputs) -> N
     )
     short, long = outputs
 
+    ref_ids, ref_text, _ = symmetric_outputs[last]
     check_outputs_equal(
-        outputs_0_lst=[symmetric_outputs[last]],
+        outputs_0_lst=[(ref_ids, ref_text)],
         outputs_1_lst=[long],
         name_0=f"rank{last} with every rank busy",
         name_1=f"rank{last} outliving rank0",

--- a/tests/native/model_specs.py
+++ b/tests/native/model_specs.py
@@ -16,14 +16,18 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
 
+from tests.native.utils import LAYERS_PINNABLE_ENV
+
 # Harness-visible env vars are promoted to fields because the harness branches
 # on them; `envs` is everything the harness does NOT interpret.
 _RSD_ENV = "VLLM_RBLN_NUM_DEVICES_PER_LOCAL_RANK"
+_LAYERS_ENV = "VLLM_RBLN_NUM_HIDDEN_LAYERS"
 _ID_KEYS = (
     ("tp", "tensor_parallel_size", 1),
     ("pp", "pipeline_parallel_size", 1),
@@ -39,12 +43,21 @@ class CompileModelSpec:
     envs: dict[str, str] = field(default_factory=dict)
     rsd: int = 1
     id: str | None = None
+    # Layers to build for this model, overriding the session default. Ignored
+    # when --num-hidden-layers is given, so a lane can always force its own
+    # depth -- 0 (whole model) especially.
+    num_hidden_layers: int | None = None
 
     def __post_init__(self):
-        if _RSD_ENV in self.envs:
-            raise ValueError(f"{_RSD_ENV} is harness-visible; set rsd= instead")
+        for env, field_name in ((_RSD_ENV, "rsd"), (_LAYERS_ENV, "num_hidden_layers")):
+            if env in self.envs:
+                raise ValueError(f"{env} is harness-visible; set {field_name}= instead")
         if self.rsd < 1:
             raise ValueError(f"rsd must be >= 1, got {self.rsd}")
+        if self.num_hidden_layers is not None and self.num_hidden_layers < 0:
+            raise ValueError(
+                f"num_hidden_layers must be >= 0, got {self.num_hidden_layers}"
+            )
 
     @property
     def test_id(self) -> str:
@@ -80,5 +93,9 @@ def spec_params(specs: list[CompileModelSpec]) -> list[Any]:
 def apply_spec_envs(spec: CompileModelSpec, monkeypatch) -> None:
     if spec.rsd > 1:
         monkeypatch.setenv(_RSD_ENV, str(spec.rsd))
+    # Only when --num-hidden-layers was left off: an explicit value -- 0 above
+    # all -- belongs to the lane, not to one model.
+    if spec.num_hidden_layers is not None and os.environ.get(LAYERS_PINNABLE_ENV):
+        monkeypatch.setenv(_LAYERS_ENV, str(spec.num_hidden_layers))
     for key, value in spec.envs.items():
         monkeypatch.setenv(key, value)

--- a/tests/native/patches/test_distributed_utils.py
+++ b/tests/native/patches/test_distributed_utils.py
@@ -1,0 +1,208 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VLLM_RBLN_NUM_HIDDEN_LAYERS truncation, driven through the real
+``make_layers`` with a stub layer type -- no checkpoint, no device."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+from transformers import DeepseekV3Config
+from vllm.distributed import parallel_state
+from vllm.distributed import utils as distributed_utils
+from vllm.model_executor.models import utils as models_utils
+from vllm.model_executor.models.deepseek_v2 import get_spec_layer_idx_from_weight_name
+from vllm.model_executor.models.utils import (
+    PPMissingLayer,
+    is_pp_missing_parameter,
+    make_layers,
+)
+
+from vllm_rbln import patches
+from vllm_rbln.patches.distributed_utils import patched_get_pp_indices
+from vllm_rbln.patches.registry import get_registered_patch_descriptors
+
+TOTAL_LAYERS = 32
+LIMIT = 3
+
+
+class StubLayer(nn.Module):
+    """Stands in for a decoder layer: one named parameter, nothing else."""
+
+    def __init__(self, prefix: str) -> None:
+        super().__init__()
+        self.prefix = prefix
+        self.weight = nn.Parameter(torch.zeros(1))
+
+
+class StubModel(nn.Module):
+    def __init__(self, layers: nn.ModuleList) -> None:
+        super().__init__()
+        self.layers = layers
+
+
+@pytest.fixture(autouse=True)
+def _patched(monkeypatch):
+    """Install the replacement directly, so these pass however the session was
+    started (--num-hidden-layers 0 never applies it). That the registry wires it
+    up for real is TestPatchWiring's job."""
+    monkeypatch.setattr(distributed_utils, "get_pp_indices", patched_get_pp_indices)
+    # get_pp_missing_layer_names caches on id(model); a freed model from an
+    # earlier test can hand its id -- and its entry -- to ours.
+    monkeypatch.setattr(models_utils, "_model_to_pp_missing_layer_names", {})
+
+
+def build(
+    monkeypatch,
+    limit: int,
+    *,
+    total: int = TOTAL_LAYERS,
+    pp_rank: int = 0,
+    pp_size: int = 1,
+) -> tuple[int, int, nn.ModuleList]:
+    monkeypatch.setenv("VLLM_RBLN_NUM_HIDDEN_LAYERS", str(limit))
+    monkeypatch.setattr(
+        parallel_state,
+        "get_pp_group",
+        lambda: type("PP", (), {"rank_in_group": pp_rank, "world_size": pp_size})(),
+    )
+    return make_layers(total, StubLayer, prefix="layers")
+
+
+class TestPatchWiring:
+    """Without this, a typo in the target or a module missing from
+    patches/__init__ would leave every other test here passing."""
+
+    def test_listed_in_the_patch_package(self):
+        assert hasattr(patches, "distributed_utils")
+
+    def test_registered_against_get_pp_indices(self):
+        [descriptor] = [
+            d
+            for d in get_registered_patch_descriptors()
+            if d.replacement is patched_get_pp_indices
+        ]
+        assert descriptor.target == "vllm.distributed.utils.get_pp_indices"
+
+    def test_gated_on_the_variable(self, monkeypatch):
+        [descriptor] = [
+            d
+            for d in get_registered_patch_descriptors()
+            if d.replacement is patched_get_pp_indices
+        ]
+        monkeypatch.setenv("VLLM_RBLN_NUM_HIDDEN_LAYERS", "0")
+        assert not descriptor.condition()
+        monkeypatch.setenv("VLLM_RBLN_NUM_HIDDEN_LAYERS", str(LIMIT))
+        assert descriptor.condition()
+
+
+def test_builds_only_the_first_n_layers(monkeypatch):
+    start, end, layers = build(monkeypatch, LIMIT)
+
+    assert (start, end) == (0, LIMIT)
+    # The list keeps its full length: indices still address the checkpoint's.
+    assert len(layers) == TOTAL_LAYERS
+    assert [type(layer) for layer in layers[:LIMIT]] == [StubLayer] * LIMIT
+    assert {type(layer) for layer in layers[LIMIT:]} == {PPMissingLayer}
+
+
+def test_dropped_layers_read_as_missing_to_the_weight_loaders(monkeypatch):
+    """The half that replaces the loader override: every upstream loader asks
+    is_pp_missing_parameter before touching a weight."""
+    model = StubModel(build(monkeypatch, LIMIT)[2])
+
+    assert not is_pp_missing_parameter(f"layers.{LIMIT - 1}.weight", model)
+    assert is_pp_missing_parameter(f"layers.{LIMIT}.weight", model)
+    assert is_pp_missing_parameter(f"layers.{TOTAL_LAYERS - 1}.weight", model)
+
+
+def test_a_model_shorter_than_the_limit_is_left_alone(monkeypatch):
+    start, end, layers = build(monkeypatch, TOTAL_LAYERS * 2)
+
+    assert (start, end) == (0, TOTAL_LAYERS)
+    assert PPMissingLayer not in {type(layer) for layer in layers}
+
+
+def test_zero_disables_the_truncation(monkeypatch):
+    start, end, layers = build(monkeypatch, 0)
+
+    assert (start, end) == (0, TOTAL_LAYERS)
+    assert PPMissingLayer not in {type(layer) for layer in layers}
+
+
+def test_pipeline_stages_split_the_kept_layers(monkeypatch):
+    """Spread rather than piled on rank 0: no stage may end up empty, or its
+    attention-free spec caps every other stage at one KV block."""
+    stages = [
+        build(monkeypatch, LIMIT, pp_rank=rank, pp_size=2)[:2] for rank in range(2)
+    ]
+
+    assert all(end > start for start, end in stages)
+    assert stages == [(0, 2), (2, LIMIT)]
+
+
+def test_fewer_layers_than_stages_is_rejected(monkeypatch):
+    with pytest.raises(ValueError, match="pipeline_parallel_size=4"):
+        build(monkeypatch, LIMIT, pp_size=4)
+
+
+# DeepSeek-V3's published config; DeepseekV3Config itself carries no
+# num_nextn_predict_layers, since HF's own implementation has no MTP.
+DEEPSEEK_V3 = dict(
+    num_hidden_layers=61, num_nextn_predict_layers=1, first_k_dense_replace=3
+)
+MTP_WEIGHT = "model.layers.61.mtp_block.self_attn.o_proj.weight"
+
+
+def deepseek_v3_config(**overrides) -> DeepseekV3Config:
+    return DeepseekV3Config(**{**DEEPSEEK_V3, **overrides})
+
+
+class TestDeepSeekV3MTP:
+    """The MTP block is built outside make_layers, at an index taken from
+    config.num_hidden_layers -- which this truncation deliberately never sets."""
+
+    def test_mtp_sits_past_the_kept_layers_and_the_stack(self, monkeypatch):
+        config = deepseek_v3_config()
+        _, end, layers = build(monkeypatch, LIMIT, total=config.num_hidden_layers)
+        mtp_index = get_spec_layer_idx_from_weight_name(config, MTP_WEIGHT)
+
+        # Where DeepSeekMultiTokenPredictor keys its block and where the loader
+        # looks for its weights -- one index, past the whole decoder stack.
+        assert mtp_index == config.num_hidden_layers == len(layers) == 61
+        assert mtp_index >= end
+
+    def test_a_kept_layer_is_not_claimed_by_the_drafter(self, monkeypatch):
+        config = deepseek_v3_config()
+        build(monkeypatch, LIMIT, total=config.num_hidden_layers)
+
+        for index in range(LIMIT):
+            name = f"model.layers.{index}.mlp.gate_proj.weight"
+            assert get_spec_layer_idx_from_weight_name(config, name) is None
+
+    def test_overriding_the_config_would_aim_the_mtp_at_a_real_layer(self):
+        """Why the truncation moved off hf_overrides: shrinking the config makes
+        the drafter claim layer 3 -- a real decoder layer -- and drops the
+        checkpoint's own MTP weights."""
+        overridden = deepseek_v3_config(num_hidden_layers=LIMIT)
+
+        assert (
+            get_spec_layer_idx_from_weight_name(
+                overridden, f"model.layers.{LIMIT}.mlp.gate_proj.weight"
+            )
+            == LIMIT
+        )
+        assert get_spec_layer_idx_from_weight_name(overridden, MTP_WEIGHT) is None

--- a/tests/native/runners.py
+++ b/tests/native/runners.py
@@ -146,19 +146,34 @@ class AsyncVllmRunner:
         them has -- or pointedly does not have -- work."""
         return self._loop.run_until_complete(self._generate_all(requests))
 
-    async def _generate_all(self, requests: list[DPRequest]) -> list[Any]:
+    def generate_greedy_logprobs(
+        self, requests: list[DPRequest], num_logprobs: int
+    ) -> list[tuple[list[int], str, list[dict[int, float]]]]:
+        """generate_greedy plus per-step top-k logprobs, for the tolerant
+        comparison: greedy flips on near-tied logits, so two runs that agree
+        mathematically can still pick different tokens."""
+        return self._loop.run_until_complete(self._generate_all(requests, num_logprobs))
+
+    async def _generate_all(
+        self, requests: list[DPRequest], num_logprobs: int | None = None
+    ) -> list[Any]:
         # gather() must be built inside the loop, or its futures attach to
         # whatever loop asyncio considers current.
         return list(
             await asyncio.gather(
-                *(self._generate_one(i, req) for i, req in enumerate(requests))
+                *(
+                    self._generate_one(i, req, num_logprobs)
+                    for i, req in enumerate(requests)
+                )
             )
         )
 
     async def _generate_one(
-        self, index: int, request: DPRequest
-    ) -> tuple[list[int], str]:
-        params = SamplingParams(temperature=0.0, max_tokens=request.max_tokens)
+        self, index: int, request: DPRequest, num_logprobs: int | None = None
+    ) -> tuple[list[int], str] | tuple[list[int], str, list[dict[int, float]]]:
+        params = SamplingParams(
+            temperature=0.0, max_tokens=request.max_tokens, logprobs=num_logprobs
+        )
         stream = self.engine.generate(
             request.prompt,
             params,
@@ -187,7 +202,13 @@ class AsyncVllmRunner:
             f"stream without producing any output"
         )
         completion = final.outputs[0]
-        return list(completion.token_ids), completion.text
+        if num_logprobs is None:
+            return list(completion.token_ids), completion.text
+        logprobs = [
+            {tid: lp.logprob for tid, lp in step.items()}
+            for step in (completion.logprobs or [])
+        ]
+        return list(completion.token_ids), completion.text, logprobs
 
     def __enter__(self) -> AsyncVllmRunner:
         return self
@@ -216,8 +237,9 @@ class HfRunner:
         config = AutoConfig.from_pretrained(model, trust_remote_code=True)
         # Mirror the engine's truncation, or the oracle is a different model.
         if envs.VLLM_RBLN_NUM_HIDDEN_LAYERS > 0:
-            config.num_hidden_layers = min(
-                config.num_hidden_layers, envs.VLLM_RBLN_NUM_HIDDEN_LAYERS
+            text_config = config.get_text_config()
+            text_config.num_hidden_layers = min(
+                text_config.num_hidden_layers, envs.VLLM_RBLN_NUM_HIDDEN_LAYERS
             )
         self.model: Any = AutoModelForCausalLM.from_pretrained(
             model, config=config, torch_dtype=dtype, trust_remote_code=True

--- a/tests/native/runners.py
+++ b/tests/native/runners.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from vllm import LLM, SamplingParams
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -211,8 +211,16 @@ class HfRunner:
     """Reference oracle: the same model via HuggingFace transformers on CPU."""
 
     def __init__(self, model: str, dtype: str = "auto") -> None:
+        from vllm_rbln import envs
+
+        config = AutoConfig.from_pretrained(model, trust_remote_code=True)
+        # Mirror the engine's truncation, or the oracle is a different model.
+        if envs.VLLM_RBLN_NUM_HIDDEN_LAYERS > 0:
+            config.num_hidden_layers = min(
+                config.num_hidden_layers, envs.VLLM_RBLN_NUM_HIDDEN_LAYERS
+            )
         self.model: Any = AutoModelForCausalLM.from_pretrained(
-            model, torch_dtype=dtype, trust_remote_code=True
+            model, config=config, torch_dtype=dtype, trust_remote_code=True
         )
         self.model.eval()
         self.tokenizer: Any = AutoTokenizer.from_pretrained(

--- a/tests/native/test_output_checks.py
+++ b/tests/native/test_output_checks.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The three output comparisons, in increasing tolerance: equal, almost equal,
+logprobs close. Fixtures are the real numbers measured off the eagle e2e
+divergence, so a threshold change shows up as a verdict change here."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tests.native.utils import (
+    NearTieWarning,
+    check_logprobs_close,
+    check_outputs_almost_equal,
+    check_outputs_equal,
+)
+
+# Llama-3.1-8B truncated to 3 layers, generated index 3: the position where the
+# eagle e2e run's reference and spec paths split. Measured in fp32 on CPU.
+LEADING = 113526  # the spec run's pick
+RUNNER_UP = 26494  # the reference run's pick
+LEADING_LOGPROB = -4.3295
+RUNNER_UP_LOGPROB = -4.3538
+FILLER = {124512: -4.8294, 26966: -5.0267, 6339: -5.0666}
+
+
+def step(pick: int, other: int, other_logprob: float) -> dict[int, float]:
+    """One step's top-k as the runner reports it: {token id: logprob}."""
+    own_logprob = LEADING_LOGPROB if pick == LEADING else RUNNER_UP_LOGPROB
+    return {pick: own_logprob, other: other_logprob, **FILLER}
+
+
+def outputs(pick: int, other: int, other_logprob: float):
+    return [([pick], "", [step(pick, other, other_logprob)])]
+
+
+@pytest.fixture
+def eagle_divergence():
+    """Both runs, each rating the other's pick as measured."""
+    return (
+        outputs(LEADING, RUNNER_UP, RUNNER_UP_LOGPROB),
+        outputs(RUNNER_UP, LEADING, LEADING_LOGPROB),
+    )
+
+
+def test_the_measured_gap_is_a_few_percent_of_probability():
+    """0.0243 nats is the whole question: it is what the two comparisons are
+    thresholding, expressed as a probability ratio."""
+    gap = LEADING_LOGPROB - RUNNER_UP_LOGPROB
+    assert gap == pytest.approx(0.0243, abs=1e-4)
+    assert math.exp(gap) - 1 == pytest.approx(0.0246, abs=1e-3)
+
+
+def test_almost_equal_accepts_what_the_npu_runs_actually_reported():
+    """The e2e numbers, not the fp32 ones: at that position the reference rated
+    the pair a literal tie and the spec run rated it 0.0625 -- two bf16 steps
+    apart, around a true gap of 0.0243. The threshold has to clear that."""
+    tie = -4.3295
+    lhs = [([RUNNER_UP], "", [{RUNNER_UP: tie, LEADING: tie}])]
+    rhs = [([LEADING], "", [{LEADING: tie, RUNNER_UP: tie - 0.0625}])]
+
+    with pytest.warns(NearTieWarning):
+        check_outputs_almost_equal(
+            outputs_0_lst=lhs, outputs_1_lst=rhs, name_0="reference", name_1="spec"
+        )
+
+
+def test_equal_rejects_it(eagle_divergence):
+    lhs, rhs = eagle_divergence
+    with pytest.raises(AssertionError):
+        check_outputs_equal(
+            outputs_0_lst=[(ids, text) for ids, text, _ in lhs],
+            outputs_1_lst=[(ids, text) for ids, text, _ in rhs],
+            name_0="reference",
+            name_1="spec",
+        )
+
+
+def test_almost_equal_accepts_it(eagle_divergence):
+    lhs, rhs = eagle_divergence
+    with pytest.warns(NearTieWarning):
+        check_outputs_almost_equal(
+            outputs_0_lst=lhs, outputs_1_lst=rhs, name_0="reference", name_1="spec"
+        )
+
+
+def test_almost_equal_rejects_a_pick_outside_the_leading_pair():
+    """Three candidates inside the probability tolerance, so only the ranking
+    can reject: each run's pick puts the other's third. This is the criterion
+    check_logprobs_close does not have."""
+    middle = 999_999
+    lhs = [([LEADING], "", [{LEADING: -4.3295, middle: -4.3300, RUNNER_UP: -4.3305}])]
+    rhs = [([RUNNER_UP], "", [{RUNNER_UP: -4.3295, middle: -4.3300, LEADING: -4.3305}])]
+
+    with pytest.warns(NearTieWarning):
+        check_logprobs_close(
+            outputs_0_lst=lhs, outputs_1_lst=rhs, name_0="reference", name_1="spec"
+        )
+    with pytest.raises(AssertionError, match="outside the leading 2"):
+        check_outputs_almost_equal(
+            outputs_0_lst=lhs, outputs_1_lst=rhs, name_0="reference", name_1="spec"
+        )
+
+
+@pytest.mark.parametrize("gap", [0.15, 0.3, 0.49])
+def test_almost_equal_rejects_gaps_check_logprobs_close_allows(gap):
+    """The band between the two thresholds: tolerated as a near-tie, rejected as
+    almost equal."""
+    lhs = outputs(LEADING, RUNNER_UP, LEADING_LOGPROB - gap)
+    rhs = [
+        (
+            [RUNNER_UP],
+            "",
+            [{RUNNER_UP: LEADING_LOGPROB - gap, LEADING: LEADING_LOGPROB, **FILLER}],
+        )
+    ]
+
+    with pytest.warns(NearTieWarning):
+        check_logprobs_close(
+            outputs_0_lst=lhs, outputs_1_lst=rhs, name_0="reference", name_1="spec"
+        )
+    with pytest.raises(AssertionError, match="not a near-tie"):
+        check_outputs_almost_equal(
+            outputs_0_lst=lhs, outputs_1_lst=rhs, name_0="reference", name_1="spec"
+        )

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -448,6 +448,7 @@ def start_module_in_spawned_process(
     nodeid_prefix: str = "",
     device_tensor: str | None,
     model_compile: bool,
+    num_hidden_layers: int,
     tb_style: str | None = None,
     maxfail: int = 0,
     stream_output: bool = False,
@@ -464,9 +465,10 @@ def start_module_in_spawned_process(
     -m/-k/--deselect mean what they say: handing over the file would run the
     deselected tests too (on the NPU, invisibly), and would re-run any unmarked
     test of a mixed file that the parent is already running in-process.
-    --device-tensor / --model-compile are forwarded so the child's skip/run
-    decisions match the parent's, and --tb / --maxfail so the reports it builds
-    are rendered and cut off the way the parent was asked to.
+    --device-tensor / --model-compile / --num-hidden-layers are forwarded so the
+    child's skip/run decisions and engine config match the parent's, and --tb /
+    --maxfail so the reports it builds are rendered and cut off the way the
+    parent was asked to.
 
     The child's raw stream is redirected to a log file rather than inherited.
     Inheriting it would put the WHOLE file's output -- every EngineCore
@@ -504,6 +506,8 @@ def start_module_in_spawned_process(
         args += ["--device-tensor", device_tensor]
     if model_compile:
         args.append("--model-compile")
+    # A flag, not env: the child scrubs every VLLM_RBLN_* it inherits.
+    args += ["--num-hidden-layers", str(num_hidden_layers)]
     if tb_style:
         args.append(f"--tb={tb_style}")
     if maxfail:

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -271,6 +271,10 @@ _SPAWN_CHILD_ENV = "VLLM_RBLN_TEST_SPAWN_CHILD"
 # Path the module-batch child writes per-test outcomes to (one JSON obj/line),
 # so the parent can attribute results back to each test of the single spawn.
 _SPAWN_RESULTS_ENV = "VLLM_RBLN_TEST_SPAWN_RESULTS"
+# Set by the parent's conftest when --num-hidden-layers was left off, so a spec
+# may pin its own count. It rides in the env because the child is handed the
+# resolved value and so cannot tell the option was absent.
+LAYERS_PINNABLE_ENV = "VLLM_RBLN_TEST_LAYERS_PINNABLE"
 
 
 def _format_subprocess_exit(returncode: int) -> str:

--- a/tests/native/utils.py
+++ b/tests/native/utils.py
@@ -116,11 +116,38 @@ class NearTieWarning(UserWarning):
     """A greedy pick differed but both runs rated the two tokens near-equal."""
 
 
+# The stricter bound: only the step's leading pair may swap, and each run must
+# rate them within this many nats.
+#
+# The floor is the arithmetic's own resolution, not the true gap: what is
+# compared is each run's *estimate* of one gap, and a bf16 logprob near -4 lands
+# on a grid of 2**2 * 2**-7 = 0.03125 nats. Two runs of the same math routinely
+# report estimates a couple of steps apart -- the eagle e2e divergence has one
+# run at 0.0 (a literal tie, broken by token id) and the other at 0.0625, around
+# a true gap of 0.0243 measured in fp32. Anything below ~0.0625 asks for an
+# agreement the representation cannot express. 0.125 is four steps at that
+# magnitude and ~13% in probability, still far inside check_logprobs_close's
+# 0.5 nats (a 65% difference).
+ALMOST_EQUAL_MAX_LOGPROB_GAP = 0.125
+ALMOST_EQUAL_MAX_RANK = 2
+
+
 def _tie_gap(topk: dict[int, float], *, own: int, other: int) -> float | None:
     """``logprob(own) - logprob(other)`` within one run's top-k; None if absent."""
     if own not in topk or other not in topk:
         return None
     return topk[own] - topk[other]
+
+
+def _rank(topk: dict[int, float], token: int) -> int | None:
+    """0-based position of ``token`` among the step's candidates ordered by
+    logprob; None if the step did not report it. The run's own greedy pick is
+    rank 0, so the other run's pick is rank 1 when they are the leading pair."""
+    if token not in topk:
+        return None
+    # Break ties deterministically (PyTorch argmax returns the first max index).
+    ordered = sorted(topk.items(), key=lambda kv: (-kv[1], kv[0]))
+    return next((i for i, (tid, _) in enumerate(ordered) if tid == token), None)
 
 
 def check_logprobs_close(
@@ -130,10 +157,13 @@ def check_logprobs_close(
     name_0: str,
     name_1: str,
     max_logprob_gap: float = NEAR_TIE_MAX_LOGPROB_GAP,
+    max_rank: int | None = None,
 ) -> None:
     """Assert two runs agree, tolerating only genuine near-tie flips: at the
     first differing token each run must rank the other's pick within its top-k
-    and within ``max_logprob_gap`` nats (else fail). Stops at first divergence."""
+    and within ``max_logprob_gap`` nats (else fail). ``max_rank`` additionally
+    caps where the other's pick may sit in this run's ordering. Stops at first
+    divergence."""
     assert len(outputs_0_lst) == len(outputs_1_lst)
     for i, ((ids_0, _, lps_0), (ids_1, _, lps_1)) in enumerate(
         zip(outputs_0_lst, outputs_1_lst)
@@ -150,6 +180,17 @@ def check_logprobs_close(
                     f"picked {t_1}; not a near-tie (gap {name_0}={gap_0}, "
                     f"{name_1}={gap_1} nats, threshold {max_logprob_gap})"
                 )
+            if max_rank is not None:
+                # Both are reported -- the gap check above needs them present --
+                # but a step that omitted one is outside the leading pair too.
+                rank_0 = _rank(lps_0[pos], t_1)
+                rank_1 = _rank(lps_1[pos], t_0)
+                if rank_0 is None or rank_1 is None or max(rank_0, rank_1) >= max_rank:
+                    raise AssertionError(
+                        f"prompt {i} token {pos}: {name_0} picked {t_0}, {name_1} "
+                        f"picked {t_1}; the other's pick ranks {name_0}={rank_0}, "
+                        f"{name_1}={rank_1}, outside the leading {max_rank}"
+                    )
             warnings.warn(
                 f"prompt {i} token {pos}: near-tie flip -- {name_0} picked {t_0}, "
                 f"{name_1} picked {t_1} (gap {max(gap_0, gap_1):.3f} nats)",
@@ -157,6 +198,28 @@ def check_logprobs_close(
                 stacklevel=2,
             )
             break
+
+
+def check_outputs_almost_equal(
+    *,
+    outputs_0_lst: list[TokensTextLogprobs],
+    outputs_1_lst: list[TokensTextLogprobs],
+    name_0: str,
+    name_1: str,
+) -> None:
+    """check_outputs_equal, minus the flips no arithmetic could avoid: a
+    divergence survives only when the two picks are the step's leading pair and
+    their probabilities agree to ~13%. Anything a real disagreement would produce
+    -- a pick further down the ordering, or a visible probability difference --
+    still fails."""
+    check_logprobs_close(
+        outputs_0_lst=outputs_0_lst,
+        outputs_1_lst=outputs_1_lst,
+        name_0=name_0,
+        name_1=name_1,
+        max_logprob_gap=ALMOST_EQUAL_MAX_LOGPROB_GAP,
+        max_rank=ALMOST_EQUAL_MAX_RANK,
+    )
 
 
 # The driver exposes one node per NPU.

--- a/tests/native/v1/spec_decode/test_spec_decode_e2e.py
+++ b/tests/native/v1/spec_decode/test_spec_decode_e2e.py
@@ -18,7 +18,7 @@
 
 import pytest
 
-from tests.native.utils import check_outputs_equal
+from tests.native.utils import check_outputs_almost_equal
 from tests.native.v1.spec_decode.utils import (
     _DRAFT,
     MEDUSA_DRAFT,
@@ -31,13 +31,14 @@ from tests.native.v1.spec_decode.utils import (
 _NGRAM_TARGET = "meta-llama/Llama-3.2-1B-Instruct"
 PROMPT = "The quick brown fox jumps over the lazy dog. " * 20
 MAX_TOKENS = 16
+NUM_LOGPROBS = 5
 
 # method -> (target model, extra LLM kwargs, speculative_config). The eagle/medusa
 # drafts cap at 2048 positions, so max_model_len is lowered for them.
 SPEC_METHODS = {
     "ngram": (
         _NGRAM_TARGET,
-        {"num_gpu_blocks_override": 32},
+        {},
         {
             "method": "ngram",
             "prompt_lookup_max": 5,
@@ -47,7 +48,7 @@ SPEC_METHODS = {
     ),
     "suffix": (
         _NGRAM_TARGET,
-        {"num_gpu_blocks_override": 32},
+        {},
         {
             "method": "suffix",
             "suffix_decoding_max_spec_factor": 2.0,
@@ -56,12 +57,12 @@ SPEC_METHODS = {
     ),
     "eagle": (
         TARGET_MODEL,
-        {"max_model_len": 2048, "tensor_parallel_size": 4},
+        {"max_model_len": 2048, "tensor_parallel_size": 2},
         {"method": "eagle", "model": _DRAFT["eagle"], "num_speculative_tokens": 3},
     ),
     "eagle3": (
         TARGET_MODEL,
-        {"max_model_len": 2048, "tensor_parallel_size": 4},
+        {"max_model_len": 2048, "tensor_parallel_size": 2},
         {"method": "eagle3", "model": _DRAFT["eagle3"], "num_speculative_tokens": 3},
     ),
     "medusa": (
@@ -98,26 +99,36 @@ def _use_reference_sampler(monkeypatch):
 
 @pytest.mark.model_compile
 @pytest.mark.parametrize("method", [_method_param(m) for m in SPEC_METHODS])
-def test_speculative_decoding_matches_reference(vllm_runner, method: str) -> None:
+def test_speculative_decoding_matches_reference(
+    vllm_runner, method: str, whole_model: bool
+) -> None:
     target, extra_kwargs, spec_config = SPEC_METHODS[method]
 
     with vllm_runner(target, **extra_kwargs) as ref_model:
-        ref_outputs = ref_model.generate_greedy([PROMPT], MAX_TOKENS)
+        ref_outputs = ref_model.generate_greedy_logprobs(
+            [PROMPT], MAX_TOKENS, NUM_LOGPROBS
+        )
 
     with vllm_runner(
         target, **extra_kwargs, speculative_config=spec_config
     ) as spec_model:
-        spec_outputs = spec_model.generate_greedy([PROMPT], MAX_TOKENS)
+        spec_outputs = spec_model.generate_greedy_logprobs(
+            [PROMPT], MAX_TOKENS, NUM_LOGPROBS
+        )
         # Read while the engine is alive (__exit__ shuts down the EngineCore).
         accepted = spec_model.spec_decode_accepted_tokens()
 
-    check_outputs_equal(
+    # Rejection sampling is lossless in exact arithmetic only: the spec run
+    # verifies K+1 tokens in one target pass where the reference decodes one at
+    # a time, so the two differ by rounding. Only near-tie flips are tolerated.
+    check_outputs_almost_equal(
         outputs_0_lst=ref_outputs,
         outputs_1_lst=spec_outputs,
         name_0="reference",
         name_1=f"spec:{method}",
     )
     # Equivalence alone passes even if every draft is rejected, so where drafts
-    # can realistically hit, require at least one acceptance.
-    if method in _EXPECT_ACCEPTANCE:
+    # can realistically hit, require at least one acceptance. Truncated layers
+    # leave the draft's predictions unrelated to the target's, so nothing hits.
+    if method in _EXPECT_ACCEPTANCE and whole_model:
         assert accepted > 0, f"spec:{method} accepted no draft tokens"

--- a/vllm_rbln/envs.py
+++ b/vllm_rbln/envs.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_COMPILE_MODEL: bool = True
     VLLM_RBLN_COMPILE_STRICT_MODE: bool = False
     VLLM_RBLN_COMPILE_ONLY: bool = False
+    VLLM_RBLN_NUM_HIDDEN_LAYERS: int = 0
     VLLM_RBLN_USE_DEVICE_TENSOR: bool = True
     VLLM_RBLN_DISABLE_OFFLOAD: bool = False
     # Default follows VLLM_RBLN_USE_DEVICE_TENSOR (see use_auto_port), so it is
@@ -263,6 +264,16 @@ environment_variables = {
         lambda: (
             os.environ.get("VLLM_RBLN_COMPILE_ONLY", "False").lower() in ("true", "1")
         )
+    ),
+    # Build only the first N decoder layers and leave the rest as
+    # `PPMissingLayer`, to cut compile time during bring-up. 0 disables the
+    # truncation. The HF config is left untouched, so layer indices still line
+    # up with the checkpoint and the untruncated count remains available to
+    # anything that reads it (e.g. the MTP start index). For a hybrid attention
+    # model, pick a multiple of the layer-type period (2 for gpt-oss) to keep
+    # the KV cache group structure the full model would have.
+    "VLLM_RBLN_NUM_HIDDEN_LAYERS": lambda: int(
+        os.environ.get("VLLM_RBLN_NUM_HIDDEN_LAYERS", 0)
     ),
     # Use RBLN device tensors end-to-end (platform device_type="rbln",
     # KV cache / inputs on device, CPU-first attention metadata, padded

--- a/vllm_rbln/patches/__init__.py
+++ b/vllm_rbln/patches/__init__.py
@@ -28,6 +28,7 @@ from . import (
     attention,
     deepseek_mtp,
     deepseek_v2,
+    distributed_utils,
     fp8_moe_method,
     gpt_oss,
     gpt_oss_mxfp4_config,

--- a/vllm_rbln/patches/distributed_utils.py
+++ b/vllm_rbln/patches/distributed_utils.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Rebellions Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vllm.distributed.utils import get_pp_indices
+
+from vllm_rbln import envs
+from vllm_rbln.patches import register_patch
+
+original_get_pp_indices = get_pp_indices
+
+
+@register_patch(
+    target="vllm.distributed.utils.get_pp_indices",
+    reason=(
+        "Honor VLLM_RBLN_NUM_HIDDEN_LAYERS: build only the first N decoder "
+        "layers, so bring-up and tests compile a fraction of the model "
+        "instead of all of it."
+    ),
+    condition=lambda: envs.VLLM_RBLN_NUM_HIDDEN_LAYERS > 0,
+)
+def patched_get_pp_indices(
+    num_hidden_layers: int, pp_rank: int, pp_size: int
+) -> tuple[int, int]:
+    # `make_layers` is what truncating end_layer actually shrinks, but model
+    # modules bind it at import time; it looks `get_pp_indices` up inside its
+    # own body, so this target lands regardless of import order.
+    layer_limit = envs.VLLM_RBLN_NUM_HIDDEN_LAYERS
+
+    # `condition` gates on the value at apply time; this reads it per call, so
+    # honor a later 0 rather than truncating to nothing.
+    if layer_limit <= 0:
+        return original_get_pp_indices(num_hidden_layers, pp_rank, pp_size)
+
+    # A stage with no attention layer reports an attention-free spec worth
+    # `num_blocks=1`, which `get_kv_cache_configs` imposes on every other stage.
+    if layer_limit < pp_size:
+        raise ValueError(
+            f"VLLM_RBLN_NUM_HIDDEN_LAYERS={layer_limit} is smaller than "
+            f"pipeline_parallel_size={pp_size}, which would leave a pipeline "
+            "stage with no layer. Raise it to at least the pipeline parallel "
+            "size."
+        )
+
+    return original_get_pp_indices(
+        min(num_hidden_layers, layer_limit), pp_rank, pp_size
+    )


### PR DESCRIPTION
<!--
Thank you for contributing to vllm-rbln! 🚀
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: https://github.com/rbln-sw/vllm-rbln/blob/main/CONTRIBUTING.md
-->

### 🚀 Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format for the title.
see: https://www.conventionalcommits.org/en/v1.0.0/

Examples:
  feat(core): support V1 engine
  fix(model): get num_gpu_blocks logic in V1
  docs: clarify usage of tensor parallel
-->

<!-- Describe your changes in detail -->

`VLLM_RBLN_NUM_HIDDEN_LAYERS=N` builds only the first N decoder layers and leaves the rest as `PPMissingLayer`. 0 keeps the whole model.

This replaces `hf_overrides={"num_hidden_layers": N}`, which needed a `load_weights` override per model to skip the extra checkpoint layers. Upstream's `is_pp_missing_parameter` already does that, so no loader patch is needed. The HF config is also left untouched, so layer indices still match the checkpoint and DeepSeek-V3's MTP block keeps pointing past the stack instead of at a real layer.

Under PP the N layers are spread across stages; `N < pp_size` is rejected because an empty stage caps every other stage at one KV block.

`tests/native` runs at 3 layers by default (`--num-hidden-layers`, 0 for the whole model), `hf_runner` included. Two comparisons had to loosen: at 3 layers the top two tokens can be indistinguishable in bf16, and greedy is an argmax. `check_outputs_almost_equal` accepts a divergence only when the two picks are the step's leading pair and each run rates them within 0.125 nats.

---

### 📌 Related Issues / Tickets

<!--
All pull requests must be linked to a Development-related Issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
-->

* Resolves #
* Related to #

---

### ✅ Type of Change

<!-- Mark all that apply using [x]. -->

* [x] ❓ Other (`other`): dev/test knob, not a serving path

---

### 🧪 How to Test

1. `pytest tests/native/patches/test_distributed_utils.py tests/native/test_output_checks.py` — 20 tests, no checkpoint, no device.
2. `pytest tests/native --model-compile` — runs at 4 layers; `--num-hidden-layers 0` restores the whole model.
3. `VLLM_RBLN_NUM_HIDDEN_LAYERS=3 vllm serve <model>` — 3 layers built, remaining weights skipped.

---

### 📸 Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

### 📋 Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to an existing issue
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

---

### 💬 Notes

<!-- Anything reviewers should pay extra attention to? -->

---
